### PR TITLE
Retry flaky test three times before failing

### DIFF
--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
@@ -20,7 +20,6 @@ import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.ExpectedToFail;
 import org.junitpioneer.jupiter.RetryingTest;
 
 @QuarkusTest


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Use `@RetryingTest` annotation to re-run test thrice before failing. We've seen the `ConfluentCloudQueryResourceTest.shouldCacheClusterInfoOnGetKafkaClusters` be flaky and fail in the past. We'll need a longer term fix for the root cause (cache not updated in time?), but until then we can slap on this retry-bandaid.

See https://semaphore.ci.confluent.io/jobs/d892531b-d8c4-4932-8e65-5f495c1739fb#L1567 for example.