### PR TITLE
Follow-ups for PR #64

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -310,6 +310,16 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "Provided preferences are not valid",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Failure"
+                }
+              }
+            }
           }
         }
       }

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -209,6 +209,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Preferences"
+        "400":
+          description: Provided preferences are not valid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Failure"
   /gateway/v1/templates:
     get:
       tags:

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
@@ -39,8 +39,9 @@ public class OAuthCallbackResource {
       .orElse("https://marketplace.visualstudio.com/items?itemName=confluentinc.vscode-confluent");
 
   static final String TLS_HANDSHAKE_ERROR_MESSAGE =
-      "Failed to perform the SSL/TLS handshake. Consider configuring custom certificates in "
-      + "Confluent for VS Code if you are behind a firewall that performs SSL inspection.";
+      "Failed to perform the SSL/TLS handshake. Consider configuring custom certificates in the "
+      + "extension settings of Confluent for VS Code if you are behind a firewall that performs "
+      + "SSL inspection.";
 
   @Inject
   ConnectionStateManager mgr;

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/PreferencesResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/PreferencesResource.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.resources;
 
+import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.exceptions.InvalidPreferencesException;
 import io.confluent.idesidecar.restapi.models.Preferences;
 import io.confluent.idesidecar.restapi.models.Preferences.PreferencesSpec;
@@ -12,6 +13,10 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
 @Path(PreferencesResource.API_RESOURCE_PATH)
 @Produces(MediaType.APPLICATION_JSON)
@@ -37,6 +42,30 @@ public class PreferencesResource {
 
   @PUT
   @Consumes(MediaType.APPLICATION_JSON)
+  @APIResponses(
+      value = {
+          @APIResponse(
+              responseCode = "200",
+              description = "OK",
+              content = {
+                  @Content(
+                      mediaType = "application/json",
+                      schema = @Schema(implementation = Preferences.class)
+                  )
+              }
+          ),
+          @APIResponse(
+              responseCode = "400",
+              description = "Provided preferences are not valid",
+              content = {
+                  @Content(
+                      mediaType = "application/json",
+                      schema = @Schema(implementation = Failure.class)
+                  )
+              }
+          )
+      }
+  )
   public Preferences updatePreferences(Preferences updatedPreferences)
       throws InvalidPreferencesException {
     updatedPreferences.spec().validate();

--- a/src/main/resources/templates/callback.html
+++ b/src/main/resources/templates/callback.html
@@ -99,7 +99,7 @@
   <p>
     If you prefer to log in with a different account, please head to
     <a href="{confluent_cloud_homepage}">Confluent Cloud</a> in your browser, sign out, and start
-    the authentication flow in VS Code again.
+    the authentication flow in Confluent for VS Code again.
   </p>
   <p>You may close this page.</p>
 </div>

--- a/src/main/resources/templates/callback_failure.html
+++ b/src/main/resources/templates/callback_failure.html
@@ -95,7 +95,7 @@
   <h1>Authentication Failed</h1>
   <p>We couldn't complete the authentication with Confluent Cloud due to the following error:</p>
   <p><b>{error}</b></p>
-  <p>You may close this page and re-start the authentication flow in VS Code.</p>
+  <p>You may close this page and re-start the authentication flow in Confluent for VS Code.</p>
 </div>
 </body>
 


### PR DESCRIPTION
## Summary of Changes

A few smaller follow-ups for https://github.com/confluentinc/ide-sidecar/pull/64:

* Document the `400` response of the endpoint `PUT /gateway/v1/preferences` per @rhauch's suggestion.
* Provide a more meaningful error message in the case of a failed SSL handshake.
* Use "Confluent for VS Code" when referencing the extension on the callback pages.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

