### PR TITLE
feat: Enable Sidecar to detect SR running on default local port

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -670,6 +670,9 @@
           },
           "ccloud_config" : {
             "$ref" : "#/components/schemas/CCloudConfig"
+          },
+          "local_config" : {
+            "$ref" : "#/components/schemas/LocalConfig"
           }
         }
       },
@@ -845,6 +848,15 @@
       "JsonNodeType" : {
         "enum" : [ "ARRAY", "BINARY", "BOOLEAN", "MISSING", "NULL", "NUMBER", "OBJECT", "POJO", "STRING" ],
         "type" : "string"
+      },
+      "LocalConfig" : {
+        "description" : "Configuration for local cluster",
+        "type" : "object",
+        "properties" : {
+          "schema-registry-uri" : {
+            "type" : "string"
+          }
+        }
       },
       "ObjectMetadata" : {
         "type" : "object",

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -464,6 +464,8 @@ components:
           $ref: "#/components/schemas/ConnectionType"
         ccloud_config:
           $ref: "#/components/schemas/CCloudConfig"
+        local_config:
+          $ref: "#/components/schemas/LocalConfig"
     ConnectionStatus:
       required:
       - authentication
@@ -598,6 +600,12 @@ components:
       - POJO
       - STRING
       type: string
+    LocalConfig:
+      description: Configuration for local cluster
+      type: object
+      properties:
+        schema-registry-uri:
+          type: string
     ObjectMetadata:
       type: object
       properties:

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -28,11 +28,11 @@ public record ConnectionSpec(
   }
 
   public ConnectionSpec withId(String id) {
-    return new ConnectionSpec(id, name, type, ccloudConfig, null);
+    return new ConnectionSpec(id, name, type, ccloudConfig, localConfig);
   }
 
   public ConnectionSpec withName(String name) {
-    return new ConnectionSpec(id, name, type, ccloudConfig, null);
+    return new ConnectionSpec(id, name, type, ccloudConfig, localConfig);
   }
 
   /**
@@ -40,7 +40,7 @@ public record ConnectionSpec(
    * Confluent Cloud organization ID set in the CCloudConfig.
    */
   public ConnectionSpec withCCloudOrganizationId(String ccloudOrganizationId) {
-    return new ConnectionSpec(id, name, type, new CCloudConfig(ccloudOrganizationId), null);
+    return new ConnectionSpec(id, name, type, new CCloudConfig(ccloudOrganizationId), localConfig);
   }
 
   public String ccloudOrganizationId() {
@@ -58,9 +58,6 @@ public record ConnectionSpec(
   public record LocalConfig(
       @JsonProperty(value = "schema-registry-uri") String schemaRegistryUri
   ) {
-    public String schemaRegistryUri() {
-      return this.schemaRegistryUri;
-    }
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -13,7 +13,8 @@ public record ConnectionSpec(
     String id,
     String name,
     ConnectionType type,
-    @JsonProperty("ccloud_config") CCloudConfig ccloudConfig
+    @JsonProperty("ccloud_config") CCloudConfig ccloudConfig,
+    @JsonProperty("local_config") LocalConfig localConfig
 ) {
 
   public enum ConnectionType {
@@ -23,15 +24,15 @@ public record ConnectionSpec(
   }
 
   public ConnectionSpec(String id, String name, ConnectionType type) {
-    this(id, name, type, null);
+    this(id, name, type, null, null);
   }
 
   public ConnectionSpec withId(String id) {
-    return new ConnectionSpec(id, name, type, ccloudConfig);
+    return new ConnectionSpec(id, name, type, ccloudConfig, null);
   }
 
   public ConnectionSpec withName(String name) {
-    return new ConnectionSpec(id, name, type, ccloudConfig);
+    return new ConnectionSpec(id, name, type, ccloudConfig, null);
   }
 
   /**
@@ -39,7 +40,7 @@ public record ConnectionSpec(
    * Confluent Cloud organization ID set in the CCloudConfig.
    */
   public ConnectionSpec withCCloudOrganizationId(String ccloudOrganizationId) {
-    return new ConnectionSpec(id, name, type, new CCloudConfig(ccloudOrganizationId));
+    return new ConnectionSpec(id, name, type, new CCloudConfig(ccloudOrganizationId), null);
   }
 
   public String ccloudOrganizationId() {
@@ -51,6 +52,15 @@ public record ConnectionSpec(
       @JsonProperty(value = "organization_id", required = true) String organizationId
   ) {
 
+  }
+
+  @Schema(description = "Configuration for local cluster")
+  public record LocalConfig(
+      @JsonProperty(value = "schema-registry-uri") String schemaRegistryUri
+  ) {
+    public String schemaRegistryUri() {
+      return this.schemaRegistryUri;
+    }
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcher.java
@@ -34,6 +34,6 @@ public class FakeLocalFetcher implements LocalFetcher {
 
   @Override
   public Uni<LocalSchemaRegistry> getSchemaRegistry(String connectionId) {
-    return Uni.createFrom().item(new LocalSchemaRegistry("http://localhost:8081", connectionId));
+    return Uni.createFrom().item(new LocalSchemaRegistry(connectionId, "http://localhost:8081"));
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcher.java
@@ -34,6 +34,6 @@ public class FakeLocalFetcher implements LocalFetcher {
 
   @Override
   public Uni<LocalSchemaRegistry> getSchemaRegistry(String connectionId) {
-    return Uni.createFrom().item(new LocalSchemaRegistry(connectionId));
+    return Uni.createFrom().item(new LocalSchemaRegistry("http://localhost:8081", connectionId));
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/LocalSchemaRegistry.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/LocalSchemaRegistry.java
@@ -11,10 +11,10 @@ public record LocalSchemaRegistry(
     String connectionId
 ) implements Cluster, SchemaRegistry {
 
-  LocalSchemaRegistry(String connectionId) {
+  LocalSchemaRegistry(String uri, String connectionId) {
     this(
         "local-sr",
-        "http://localhost:8080",
+        uri,
         connectionId
     );
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/LocalSchemaRegistry.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/LocalSchemaRegistry.java
@@ -11,7 +11,7 @@ public record LocalSchemaRegistry(
     String connectionId
 ) implements Cluster, SchemaRegistry {
 
-  LocalSchemaRegistry(String uri, String connectionId) {
+  LocalSchemaRegistry(String connectionId, String uri) {
     this(
         "local-sr",
         uri,

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
@@ -153,15 +153,22 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
   public String resolveSchemaRegistryUri(String connectionId) {
     var localConfig = connections.getConnectionSpec(connectionId).localConfig();
     if (localConfig == null || localConfig.schemaRegistryUri() == null) {
+      // Use the default SR URI when missing LocalConfig or missing SR URI in that config
       return CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
     }
-    return localConfig.schemaRegistryUri(); // may be null if no SR is to be used
+    var uri = localConfig.schemaRegistryUri();
+    if (uri.isBlank()) {
+      // Blank URL means no SR
+      return null;
+    }
+    return uri;
   }
 
 
   public Uni<LocalSchemaRegistry> getSchemaRegistry(String connectionId) {
     String uri = resolveSchemaRegistryUri(connectionId);
     if (uri == null) {
+      Log.infof("No Schema Registry will be used for connection %s", connectionId);
       return Uni.createFrom().nullItem();
     }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
@@ -176,7 +176,7 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
             Log.infof("Request to schema-registry '%s' failed.", configUri);
             return Uni.createFrom().nullItem();
           }
-          return Uni.createFrom().item(() -> new LocalSchemaRegistry(uri, connectionId));
+          return Uni.createFrom().item(() -> new LocalSchemaRegistry(connectionId, uri));
         })
         .map(localSchemaRegistry -> onLoad(connectionId, localSchemaRegistry));
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,6 +98,7 @@ ide-sidecar:
         kafkarest-uri: http://localhost:8082
         kafkarest-hostname: rest-proxy
         cluster-name: confluent-local
+        schema-registry-uri: http://localhost:8081
       resources:
         clusters-list-uri: ${ide-sidecar.connections.confluent-local.default.kafkarest-uri}/v3/clusters
         brokers-list-uri: ${ide-sidecar.connections.confluent-local.default.kafkarest-uri}/v3/clusters/%s/brokers

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/FakeLocalFetcherTest.java
@@ -47,6 +47,6 @@ class FakeLocalFetcherTest {
         .withSubscriber(UniAssertSubscriber.create())
         .assertCompleted()
         .getItem();
-    assertEquals("http://localhost:8080", cluster.uri());
+    assertEquals("http://localhost:8081", cluster.uri());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
@@ -231,6 +231,15 @@ class RealLocalFetcherTest {
     manager.createConnectionState(connectionSpec);
 
     String uri = localFetcher.resolveSchemaRegistryUri("3");
-    assertNull(uri); // No Schema Registry
+    assertEquals("", uri); // No Schema Registry
+  }
+
+  @Test
+  void shouldReturnDefaultSchemaRegistryUriWhenSchemaRegistryUriIsNull() throws CreateConnectionException {
+    var localConfig = new ConnectionSpec.LocalConfig(null);
+    var connectionSpec = new ConnectionSpec("4", "Local Connection", ConnectionSpec.ConnectionType.LOCAL, null, localConfig);
+    manager.createConnectionState(connectionSpec);
+    String uri = localFetcher.resolveSchemaRegistryUri("4");
+    assertEquals("http://localhost:8081", uri);
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.confluent.idesidecar.restapi.exceptions.ResourceFetchingException;
 import io.confluent.idesidecar.restapi.models.graph.ConfluentRestClient.PaginationState;
 import io.confluent.idesidecar.restapi.models.graph.RealLocalFetcher.KafkaBrokerConfigResponse;
+import io.confluent.idesidecar.restapi.models.graph.RealLocalFetcher.SchemaRegistryConfigResponse;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
@@ -191,4 +192,23 @@ class RealLocalFetcherTest {
     assertEquals(Arrays.asList(expectedAddresses), addresses);
   }
 
+  @Test
+  void schemaRegistryFetch_shouldParseConfigResponseFromValidJson() {
+    var json = loadResource(
+        "confluent-local-resources-mock-responses/get-schema-registry-response.json"
+    );
+    SchemaRegistryConfigResponse config = localFetcher.parseSchemaRegistryConfig(URL, json);
+    assertEquals("BACKWARD", config.compatibilityLevel());
+
+  }
+
+  @Test
+  void sadfouldFailToParseConfigResponseFromError() {
+    var exception = assertThrows(
+        ResourceFetchingException.class,
+        () -> localFetcher.parseSchemaRegistryConfig(URL, ERROR_JSON)
+    );
+    assertTrue(exception.getMessage().contains("HTTP 404 Not Found"));
+    assertTrue(exception.getMessage().contains(URL));
+  }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
@@ -231,7 +231,7 @@ class RealLocalFetcherTest {
     manager.createConnectionState(connectionSpec);
 
     String uri = localFetcher.resolveSchemaRegistryUri("3");
-    assertEquals("", uri); // No Schema Registry
+    assertNull(uri); // No Schema Registry
   }
 
   @Test

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -464,7 +464,9 @@ public class ConnectionsResourceTest {
 
     var badSpec = new ConnectionSpec(
         "c3", "Connection name changed!", ConnectionType.PLATFORM,
-        new CCloudConfig("org-id"), null);
+        new CCloudConfig("org-id"),
+        null
+    );
     given()
         .contentType(ContentType.JSON)
         .body(badSpec)

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -464,7 +464,7 @@ public class ConnectionsResourceTest {
 
     var badSpec = new ConnectionSpec(
         "c3", "Connection name changed!", ConnectionType.PLATFORM,
-        new CCloudConfig("org-id"));
+        new CCloudConfig("org-id"), null);
     given()
         .contentType(ContentType.JSON)
         .body(badSpec)

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
@@ -36,7 +36,7 @@ public class KafkaConsumeResourceIT {
   public record KafkaClusterDetails(String id, String name, String bootstrapServers, String uri) {}
 
   private static ConfluentLocalTestBed confluentLocal;
-
+  
   private String connectionId;
 
   @BeforeAll
@@ -534,15 +534,6 @@ public class KafkaConsumeResourceIT {
         .statusCode(204);
   }
 
-  void deleteLocalConnection(String id) {
-    given()
-        .when()
-        .header("Content-Type", "application/json")
-        .delete("/gateway/v1/connections/" + id)
-        .then()
-        .statusCode(204);
-  }
-
   void createLocalConnection(String id, String name) {
     given()
         .when()
@@ -624,6 +615,7 @@ public class KafkaConsumeResourceIT {
       response.then().statusCode(201); // Only assert status if successful
     }
   }
+
 
   void produceRecords(String bootstrapServers, String topicName, String[][] records) {
     // Configure the Producer

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
@@ -8,13 +8,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeData;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord;
+import io.confluent.idesidecar.restapi.proto.Message.MyMessage;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.ConfluentLocalKafkaWithRestProxyContainer;
+import io.confluent.idesidecar.restapi.util.ConfluentLocalTestBed;
 import io.confluent.idesidecar.restapi.util.ResourceIOUtil;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import io.quarkus.test.junit.TestProfile;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -30,13 +37,15 @@ public class KafkaConsumeResourceIT {
   public record KafkaClusterDetails(String id, String name, String bootstrapServers, String uri) {}
 
   private KafkaClusterDetails setupTestEnvironment(
-      ConfluentLocalKafkaWithRestProxyContainer confluentLocal, String connectionId, String topicName, int partitions, String[][] sampleRecords) {
+      ConfluentLocalTestBed confluentLocal, String connectionId, String topicName, int partitions, String[][] sampleRecords) {
     confluentLocal.start();
     createLocalConnection(connectionId, connectionId);
     var localKafkaClusterDetails = getLocalKafkaClusterId();
     assertFalse(localKafkaClusterDetails.id().isEmpty());
     createLocalKafkaTopic(connectionId, localKafkaClusterDetails.id(), topicName, partitions);
-    produceRecords(localKafkaClusterDetails.bootstrapServers(), topicName, sampleRecords);
+    if (sampleRecords != null) {
+      produceRecords(localKafkaClusterDetails.bootstrapServers(), topicName, sampleRecords);
+    }
     return localKafkaClusterDetails;
   }
 
@@ -59,7 +68,7 @@ public class KafkaConsumeResourceIT {
 
   @Test
   void testConfluentLocalContainer() {
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection";
       var topicName = "test_topic";
       var sampleRecords = new String[][]{
@@ -91,7 +100,7 @@ public class KafkaConsumeResourceIT {
     // Test that the Kafka consumer respects the "max_poll_records" limit
     // and returns only the specified number of records when consuming
     // from multiple partitions in a Kafka topic. The max limit is 2000 (MAX_POLL_RECORDS_LIMIT)
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection3";
       var topicName = "test_topic_max_poll";
       var sampleRecords = new String[][]{
@@ -130,7 +139,7 @@ public class KafkaConsumeResourceIT {
     // across multiple partitions, ensuring that the total number of records
     // returned does not exceed the specified limit, regardless of how
     // many partitions the records are consumed from.
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection9";
       var topicName = "test_topic_max_poll";
       var sampleRecords = new String[][]{
@@ -174,7 +183,7 @@ public class KafkaConsumeResourceIT {
     // Test that the Kafka consumer, when provided with a null value for
     // "max_poll_records", retrieves all available records  from the
     // topic (with default size limits). Here, it should retrieve four records.
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection4";
       var topicName = "test_topic_null_max_poll";
       var sampleRecords = new String[][]{
@@ -209,7 +218,7 @@ public class KafkaConsumeResourceIT {
     // for a specific partition. Then, issue a new consume request starting from a specified
     // offset (in this case, offset 2) and verify that the correct records are retrieved
     // from that offset onwards.
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       // Set up Kafka Cluster
       var connectionId = "local-connection6";
       var topicName = "test_topic_next_offset_query";
@@ -291,7 +300,7 @@ public class KafkaConsumeResourceIT {
 
   @Test
   void testConsumeFromMultiplePartitions_fromBeginningTrue() {
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection5";
       var topicName = "test_topic_from_beginning_true";
       var sampleRecords = new String[][]{
@@ -321,7 +330,7 @@ public class KafkaConsumeResourceIT {
 
   @Test
   void testConsumeFromMultiplePartitions_withNullFetchMaxBytes() {
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection1";
       var topicName = "test_topic_null_fetch_max_bytes";
       var sampleRecords = new String[][]{
@@ -350,7 +359,7 @@ public class KafkaConsumeResourceIT {
 
   @Test
   void testConsumeFromMultiplePartitions_withFetchMaxBytesLimit() {
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection8";
       var topicName = "test_topic_fetch_max_bytes";
       var sampleRecords = new String[][]{
@@ -384,7 +393,7 @@ public class KafkaConsumeResourceIT {
     // limit are partially consumed, with their values being omitted and marked as
     // exceeding the limit. It validates that smaller messages are fully retrieved, while larger
     // ones are marked as exceeding the allowed size.
-    try (var confluentLocal = new ConfluentLocalKafkaWithRestProxyContainer()) {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
       var connectionId = "local-connection2";
       var topicName = "test_topic_fetch_max_bytes";
       var sampleRecords = new String[][]{
@@ -427,6 +436,92 @@ public class KafkaConsumeResourceIT {
     }
   }
 
+  /**
+   * This test validates the consumption of protobuf messages from kafka topic and decoded by
+   * schema-registry.
+   * The test performs the following steps:
+   * 1. Produces three Protobuf messages to the specified Kafka topic with unique keys. These
+   *    messages are encoded into base64 strings with a MAGIC byte prefix containing schema-id.
+   * 2. Consumes all messages from the Kafka topic starting from the beginning using message-viewer
+   *    API.
+   * 3. Verifies that the expected number of messages (3) is consumed.
+   * 4. The messages should be decoded by the message-viewer and return as JSON records.
+   * 4. Converts the consumed messages from JSON back into Protobuf format.
+   * 5. Compares the consumed Protobuf messages with the original messages to ensure correctness.
+   * 6. Checks that no "exceeded fields" flag is set during consumption.
+   */
+  @Test
+  public void testShouldDecodeProfobufMessagesUsingSRInMessageViewer() throws Exception {
+    try (var confluentLocal = new ConfluentLocalTestBed()) {
+      String topic = "myProtobufTopic";
+      var connectionId = "local-connection10";
+      var localKafkaClusterDetails = setupTestEnvironment(confluentLocal, connectionId, topic, 1, null);
+      MyMessage message1 = MyMessage.newBuilder()
+          .setName("Some One")
+          .setAge(30)
+          .setIsActive(true)
+          .build();
+
+      MyMessage message2 = MyMessage.newBuilder()
+          .setName("John Doe")
+          .setAge(25)
+          .setIsActive(false)
+          .build();
+
+      MyMessage message3 = MyMessage.newBuilder()
+          .setName("Jane Smith")
+          .setAge(40)
+          .setIsActive(true)
+          .build();
+
+      List<MyMessage> messages = List.of(message1, message2, message3);
+      List<String> keys = List.of("key0", "key1", "key2");
+
+      KafkaProducer<String, MyMessage> producer = confluentLocal.createProtobufProducer();
+
+      for (int i = 0; i < messages.size(); i++) {
+        ProducerRecord<String, MyMessage> producerRecord = new ProducerRecord<>(topic, keys.get(i),
+            messages.get(i));
+        producer.send(producerRecord);
+      }
+      producer.close();
+
+      var url = "gateway/v1/clusters/%s/topics/%s/partitions/-/consume".formatted(
+          localKafkaClusterDetails.id(), topic);
+      var rows = given()
+          .when()
+          .header("Content-Type", "application/json")
+          .header("x-connection-id", connectionId)
+          .body("{\"from_beginning\" : true}")
+          .post(url)
+          .then()
+          .statusCode(200)
+          .extract()
+          .body().asString();
+
+      var newPartitionDataList = ResourceIOUtil.asJson(rows).get("partition_data_list");
+      assertNotNull(newPartitionDataList);
+      var newRecords = newPartitionDataList.get(0).get("records");
+      assertNotNull(newRecords);
+      assertEquals(3, newRecords.size(), "Expected number of records is 3");
+      // Use JsonFormat to parse the JSON into a Protobuf object
+      for (int i = 0; i < 3; i++) {
+        assertEquals(keys.get(i), newRecords.get(i).get("key").asText(), "Mismatched key");
+
+        // Parse JSON string into MyMessage Protobuf object
+        String jsonValue = newRecords.get(i).get("value").toString();
+        MyMessage.Builder messageBuilder = MyMessage.newBuilder();
+        JsonFormat.parser().merge(jsonValue, messageBuilder); // Parse JSON to MyMessage
+        MyMessage parsedMessage = messageBuilder.build();
+
+        // Compare the parsed message with the original message
+        assertEquals(messages.get(i), parsedMessage, "Mismatched Protobuf message");
+
+        assertFalse(newRecords.get(i).get("exceeded_fields").get("value").asBoolean(), "Exceeded fields should be false");
+      }
+    }
+  }
+
   void createLocalConnection(String id, String name) {
     given()
         .when()
@@ -448,6 +543,10 @@ public class KafkaConsumeResourceIT {
                 id
                 name
                 bootstrapServers
+                uri
+              }
+              schemaRegistry {
+                id
                 uri
               }
             }

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
@@ -534,6 +534,15 @@ public class KafkaConsumeResourceIT {
         .statusCode(204);
   }
 
+  void deleteLocalConnection(String id) {
+    given()
+        .when()
+        .header("Content-Type", "application/json")
+        .delete("/gateway/v1/connections/" + id)
+        .then()
+        .statusCode(204);
+  }
+
   void createLocalConnection(String id, String name) {
     given()
         .when()

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
@@ -229,7 +229,9 @@ public class CCloudTestUtil {
                 connectionName,
                 connectionType,
                 ccloudConfig,
-                null))
+                null
+            )
+        )
         .contentType(MediaType.APPLICATION_JSON)
         .post("/gateway/v1/connections")
         .then()

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
@@ -228,7 +228,8 @@ public class CCloudTestUtil {
                 connectionId,
                 connectionName,
                 connectionType,
-                ccloudConfig))
+                ccloudConfig,
+                null))
         .contentType(MediaType.APPLICATION_JSON)
         .post("/gateway/v1/connections")
         .then()

--- a/src/test/java/io/confluent/idesidecar/restapi/util/ConfluentLocalTestBed.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/ConfluentLocalTestBed.java
@@ -48,7 +48,7 @@ public class ConfluentLocalTestBed implements AutoCloseable {
 
     this.schemaRegistry = new SchemaRegistryContainer(KAFKA_INTERNAL_LISTENER)
         .withNetwork(network)
-        .withExposedPorts(8085)
+        .withExposedPorts(8081)
         .withNetworkAliases("schema-registry")
         .dependsOn(confluent)
         .waitingFor(Wait.forHttp("/subjects").forStatusCode(200).withStartupTimeout(Duration.ofMinutes(2)));

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SchemaRegistryContainer.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SchemaRegistryContainer.java
@@ -5,7 +5,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-  private static final int PORT = 8085;
+  private static final int PORT = 8081;
 
   public SchemaRegistryContainer(String kafkaBootstrap) {
     this("confluentinc/cp-schema-registry:7.7.0", kafkaBootstrap);
@@ -16,6 +16,8 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
     withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", kafkaBootstrap);
     withEnv("SCHEMA_REGISTRY_HOST_NAME", "schemaRegistry");
     withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:" + PORT);
+    // This will map container's port 8081 to host's port 8081
+    addFixedExposedPort(PORT, PORT);
   }
 
   public String endpoint() {

--- a/src/test/resources/confluent-local-resources-mock-responses/get-schema-registry-response.json
+++ b/src/test/resources/confluent-local-resources-mock-responses/get-schema-registry-response.json
@@ -1,0 +1,3 @@
+{
+  "compatibilityLevel": "BACKWARD"
+}


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

Enable Sidecar to detect Schema Registry (SR) running on default port and use it to decode messages when consuming from local Kafka topic. Issue [156]( https://github.com/confluentinc/vscode/issues/156)

- SR default port on local cluster is 8081. [link](https://docs.confluent.io/platform/current/schema-registry/schema_registry_onprem_tutorial.html)
- Configuration of SR port will be handled in a subsequent PR.
- Fixed flaky system test. The flakiness was due to repeated start & stop of kafka & SR containers for each test.

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

