### PR TITLE
Return the original Base64-encoded str when schema retrieval fails

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/DecoderUtil.java
@@ -134,8 +134,11 @@ public class DecoderUtil {
     // Check if schema retrieval has failed recently
     String cachedError = schemaFetchErrorCache.getIfPresent(schemaId);
     if (cachedError != null) {
+      // If an error occurred, return the original Base64-encoded string
+      // from the message in the topic.
+      final String rawBase64 = Base64.getEncoder().encodeToString(bytes);
       return new DecodedResult(
-          TextNode.valueOf(new String(bytes, StandardCharsets.UTF_8)),
+          TextNode.valueOf(rawBase64),
           cachedError
       );
     }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes
- Added logic to return the original Base64 string from the message when schema decoding fails.
- Added an unit-test for the change.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

