### PR TITLE
Use pre-installed utility sem-version for java 21

### DIFF
--- a/.semaphore/build_native_executable_prologue.sh
+++ b/.semaphore/build_native_executable_prologue.sh
@@ -1,8 +1,4 @@
+sem-version java 21
 checkout
 . vault-setup
-# Install SDKMAN! (https://sdkman.io/install)
-curl -s "https://get.sdkman.io?rcupdate=false" | bash
-source "$HOME/.sdkman/bin/sdkman-init.sh"
-# Install GraalVM as defined in .sdkmanrc
-sdk env install
 make ci-bin-sem-cache-restore


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Use pre-installed `sem-version java 21` instead of using SDKMAN to install graalvm.