### PR TITLE
Enhance sidecar to support proto, Avro, JSON Schema for local cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <quarkus.platform.version>3.13.3</quarkus.platform.version>
     <io.confluent.common.version>7.7.0</io.confluent.common.version>
+    <avro.version>1.11.1</avro.version>
     <jackson-dataformat.version>2.17.1</jackson-dataformat.version>
     <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
   </properties>
@@ -271,6 +272,18 @@
       <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>kafka</artifactId>
+      <version>1.15.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.15.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -419,6 +432,47 @@
     </pluginManagement>
 
     <plugins>
+      <!-- Avro Maven Plugin -->
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>${avro.version}</version>
+        <executions>
+          <execution>
+            <id>schemas</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>schema</goal>
+              <goal>protocol</goal>
+              <goal>idl-protocol</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/test/avro/</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-test-sources/avro/</outputDirectory>
+              <stringType>String</stringType>
+              <createSetters>false</createSetters>
+              <enableDecimalLogicalType>true</enableDecimalLogicalType>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Proto Maven Plugin -->
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.6.1</version>
+        <configuration>
+            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+        </configuration>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>compile</goal>
+                    <goal>test-compile</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -1144,31 +1144,31 @@
       "HealthResponse" : {
         "type" : "object",
         "properties" : {
+          "status" : {
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
+          },
           "checks" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/HealthCheck"
             }
-          },
-          "status" : {
-            "enum" : [ "UP", "DOWN" ],
-            "type" : "string"
           }
         }
       },
       "HealthCheck" : {
         "type" : "object",
         "properties" : {
-          "status" : {
-            "enum" : [ "UP", "DOWN" ],
-            "type" : "string"
-          },
           "name" : {
             "type" : "string"
           },
           "data" : {
             "type" : "object",
             "nullable" : true
+          },
+          "status" : {
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -824,25 +824,25 @@ components:
     HealthResponse:
       type: object
       properties:
+        status:
+          enum:
+          - UP
+          - DOWN
+          type: string
         checks:
           type: array
           items:
             $ref: "#/components/schemas/HealthCheck"
-        status:
-          enum:
-          - UP
-          - DOWN
-          type: string
     HealthCheck:
       type: object
       properties:
-        status:
-          enum:
-          - UP
-          - DOWN
-          type: string
         name:
           type: string
         data:
           type: object
           nullable: true
+        status:
+          enum:
+          - UP
+          - DOWN
+          type: string

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtil.java
@@ -15,7 +15,6 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
-import io.quarkus.logging.Log;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -122,6 +121,8 @@ public class DecoderUtil {
   ) throws IOException, RestClientException {
     if (bytes == null || bytes.length == 0) {
       return OBJECT_MAPPER.nullNode();
+    } else if (schemaRegistryClient == null) {
+      return OBJECT_MAPPER.readTree(new String(bytes, StandardCharsets.UTF_8));
     }
 
     final int schemaId = getSchemaIdFromRawBytes(bytes);
@@ -203,27 +204,43 @@ public class DecoderUtil {
   }
 
   /**
-   * Parses a JSON byte array into a JsonNode. If the byte array cannot be parsed as JSON,
-   * it is returned as a TextNode containing the original string representation of the byte array.
+   * Parses a byte array into a JsonNode, handling various data formats:
+   * 1. Schema Registry encoded data
+   * 2. Plain string data
+   * If the byte array is Schema Registry encoded (starts with the MAGIC_BYTE),
+   * it is decoded and deserialized using the provided SchemaRegistryClient.
+   * Otherwise, it is treated as a plain string and wrapped in a TextNode.
    *
-   * @param bytes the JSON byte array to parse
-   * @return the parsed JsonNode, or a TextNode containing the original string if parsing fails
+   * @param bytes The byte array to parse
+   * @param schemaRegistryClient The SchemaRegistryClient used for deserialization of
+   *                             Schema Registry encoded data
+   * @param topic The name of the topic, used for Schema Registry deserialization
+   * @return A DecodedResult containing either:
+   *         - A JsonNode representing the decoded and deserialized data (for Schema Registry
+   *           encoded data)
+   *         - A TextNode containing the original string representation of the byte array (
+   *           for other cases)
+   *         The DecodedResult also includes any error message encountered during processing
    */
-  public static JsonNode parseJsonNode(byte[] bytes) {
+  public static DecodedResult parseJsonNode(
+      byte[] bytes,
+      SchemaRegistryClient schemaRegistryClient,
+      String topic) {
     if (bytes == null || bytes.length == 0) {
-      return new TextNode("");
+      return new DecodedResult(new TextNode(""), null);
     }
     if (bytes[0] == MAGIC_BYTE) {
-      // Jackson will automatically encode the map as a simple JSON object and the byte array value
-      // into a Base64-encoded string.
-      // TODO(Ravi) Deserialize the encoded bytes into JsonNode object.
-      try {
-        return OBJECT_MAPPER.readTree(bytes);
-      } catch (IOException e) {
-        Log.errorf("Error while converting bytes to Json. '%s'", e.getMessage());
-        return new TextNode(new String(bytes, StandardCharsets.UTF_8));
+      if (schemaRegistryClient != null) {
+        return decodeAndDeserialize(
+            Base64.getEncoder().encodeToString(bytes),
+            schemaRegistryClient,
+            topic
+        );
+      } else {
+        return new DecodedResult(new TextNode(new String(bytes, StandardCharsets.UTF_8)),
+            "schema-registry is null");
       }
     }
-    return new TextNode(new String(bytes, StandardCharsets.UTF_8));
+    return new DecodedResult(new TextNode(new String(bytes, StandardCharsets.UTF_8)), null);
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumer.java
@@ -1,13 +1,21 @@
 package io.confluent.idesidecar.restapi.messageviewer;
 
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.ExceededFields;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeData;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecordHeader;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.TimestampType;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,12 +35,15 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * Implements consuming records from Confluent Local Kafka topics for the message viewer API.
  */
+// CHECKSTYLE:OFF: ClassDataAbstractionCoupling
 public class SimpleConsumer {
   private static final Duration POLL_TIMEOUT = Duration.ofSeconds(1);
   private static final int MAX_POLLS = 5;
   private static final int MAX_POLL_RECORDS_LIMIT = 2_000;
   private static final int MAX_RESPONSE_BYTES = 20 * 1024 * 1024; // 20 MB
   private static final int DEFAULT_MESSAGE_MAX_BYTES = 4 * 1024 * 1024; // 4MB
+  private static final int SR_CACHE_SIZE = 10;
+  private SchemaRegistryClient schemaRegistryClient;
 
   final Properties baseConsumerConfig;
 
@@ -40,6 +51,22 @@ public class SimpleConsumer {
     var props = new Properties();
     // Custom properties
     props.putAll(baseConfig);
+
+    // Create Schema Registry client
+    String schemaRegistryUrl = (String) props.getOrDefault(SCHEMA_REGISTRY_URL_CONFIG, null);
+    if (schemaRegistryUrl != null && !schemaRegistryUrl.isEmpty()) {
+      this.schemaRegistryClient = new CachedSchemaRegistryClient(
+          schemaRegistryUrl,
+          SR_CACHE_SIZE,
+          Arrays.asList(
+              new ProtobufSchemaProvider(),
+              new AvroSchemaProvider(),
+              new JsonSchemaProvider()
+          ),
+          Collections.emptyMap()
+      );
+    }
+
     // Default properties
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
         "org.apache.kafka.common.serialization.ByteArrayDeserializer");
@@ -318,8 +345,15 @@ public class SimpleConsumer {
         && consumerRecord.key().length > messageMaxBytes;
     boolean valueExceeded = consumerRecord.value() != null
         && consumerRecord.value().length > messageMaxBytes;
-    var keyNode = keyExceeded ? null : DecoderUtil.parseJsonNode(consumerRecord.key());
-    var valueNode = valueExceeded ? null : DecoderUtil.parseJsonNode(consumerRecord.value());
+
+    var keyResult = keyExceeded ? null : DecoderUtil.parseJsonNode(
+        consumerRecord.key(),
+        schemaRegistryClient,
+        consumerRecord.topic());
+    var valueResult = valueExceeded ? null : DecoderUtil.parseJsonNode(
+        consumerRecord.value(),
+        schemaRegistryClient,
+        consumerRecord.topic());
 
     return new PartitionConsumeRecord(
         consumerRecord.partition(),
@@ -327,9 +361,12 @@ public class SimpleConsumer {
         consumerRecord.timestamp(),
         TimestampType.valueOf(consumerRecord.timestampType().name()),
         headers,
-        keyNode,
-        valueNode,
+        keyResult == null ? null : keyResult.getValue(),
+        valueResult == null ? null : valueResult.getValue(),
+        keyResult == null ? null : keyResult.getErrorMessage(),
+        valueResult == null ? null : valueResult.getErrorMessage(),
         new ExceededFields(keyExceeded, valueExceeded)
     );
   }
 }
+// CHECKSTYLE:ON: ClassDataAbstractionCoupling

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentLocalConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentLocalConsumeStrategy.java
@@ -6,6 +6,7 @@ import io.confluent.idesidecar.restapi.messageviewer.SimpleConsumer;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -80,6 +81,9 @@ public class ConfluentLocalConsumeStrategy implements ConsumeStrategy {
     Properties props = new Properties();
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
         context.getKafkaClusterInfo().bootstrapServers());
+    props.put(
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+        context.getSchemaRegistryInfo().uri());
 
     SimpleConsumer simpleConsumer = new SimpleConsumer(props);
     SimpleConsumeMultiPartitionResponse simpleConsumeResp =

--- a/src/test/avro/myavromessage.avsc
+++ b/src/test/avro/myavromessage.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "MyAvroMessage",
+  "namespace": "io.confluent.idesidecar.restapi.avro",
+  "fields": [
+    {"name": "id", "type": "string"},
+    {"name": "value", "type": "string"}
+  ],
+  "javaPackage": "io.confluent.idesidecar.restapi.avro"
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtilTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtilTest.java
@@ -208,26 +208,32 @@ public class DecoderUtilTest {
 
   @Test
   void parseJsonNodeShouldReturnEmptyStringWhenReceivingNullValue() {
-    assertEquals(new TextNode(""), DecoderUtil.parseJsonNode(null));
+    var resp = DecoderUtil.parseJsonNode(null, null, "foo");
+    assertEquals(new TextNode(""), resp.getValue());
+    assertNull(resp.getErrorMessage());
   }
 
   @Test
   void parseJsonNodeShouldReturnEmptyStringWhenReceivingEmptyByteArray() {
     var emptyArray = new byte[0];
-    assertEquals(new TextNode(""), DecoderUtil.parseJsonNode(emptyArray));
+    var resp = DecoderUtil.parseJsonNode(emptyArray, null, "foo");
+    assertEquals(new TextNode(""), resp.getValue());
+    assertNull(resp.getErrorMessage());
   }
 
   @Test
   void parseJsonNodeShouldReturnStringIfByteArrayDoesNotStartWithMagicByte() {
     var rawString = "Team DTX";
     var byteArray = rawString.getBytes(StandardCharsets.UTF_8);
-    assertEquals(new TextNode(rawString), DecoderUtil.parseJsonNode(byteArray));
+    var resp = DecoderUtil.parseJsonNode(byteArray, null, "foo");
+    assertEquals(new TextNode(rawString), resp.getValue());
+    assertNull(resp.getErrorMessage());
   }
 
   @Test
   void parseJsonNodeShouldReturnStringIfParsingByteArrayWithMagicByteFails() {
     // Build byte array with magic byte as prefix
-    var rawString = "Team DTX";
+    var rawString = "{\"Team\" : \"DTX\"}";
     var byteArray = rawString.getBytes(StandardCharsets.UTF_8);
     var byteArrayWithMagicByte = new byte[1 + byteArray.length];
     byteArrayWithMagicByte[0] = DecoderUtil.MAGIC_BYTE;
@@ -235,9 +241,9 @@ public class DecoderUtilTest {
 
     // Expect parsing to fail, should return byte array as string
     var magicByteAsString = new String(new byte[]{DecoderUtil.MAGIC_BYTE}, StandardCharsets.UTF_8);
-    assertEquals(
-        new TextNode(magicByteAsString + rawString),
-        DecoderUtil.parseJsonNode(byteArrayWithMagicByte));
+    var resp = DecoderUtil.parseJsonNode(byteArrayWithMagicByte, null, "foo");
+    assertEquals(new TextNode(magicByteAsString + rawString), resp.getValue());
+    assertEquals("schema-registry is null", resp.getErrorMessage());
   }
 
   @Test

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerTest.java
@@ -1,0 +1,230 @@
+package io.confluent.idesidecar.restapi.messageviewer;
+
+
+import io.confluent.idesidecar.restapi.avro.MyAvroMessage;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeData;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord;
+import io.confluent.idesidecar.restapi.proto.Message.MyMessage;
+import io.confluent.idesidecar.restapi.util.ConfluentLocalTestBed;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleConsumerTest {
+
+  private static ConfluentLocalTestBed testBed;
+  private static SimpleConsumer simpleConsumer;
+
+  @BeforeAll
+  public static void setUp() throws InterruptedException, ExecutionException, TimeoutException {
+    testBed = new ConfluentLocalTestBed();
+    testBed.start();
+    assertTrue(testBed.isReady(), "Test bed should be ready");
+
+    Properties consumerProps = new Properties();
+    consumerProps.setProperty("bootstrap.servers", testBed.getBootstrapServers());
+    consumerProps.setProperty("schema.registry.url", testBed.getSchemaRegistryUrl());
+    simpleConsumer = new SimpleConsumer(consumerProps);
+  }
+
+  @AfterAll
+  public static void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
+    testBed.stop();
+  }
+
+  void recreateTopic(String topic) throws ExecutionException, InterruptedException, TimeoutException {
+    if (testBed.topicExists(topic)) {
+      testBed.deleteTopic(topic);
+      testBed.waitForTopicCreation(topic, Duration.ofSeconds(30));
+    }
+    testBed.createTopic(topic, 1, (short) 1);
+    testBed.waitForTopicCreation(topic, Duration.ofSeconds(30));
+  }
+
+  @Test
+  void testAvroProduceAndConsume() throws ExecutionException, InterruptedException, TimeoutException {
+    String topic = "myavromessage1";
+    recreateTopic(topic);
+
+    Producer<String, GenericRecord> producer = testBed.createAvroProducer();
+    GenericRecordBuilder myMessageBuilder = new GenericRecordBuilder(MyAvroMessage.SCHEMA$);
+
+    List<String> ids = Arrays.asList("12345", "12346", "12347");
+    List<String> values = Arrays.asList("Test Value 1", "Test Value 2", "Test Value 3");
+
+    for (int i = 0; i < 3; i++) {
+      myMessageBuilder.set("id", ids.get(i));
+      myMessageBuilder.set("value", values.get(i));
+      GenericRecord myMessage = myMessageBuilder.build();
+
+      ProducerRecord<String, GenericRecord> record = new ProducerRecord<>(topic, "message-key-" + i, myMessage);
+      producer.send(record);
+    }
+
+    producer.flush();
+    producer.close();
+
+    Map<Integer, Long> offsets = new HashMap<>();
+    offsets.put(0, 0L);  // Assuming single partition, start from offset 0
+    List<PartitionConsumeData> response = simpleConsumer.consumeFromMultiplePartitions(
+        topic, offsets, true, null, 10, null, null);
+
+    assertEquals(1, response.size(), "Should have data for 1 partition");
+    PartitionConsumeData partitionData = response.get(0);
+    assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+    for (int i = 0; i < 3; i++) {
+      PartitionConsumeRecord record = partitionData.records().get(i);
+      assertEquals(ids.get(i), record.value().get("id").asText(), "ID should match");
+      assertEquals(values.get(i), record.value().get("value").asText(), "Value should match");
+    }
+  }
+
+  @Test
+  public void testProtoProduceAndConsumeMultipleRecords() throws Exception {
+    String topic = "myProtobufTopic";
+    recreateTopic(topic);
+
+    MyMessage message1 = MyMessage.newBuilder()
+        .setName("Some One")
+        .setAge(30)
+        .setIsActive(true)
+        .build();
+
+    MyMessage message2 = MyMessage.newBuilder()
+        .setName("John Doe")
+        .setAge(25)
+        .setIsActive(false)
+        .build();
+
+    MyMessage message3 = MyMessage.newBuilder()
+        .setName("Jane Smith")
+        .setAge(40)
+        .setIsActive(true)
+        .build();
+
+    List<MyMessage> messages = List.of(message1, message2, message3);
+    List<String> keys = List.of("key1", "key2", "key3");
+
+    KafkaProducer<String, MyMessage> producer = testBed.createProtobufProducer();
+
+    for (int i = 0; i < messages.size(); i++) {
+      ProducerRecord<String, MyMessage> producerRecord = new ProducerRecord<>(topic, keys.get(i), messages.get(i));
+      producer.send(producerRecord);
+    }
+    producer.close();
+
+    Map<Integer, Long> offsets = new HashMap<>();
+    offsets.put(0, 0L);  // Assuming single partition, start from offset 0
+    var response = simpleConsumer.consumeFromMultiplePartitions(
+        topic, offsets, true, null, 10, null, null);
+
+    assertEquals(1, response.size(), "Should have data for 1 partition");
+    PartitionConsumeData partitionData = response.get(0);
+    assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+    for (int i = 0; i < 3; i++) {
+      PartitionConsumeRecord record = partitionData.records().get(i);
+      MyMessage originalMessage = messages.get(i);
+      assertEquals(originalMessage.getName(), record.value().get("name").asText(), "Name should match");
+      assertEquals(originalMessage.getAge(), record.value().get("age").asInt(), "Age should match");
+      assertEquals(originalMessage.getIsActive(), record.value().get("is_active").asBoolean(), "IsActive should match");
+    }
+  }
+
+  @Test
+  public void testJsonProducerAndConsumer() throws Exception {
+    String topic = "test-json-topic";
+    recreateTopic(topic);
+
+    KafkaProducer<String, JSONObject> producer = testBed.createJsonSchemaProducer();
+
+    List<JSONObject> sentRecords = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      JSONObject json = new JSONObject();
+      json.put("id", i);
+      json.put("name", "Person " + i);
+      json.put("email", "person" + i + "@example.com");
+      sentRecords.add(json);
+
+      ProducerRecord<String, JSONObject> record = new ProducerRecord<>(topic, "key" + i, json);
+      producer.send(record).get();
+    }
+
+    producer.close();
+
+    Map<Integer, Long> offsets = new HashMap<>();
+    offsets.put(0, 0L);  // Assuming single partition, start from offset 0
+    var response = simpleConsumer.consumeFromMultiplePartitions(
+        topic, offsets, true, null, 10, null, null);
+
+    assertEquals(1, response.size(), "Should have data for 1 partition");
+    PartitionConsumeData partitionData = response.get(0);
+    assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+    for (int i = 0; i < 3; i++) {
+      PartitionConsumeRecord record = partitionData.records().get(i);
+      JSONObject sentJson = sentRecords.get(i);
+      assertEquals(sentJson.getInt("id"), record.value().get("id").asInt(), "ID should match");
+      assertEquals(sentJson.getString("name"), record.value().get("name").asText(), "Name should match");
+      assertEquals(sentJson.getString("email"), record.value().get("email").asText(), "Email should match");
+    }
+  }
+
+  @Test
+  public void testProduceAndConsumeMultipleStringRecords() throws Exception {
+    String topic = "test-str-topic";
+    recreateTopic(topic);
+
+    KafkaProducer<String, String> producer = testBed.createStringProducer();
+
+    List<ProducerRecord<String, String>> records = Arrays.asList(
+        new ProducerRecord<>(topic, "key1", "value1"),
+        new ProducerRecord<>(topic, "key2", "value2"),
+        new ProducerRecord<>(topic, "key3", "value3")
+    );
+
+    for (ProducerRecord<String, String> record : records) {
+      producer.send(record).get();
+    }
+
+    producer.close();
+
+    Map<Integer, Long> offsets = new HashMap<>();
+    offsets.put(0, 0L);  // Assuming single partition, start from offset 0
+    var response = simpleConsumer.consumeFromMultiplePartitions(
+        topic, offsets, true, null, 10, null, null);
+
+    assertEquals(1, response.size(), "Should have data for 1 partition");
+    PartitionConsumeData partitionData = response.get(0);
+    assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+    for (int i = 0; i < 3; i++) {
+      PartitionConsumeRecord record = partitionData.records().get(i);
+      String key = record.key().asText();
+      String value = record.value().asText();
+
+      assertEquals(records.get(i).key(), key, "Key should match");
+      assertEquals(records.get(i).value(), value, "Value should match");
+    }
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
@@ -6,16 +6,30 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.idesidecar.restapi.avro.MyAvroMessage;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.ConfluentLocalContainer;
+import io.confluent.idesidecar.restapi.util.ConfluentLocalTestBed;
 import io.confluent.idesidecar.restapi.util.ResourceIOUtil;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +38,29 @@ import org.junit.jupiter.api.Test;
 @TestProfile(NoAccessFilterProfile.class)
 public class KafkaConsumeResourceIT {
   public record KafkaClusterDetails(String id, String name, String bootstrapServers, String uri) {}
+  private static ConfluentLocalTestBed testBed;
+
+  @BeforeAll
+  public static void setUp() throws InterruptedException, ExecutionException, TimeoutException {
+    testBed = new ConfluentLocalTestBed();
+    testBed.start();
+    assertTrue(testBed.isReady(), "Test bed should be ready");
+  }
+
+  @AfterAll
+  public static void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
+    testBed.stop();
+  }
+
+  void recreateTopic(String topic)
+      throws ExecutionException, InterruptedException, TimeoutException {
+    if (testBed.topicExists(topic)) {
+      testBed.deleteTopic(topic);
+      testBed.waitForTopicCreation(topic, Duration.ofSeconds(30));
+    }
+    testBed.createTopic(topic, 1, (short) 1);
+    testBed.waitForTopicCreation(topic, Duration.ofSeconds(30));
+  }
 
   @Test
   void testConfluentLocalContainer() {
@@ -154,7 +191,6 @@ public class KafkaConsumeResourceIT {
         .statusCode(201);
   }
 
-
   void produceRecords(String bootstrapServers, String topicName, String[][] records) {
     // Configure the Producer
     var properties = new Properties();
@@ -171,6 +207,68 @@ public class KafkaConsumeResourceIT {
             recordData[1]);
         producer.send(record);
       }
+    }
+  }
+
+  @Test
+  void testAvroProduceAndConsume() throws Exception {
+    String topic = "myavromessage1";
+    recreateTopic(topic);
+
+    var connectionId = "local-connection-avro";
+    createLocalConnection(connectionId, connectionId);
+    var localKafkaClusterDetails = getLocalKafkaClusterId();
+
+    // Create the producer
+    /*Producer<String, GenericRecord> producer = testBed.createAvroProducer();
+
+    // Avro schema (assuming MyAvroMessage.SCHEMA$ is available)
+    GenericRecordBuilder myMessageBuilder = new GenericRecordBuilder(MyAvroMessage.SCHEMA$);
+
+    // Prepare data for 3 records
+    List<String> ids = Arrays.asList("12345", "12346", "12347");
+    List<String> values = Arrays.asList("Test Value 1", "Test Value 2", "Test Value 3");
+
+    // Send 3 records
+    for (int i = 0; i < 3; i++) {
+      myMessageBuilder.set("id", ids.get(i));
+      myMessageBuilder.set("value", values.get(i));
+      GenericRecord myMessage = myMessageBuilder.build();
+
+      ProducerRecord<String, GenericRecord> record = new ProducerRecord<>(topic, "message-key-" + i, myMessage);
+      producer.send(record);
+    }
+
+    producer.flush();
+    producer.close();*/
+
+    // Consume using REST API
+    var url = "gateway/v1/clusters/%s/topics/%s/partitions/-/consume".formatted(
+        localKafkaClusterDetails.id(), topic);
+    var response = given()
+        .when()
+        .header("Content-Type", "application/json")
+        .header("x-connection-id", connectionId)
+        .body("{\"from_beginning\" : true, \"max_poll_records\" : 3}")
+        .post(url)
+        .then()
+        .statusCode(200)
+        .extract()
+        .body().asString();
+
+    // Parse and assert the response
+    JsonNode partitionDataList = new ObjectMapper().readTree(response).get("partition_data_list");
+    assertNotNull(partitionDataList);
+    assertFalse(partitionDataList.isEmpty(), "partition_data_list should not be empty");
+
+    JsonNode records = partitionDataList.get(0).get("records");
+    assertNotNull(records);
+    assertEquals(3, records.size(), "Expected number of records is 3");
+
+    for (int i = 0; i < 3; i++) {
+      JsonNode record = records.get(i);
+      // assertEquals(ids.get(i), record.get("value").get("id").asText(), "ID should match");
+      // assertEquals(values.get(i), record.get("value").get("value").asText(), "Value should match");
     }
   }
 

--- a/src/test/java/io/confluent/idesidecar/restapi/util/ConfluentLocalTestBed.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/ConfluentLocalTestBed.java
@@ -1,0 +1,236 @@
+package io.confluent.idesidecar.restapi.util;
+
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
+import java.util.Map;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.json.JSONObject;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.testcontainers.utility.DockerImageName;
+
+public class ConfluentLocalTestBed {
+  public static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:7.7.0");
+  private final Network network;
+  private final KafkaContainer kafka;
+  private final SchemaRegistryContainer schemaRegistry;
+
+  public ConfluentLocalTestBed() {
+    this.network = Network.newNetwork();
+    this.kafka = new KafkaContainer(KAFKA_IMAGE)
+        .withNetwork(network)
+        .withNetworkAliases("kafka")
+        .waitingFor(Wait.forLogMessage(".*started.*\\n", 1));
+
+    this.schemaRegistry = new SchemaRegistryContainer("kafka:9092")
+        .withNetwork(network)
+        .withExposedPorts(8085)
+        .dependsOn(kafka)
+        .waitingFor(Wait.forHttp("/subjects").forStatusCode(200).withStartupTimeout(Duration.ofMinutes(2)));
+  }
+
+  public void start() {
+    kafka.start();
+    schemaRegistry.start();
+  }
+
+  public void stop() {
+    schemaRegistry.stop();
+    kafka.stop();
+  }
+
+  public boolean isReady() {
+    return isKafkaReady() && isSchemaRegistryReady();
+  }
+
+  private boolean isKafkaReady() {
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      adminClient.listTopics().names().get(10, TimeUnit.SECONDS);
+      return true;
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      System.err.println("Kafka is not ready: " + e.getMessage());
+      return false;
+    }
+  }
+
+  private boolean isSchemaRegistryReady() {
+    try {
+      String endpoint = schemaRegistry.endpoint();
+      java.net.HttpURLConnection connection = (java.net.HttpURLConnection) new java.net.URL(endpoint + "/subjects").openConnection();
+      connection.setRequestMethod("GET");
+      int responseCode = connection.getResponseCode();
+      return responseCode == 200;
+    } catch (java.io.IOException e) {
+      System.err.println("Schema Registry is not ready: " + e.getMessage());
+      return false;
+    }
+  }
+
+  public void createTopic(String topicName, int partitions, short replicationFactor) throws InterruptedException, ExecutionException, TimeoutException {
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      NewTopic newTopic = new NewTopic(topicName, partitions, replicationFactor);
+      adminClient.createTopics(Collections.singleton(newTopic)).all().get(30, TimeUnit.SECONDS);
+    }
+  }
+
+  public void deleteTopic(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      adminClient.deleteTopics(Collections.singleton(topicName)).all().get(30, TimeUnit.SECONDS);
+    }
+  }
+
+  public void waitForTopicCreation(String topicName, Duration timeout) throws InterruptedException, ExecutionException, TimeoutException {
+    long startTime = System.currentTimeMillis();
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      while (System.currentTimeMillis() - startTime < timeout.toMillis()) {
+        if (adminClient.listTopics().names().get().contains(topicName)) {
+          return;
+        }
+        Thread.sleep(1000);
+      }
+      throw new TimeoutException("Timed out waiting for topic creation: " + topicName);
+    }
+  }
+
+  public boolean topicExists(String topicName) throws InterruptedException, ExecutionException, TimeoutException {
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      return adminClient.listTopics().names().get(30, TimeUnit.SECONDS).contains(topicName);
+    }
+  }
+
+  public void waitForTopicDeletion(String topicName, Duration timeout) throws InterruptedException, ExecutionException, TimeoutException {
+    long startTime = System.currentTimeMillis();
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      while (System.currentTimeMillis() - startTime < timeout.toMillis()) {
+        if (!adminClient.listTopics().names().get().contains(topicName)) {
+          return;
+        }
+        Thread.sleep(1000);
+      }
+      throw new TimeoutException("Timed out waiting for topic deletion: " + topicName);
+    }
+  }
+
+  public Set<String> listTopics() throws InterruptedException, ExecutionException, TimeoutException {
+    try (AdminClient adminClient = AdminClient.create(getKafkaProperties())) {
+      ListTopicsResult topics = adminClient.listTopics();
+      return topics.names().get(30, TimeUnit.SECONDS);
+    }
+  }
+
+  public Properties getKafkaProperties() {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+    return props;
+  }
+
+  public <K, V> KafkaProducer<K, V> createProducer(Class<?> keySerializerClass, Class<?> valueSerializerClass) {
+    Properties props = getKafkaProperties();
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    return new KafkaProducer<>(props);
+  }
+
+  public <K, V> KafkaConsumer<K, V> createConsumer(String groupId, Class<?> keyDeserializerClass, Class<?> valueDeserializerClass) {
+    Properties props = getKafkaProperties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    return new KafkaConsumer<>(props);
+  }
+
+  // Convenience methods for creating specific types of producers and consumers
+  public KafkaProducer<String, GenericRecord> createAvroProducer() {
+    return createProducer(StringSerializer.class, KafkaAvroSerializer.class);
+  }
+
+  public KafkaConsumer<String, GenericRecord> createAvroConsumer(String groupId) {
+    return createConsumer(groupId, StringDeserializer.class, KafkaAvroDeserializer.class);
+  }
+
+  public <T extends com.google.protobuf.Message> KafkaProducer<String, T> createProtobufProducer() {
+    Properties props = getKafkaProperties();
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    return new KafkaProducer<>(props);
+  }
+
+  public <T extends com.google.protobuf.Message> KafkaConsumer<String, T> createProtobufConsumer(String groupId, Class<T> messageType) {
+    Properties props = getKafkaProperties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaProtobufDeserializer.class);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    props.put(KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE, messageType.getName());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    return new KafkaConsumer<>(props);
+  }
+
+  public KafkaProducer<String, JSONObject> createJsonSchemaProducer() {
+    Properties props = getKafkaProperties();
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaJsonSchemaSerializer.class);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    return new KafkaProducer<>(props);
+  }
+
+  public KafkaConsumer<String, Map<String, Object>> createJsonSchemaConsumer(String groupId) {
+    Properties props = getKafkaProperties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaJsonSchemaDeserializer.class);
+    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.endpoint());
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    props.put(KafkaJsonSchemaDeserializerConfig.JSON_VALUE_TYPE, Map.class.getName());
+    return new KafkaConsumer<>(props);
+  }
+
+  public KafkaProducer<String, String> createStringProducer() {
+    return createProducer(StringSerializer.class, StringSerializer.class);
+  }
+
+  public KafkaConsumer<String, String> createStringConsumer(String groupId) {
+    return createConsumer(groupId, StringDeserializer.class, StringDeserializer.class);
+  }
+
+  public String getKafkaBootstrapServers() {
+    return kafka.getBootstrapServers();
+  }
+
+  public String getSchemaRegistryUrl() {
+    return schemaRegistry.endpoint();
+  }
+
+  public String getBootstrapServers() {
+    return kafka.getBootstrapServers();
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SchemaRegistryContainer.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SchemaRegistryContainer.java
@@ -1,0 +1,24 @@
+package io.confluent.idesidecar.restapi.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+  private static final int PORT = 8085;
+
+  public SchemaRegistryContainer(String kafkaBootstrap) {
+    this("confluentinc/cp-schema-registry:7.7.0", kafkaBootstrap);
+  }
+
+  public SchemaRegistryContainer(String dockerImageName, String kafkaBootstrap) {
+    super(DockerImageName.parse(dockerImageName));
+    withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", kafkaBootstrap);
+    withEnv("SCHEMA_REGISTRY_HOST_NAME", "schemaRegistry");
+    withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + PORT);
+  }
+
+  public String endpoint() {
+    return String.format("http://%s:%d", getHost(), getMappedPort(PORT));
+  }
+}

--- a/src/test/proto/message.proto
+++ b/src/test/proto/message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package io.confluent.idesidecar.restapi;
+option java_package = "io.confluent.idesidecar.restapi.proto";
+
+message MyMessage {
+  string name = 1;
+  int32 age = 2;
+  bool is_active = 3;
+}


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

This commit adds support for Protobuf, Avro, and JSON Schema serialization/deserialization 
in the local Kafka cluster setup. It includes the following changes:

- Refactor ConfluentLocalTestBed to support multiple serialization formats
- Add methods for creating Protobuf, Avro, and JSON Schema producers and consumers
- Implement tests for each serialization format (Protobuf, Avro, JSON Schema)
- Add support for plain string serialization/deserialization

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

NOTE: A test in 'KafkaConsumeResourceIT' will be added while integrating confluent kafka local, confluent local REST server & schema-registry container.
