### PR TITLE
Set default_branch to main in all Semaphore `change_in` calls

### DIFF
--- a/.semaphore/multi-arch-builds.yml
+++ b/.semaphore/multi-arch-builds.yml
@@ -104,7 +104,7 @@ blocks:
 
   - name: "Upload native executables to GitHub Releases"
     run:
-      when: "branch =~ '.*' and change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore'})"
+      when: "branch =~ '.*' and change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     dependencies:
       - "Build Native Executable (MacOS AMD64)"
       - "Build Native Executable (MacOS ARM64)"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ blocks:
   - name: "Build and Test"
     dependencies: []
     skip:
-      when: "change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore'})"
+      when: "change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:
       jobs:
         - name: "Build JARs and Unit Test"
@@ -51,7 +51,7 @@ blocks:
   - name: "Release"
     dependencies: ["Build and Test"]
     skip:
-      when: "pull_request =~ '.*' or change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore'})"
+      when: "pull_request =~ '.*' or change_in('/.versions/ide-sidecar-version.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:
       jobs:
         - name: "Release"
@@ -64,7 +64,7 @@ blocks:
   - name: "Update third party notices PR"
     dependencies: ["Release"]
     run:
-      when: "branch =~ '.*' and change_in('/pom.xml')"
+      when: "branch =~ '.*' and change_in('/pom.xml', {default_branch: 'main'})"
     task:
       prologue:
         commands:
@@ -95,4 +95,4 @@ promotions:
   - name: Multi-Arch Native Executable Builds
     pipeline_file: multi-arch-builds.yml
     auto_promote:
-      when: "result = 'passed' and branch =~ '.*' and change_in('/.versions/ide-sidecar-version.txt')"
+      when: "result = 'passed' and branch =~ '.*' and change_in('/.versions/ide-sidecar-version.txt', {default_branch: 'main'})"


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Set `default_branch` to `main` in Semaphore `change_in` calls
From https://docs.semaphoreci.com/reference/conditions-reference/#change_in:
default_branch: The default value is master. If changed to another branch, change_in will act on that branch as it does by default on the master, and all other branches will be compared to it instead of to the master.

