### PR TITLE
chore: Make the Maven wrapper executable before running it

### DIFF
--- a/src/main/resources/static/templates/flink-table-api-java-example/src/README.md
+++ b/src/main/resources/static/templates/flink-table-api-java-example/src/README.md
@@ -95,6 +95,7 @@ build on top of each other.
 Use Maven to build a JAR file of the project. Make sure you have at least Java 11 installed.
 The included Maven wrapper `mvnw` is useful for a consistent Maven version, you don't need to install Maven. 
 ```bash
+chmod +x mvnw
 ./mvnw clean package
 ```
 


### PR DESCRIPTION
## Summary of Changes

I've noticed that the scaffolding API does not respect the execute permissions of template files.
Until we have a fix for the underlying issue, I've updated the readme of the Flink Table API template to make the Maven wrapper executable before running it.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

