### PR TITLE
chore: Align references to Confluent for VS Code (#10)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Welcome to the Confluent ide-sidecar contributing guide
 
-Thanks for your interest in contributing to this project, which is part of the Confluent extension for VS Code!
-Our goal for the [Confluent extension for VS Code project](https://github.com/confluentinc/vscode) 
+Thanks for your interest in contributing to this project, which is part of Confluent for VS Code!
+Our goal for the [Confluent for VS Code project](https://github.com/confluentinc/vscode)
 is to help make it very easy for developers to build stream processing applications using Confluent.
 
 Anyone can contribute, and here are some ways to do so:
@@ -87,7 +87,7 @@ Most development occurs on the `main` branch. Therefore, most PRs will target th
 If we need to patch a previously-released major or minor release, we will create a `v.MAJOR.MINOR.x` branch (e.g., `v1.2.x`), and we create PRs against this branch for all fixes and changes. When the patch is ready, we'll release the first `v.MAJOR.MINOR.1` patch version (e.g., `v1.2.1`). If we need to make additional fixes, we'll continue to do so against this same branch and release subsequent patch versions (e.g., `v1.2.2`, `v1.2.3`, etc).
 
 This project's releases will be published to https://github.com/confluentinc/ide-sidecar/releases, 
-and those releases will be used by the [Confluent extension for VS Code project](https://github.com/confluentinc/vscode).
+and those releases will be used by the [Confluent for VS Code project](https://github.com/confluentinc/vscode).
 
 ## Our codebase
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Release](release.svg) 
 
 👋 Welcome to **IDE Sidecar**, the sidecar application used by
-the [Confluent Extension for VS Code](https://github.com/confluentinc/vscode).
+[Confluent for VS Code](https://github.com/confluentinc/vscode).
 
 💡 IDE Sidecar exposes REST and GraphQL APIs.
 It is a Java 21 project that uses [Quarkus](https://quarkus.io), [GraalVM](https://www.graalvm.org/), and

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>0.27.0</version>
   <packaging>jar</packaging>
   <name>IDE Sidecar</name>
-  <description>Sidecar used by the Confluent Extension for VS Code.</description>
+  <description>Sidecar used by Confluent for VS Code.</description>
 
   <scm>
     <connection>scm:git:git://github.com/confluentinc/ide-sidecar.git</connection>

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -2,10 +2,10 @@
   "openapi" : "3.0.3",
   "info" : {
     "title" : "Confluent ide-sidecar API",
-    "description" : "API for the Confluent ide-sidecar, part of the Confluent extension for VS Code",
+    "description" : "API for the Confluent ide-sidecar, part of Confluent for VS Code",
     "termsOfService" : "Your terms here",
     "contact" : {
-      "name" : "Confluent extension for VS Code Support",
+      "name" : "Confluent for VS Code Support",
       "url" : "https://confluent.io/contact",
       "email" : "vscode@confluent.io"
     },
@@ -1163,12 +1163,12 @@
             "enum" : [ "UP", "DOWN" ],
             "type" : "string"
           },
-          "name" : {
-            "type" : "string"
-          },
           "data" : {
             "type" : "object",
             "nullable" : true
+          },
+          "name" : {
+            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -2,11 +2,10 @@
 openapi: 3.0.3
 info:
   title: Confluent ide-sidecar API
-  description: "API for the Confluent ide-sidecar, part of the Confluent extension\
-    \ for VS Code"
+  description: "API for the Confluent ide-sidecar, part of Confluent for VS Code"
   termsOfService: Your terms here
   contact:
-    name: Confluent extension for VS Code Support
+    name: Confluent for VS Code Support
     url: https://confluent.io/contact
     email: vscode@confluent.io
   version: 1.0.1
@@ -841,8 +840,8 @@ components:
           - UP
           - DOWN
           type: string
-        name:
-          type: string
         data:
           type: object
           nullable: true
+        name:
+          type: string

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,10 +150,10 @@ quarkus:
     info-title: Confluent ide-sidecar API
     store-schema-directory: src/generated/resources/
     info-version: 1.0.1
-    info-description: API for the Confluent ide-sidecar, part of the Confluent extension for VS Code
+    info-description: API for the Confluent ide-sidecar, part of Confluent for VS Code
     info-terms-of-service: Your terms here
     info-contact-email: vscode@confluent.io
-    info-contact-name: Confluent extension for VS Code Support
+    info-contact-name: Confluent for VS Code Support
     info-contact-url: https://confluent.io/contact
   smallrye-graphql:
     print-data-fetcher-exception: true


### PR DESCRIPTION
## Summary of Changes

Use `Confluent for VS Code` when referencing the [VS Code extension](https://github.com/confluentinc/vscode).

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

