### PR TITLE
Improve the performance of the message viewer API

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
@@ -11,6 +11,8 @@ import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
 import io.confluent.idesidecar.restapi.messageviewer.DecoderUtil;
 import io.confluent.idesidecar.restapi.messageviewer.MessageViewerContext;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeData;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord;
 import io.confluent.idesidecar.restapi.proxy.ProxyHttpClient;
 import io.confluent.idesidecar.restapi.util.RequestHeadersConstants;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
@@ -110,8 +112,8 @@ public class ConfluentCloudConsumeStrategy implements ConsumeStrategy {
           rawTopicRowsResponse,
           SimpleConsumeMultiPartitionResponse.class
       );
-      decodeSchemaEncodedValues(context, data);
-      context.setConsumeResponse(data);
+      var processedPartitionResponse = decodeSchemaEncodedValues(context, data);
+      context.setConsumeResponse(processedPartitionResponse);
       return context;
     } catch (JsonProcessingException e) {
       LOGGER.error("Error parsing the messages from ccloud : \n message ='"
@@ -148,50 +150,86 @@ public class ConfluentCloudConsumeStrategy implements ConsumeStrategy {
   /**
    * Decodes schema-encoded values in the MultiPartitionConsumeResponse.
    *
-   * @param context The MessageViewerContext.
-   * @param data    The MultiPartitionConsumeResponse to decode.
+   * @param context     The MessageViewerContext.
+   * @param rawResponse The MultiPartitionConsumeResponse to decode.
    */
-  private void decodeSchemaEncodedValues(
+  private SimpleConsumeMultiPartitionResponse decodeSchemaEncodedValues(
       MessageViewerContext context,
-      SimpleConsumeMultiPartitionResponse data
+      SimpleConsumeMultiPartitionResponse rawResponse
   ) {
     var schemaRegistry = context.getSchemaRegistryInfo();
     if (schemaRegistry == null) {
-      return;
+      return rawResponse;
     }
+
     var schemaRegistryClient = SCHEMA_REGISTRY_CLIENTS_BY_ID.computeIfAbsent(
         schemaRegistry.id(),
         k -> createSchemaRegistryClient(context)
     );
+    if (schemaRegistryClient == null) {
+      return rawResponse;
+    }
 
-    if (schemaRegistryClient != null) {
-      for (var partitionData : data.partitionDataList()) {
-        for (var record : partitionData.records()) {
-          // Decode the key
-          DecoderUtil.DecodedResult decodedKeyResult = decodeValue(
+    var processedPartitions = rawResponse
+        .partitionDataList().stream()
+        .map(partitionData -> processPartition(partitionData, context, schemaRegistryClient))
+        .toList();
+
+    return new SimpleConsumeMultiPartitionResponse(
+        rawResponse.clusterId(),
+        rawResponse.topicName(),
+        processedPartitions
+    );
+  }
+
+  /**
+   * Decodes the keys and the values of all records of a specific partition.
+   *
+   * @param partitionConsumeData The unprocessed data of the partition.
+   * @param context              The context of the message viewer API.
+   * @param schemaRegistryClient The schema registry client to use for decoding the keys/values.
+   * @return All records of the partition with decoded keys and values.
+   */
+  private PartitionConsumeData processPartition(
+      PartitionConsumeData partitionConsumeData,
+      MessageViewerContext context,
+      SchemaRegistryClient schemaRegistryClient
+  ) {
+
+    var processedRecords = partitionConsumeData
+        .records().stream()
+        .map(record -> {
+          var decodedRecordKey = decodeValue(
               record.key(),
               schemaRegistryClient,
               context.getTopicName()
           );
-
-          // Decode the value
-          DecoderUtil.DecodedResult decodedValueResult = decodeValue(
+          var decodedRecordValue = decodeValue(
               record.value(),
               schemaRegistryClient,
               context.getTopicName()
           );
 
-          updateRecord(
-              partitionData,
-              record,
-              decodedKeyResult.getValue(),
-              decodedValueResult.getValue(),
-              decodedKeyResult.getErrorMessage(),
-              decodedValueResult.getErrorMessage()
+          return new PartitionConsumeRecord(
+              record.partitionId(),
+              record.offset(),
+              record.timestamp(),
+              record.timestampType(),
+              record.headers(),
+              decodedRecordKey.getValue(),
+              decodedRecordValue.getValue(),
+              decodedRecordKey.getErrorMessage(),
+              decodedRecordValue.getErrorMessage(),
+              record.exceededFields()
           );
-        }
-      }
-    }
+        })
+        .toList();
+
+    return new PartitionConsumeData(
+        partitionConsumeData.partitionId(),
+        partitionConsumeData.nextOffset(),
+        processedRecords
+    );
   }
 
   /**
@@ -211,41 +249,6 @@ public class ConfluentCloudConsumeStrategy implements ConsumeStrategy {
       return DecoderUtil.decodeAndDeserialize(rawValue, schemaRegistryClient, topicName);
     }
     return new DecoderUtil.DecodedResult(value, null);
-  }
-
-  /**
-   * Updates a PartitionConsumeRecord with the decoded key and value.
-   *
-   * @param partitionData The PartitionConsumeData containing the record to update.
-   * @param record        The PartitionConsumeRecord to update.
-   * @param decodedKey    The decoded key if decoding is successful else null
-   * @param decodedValue  The decoded value if decoding is successful else null.
-   * @param keyErrorMessage The error message for key decoding if it failed, else null.
-   * @param valueErrorMessage The error message for value decoding if it failed, else null.
-   */
-  private void updateRecord(
-      SimpleConsumeMultiPartitionResponse.PartitionConsumeData partitionData,
-      SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord record,
-      JsonNode decodedKey,
-      JsonNode decodedValue,
-      String keyErrorMessage,
-      String valueErrorMessage
-  ) {
-    SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord updatedRecord =
-        new SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord(
-            record.partitionId(),
-            record.offset(),
-            record.timestamp(),
-            record.timestampType(),
-            record.headers(),
-            decodedKey,
-            decodedValue,
-            keyErrorMessage,
-            valueErrorMessage,
-            record.exceededFields()
-        );
-    int recordIndex = partitionData.records().indexOf(record);
-    partitionData.records().set(recordIndex, updatedRecord);
   }
 
   /**


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

The message viewer API consumes raw records from Confluent Cloud, deserializes the records if they reference a schema, and returns the processed records.

Prior to this change, the message viewer API used Java's [List.indexOf()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/List.html#indexOf(java.lang.Object)) to look up the index of a record in the response object after applying the schema and before updating it. `List.indexOf` uses a sequential search and is not very performant when dealing with larger lists of larger `record`s.

While the JVM's JIT compiler is able to optimize this code at runtime, GraalVM's AOT compiler is not, leading to a poor performance of the message viewer API in the native executables.

This change updates the processing and updating of records to use the Java Streams API so that we update records in-place. On my machine, this change reduces the time needed for processing/updating records from ~ 700ms to less than 5ms, i.e., it makes every request against the message viewer API almost one second faster.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

