### PR TITLE
Cache ~/.m2/repository in multi-arch-builds

### DIFF
--- a/.semaphore/build_native_executable_epilogue.sh
+++ b/.semaphore/build_native_executable_epilogue.sh
@@ -1,2 +1,3 @@
 NATIVE_EXECUTABLE=$(find target -name "*-runner")
 artifact push workflow ${NATIVE_EXECUTABLE} --destination native-executables/$(basename ${NATIVE_EXECUTABLE}-${OS}-${ARCH})
+make ci-bin-sem-cache-store


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We do a fresh install during `make mvn-package-native` in the multi-arch-builds pipeline (See  https://semaphore.ci.confluent.io/jobs/3faab186-a2a9-45e5-b573-9e70331b3c1c#L205-L7323), takes about ~4-5 minutes.

This should be fixed after adding the command to cache the m2 repo with `make ci-bin-sem-cache-store` in the epilogue commands of the native executable build blocks.

