### PR TITLE
Ensure `gh auth login` before uploading Windows executable to GH release

### DIFF
--- a/.semaphore/windows.yml
+++ b/.semaphore/windows.yml
@@ -49,7 +49,6 @@ global_job_config:
       - choco install gh -y
       - $Env:PATH += ";C:\Program Files\GitHub CLI\"
       # Usage of GH cli in automation (when "CI" is set) requires us to set the GH_TOKEN environment variable.
-      - $Env:GH_TOKEN = $Env:GITHUB_TOKEN
       - gh --version
       # This ensures native-image.cmd is able to find the local installation
       # of VC++ tools and VS Build Tools.
@@ -99,5 +98,8 @@ blocks:
               Write-Host "Signing executable $executable_with_os_arch";
               signtool sign /debug /v /f certificate.pfx "$executable_with_os_arch";
               try {artifact push workflow $executable_with_os_arch --destination "native-executables/$(Split-Path -Leaf $executable_with_os_arch)"} catch {Write-Host "Artifact push failed"}
-              $Env:GH_TOKEN = $Env:GITHUB_TOKEN
+              $Env:GH_TOKEN = [Environment]::GetEnvironmentVariable('GITHUB_TOKEN', 'Machine')
+              gh config set prompt disabled
+              gh auth login
+              gh auth status
               gh release upload "$(sem-context get release_version)" $executable_with_os_arch --clobber


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

Seems we'll have to use the `GetEnvironmentVariable` Powershell function to get the `GITHUB_TOKEN`

https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.4#use-the-systemenvironment-methods