### PR TITLE
Ignore artifact push and set GH_TOKEN again before running gh

### DIFF
--- a/.semaphore/windows.yml
+++ b/.semaphore/windows.yml
@@ -50,6 +50,7 @@ global_job_config:
       - $Env:PATH += ";C:\Program Files\GitHub CLI\"
       # Usage of GH cli in automation (when "CI" is set) requires us to set the GH_TOKEN environment variable.
       - $Env:GH_TOKEN = $Env:GITHUB_TOKEN
+      - gh --version
       # This ensures native-image.cmd is able to find the local installation
       # of VC++ tools and VS Build Tools.
       - |
@@ -97,5 +98,6 @@ blocks:
               Rename-Item -Path $executable -NewName (Split-Path -Leaf $executable_with_os_arch)
               Write-Host "Signing executable $executable_with_os_arch";
               signtool sign /debug /v /f certificate.pfx "$executable_with_os_arch";
-              artifact push workflow $executable_with_os_arch --destination "native-executables/$(Split-Path -Leaf $executable_with_os_arch)";
+              try {artifact push workflow $executable_with_os_arch --destination "native-executables/$(Split-Path -Leaf $executable_with_os_arch)"} catch {Write-Host "Artifact push failed"}
+              $Env:GH_TOKEN = $Env:GITHUB_TOKEN
               gh release upload "$(sem-context get release_version)" $executable_with_os_arch --clobber


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Ignore if artifact push fails -- we must try uploading to gh release regardless.
- Set `GH_TOKEN` right before running `gh`