### PR TITLE
fix: Set `trust_all_certificates` to `false` by default (#30)

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
@@ -50,7 +50,7 @@ public record Preferences(
         Boolean trustAllCertificates
     ) {
       this.tlsPemPaths = tlsPemPaths != null ? tlsPemPaths : List.of();
-      this.trustAllCertificates = trustAllCertificates != null ? trustAllCertificates : true;
+      this.trustAllCertificates = trustAllCertificates != null ? trustAllCertificates : false;
     }
 
     /**

--- a/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
@@ -56,11 +56,14 @@ public class WebClientFactory {
   public synchronized void updateWebClientOptions(@Observes PreferencesSpec preferences) {
     var clientOptions = new WebClientOptions();
 
-    clientOptions.setTrustAll(Boolean.TRUE.equals(preferences.trustAllCertificates()));
+    if (Boolean.TRUE.equals(preferences.trustAllCertificates())) {
+      clientOptions.setTrustAll(true);
+    }
 
-    if (preferences.tlsPemPaths() != null) {
+    var tlsPemPaths = preferences.tlsPemPaths();
+    if (tlsPemPaths != null && !tlsPemPaths.isEmpty()) {
       var pemTrustOptions = new PemTrustOptions();
-      for (var pemPath : preferences.tlsPemPaths()) {
+      for (var pemPath : tlsPemPaths) {
         pemTrustOptions.addCertPath(pemPath);
       }
       clientOptions.setPemTrustOptions(pemTrustOptions);

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
@@ -145,7 +145,7 @@ public class PreferencesResourceTest {
     assertEquals(expectedResponseJson, responseJson);
 
     // Reset the preferences
-    var expectedResponseWithoutPreferences = asJson(
+    var expectedResponseWithDefaultValues = asJson(
         loadResource("preferences/get-preferences-initial-response.json")
     );
 
@@ -172,7 +172,7 @@ public class PreferencesResourceTest {
         .asString();
     responseJson = asJson(responseBody);
 
-    assertEquals(expectedResponseWithoutPreferences, responseJson);
+    assertEquals(expectedResponseWithDefaultValues, responseJson);
   }
 
   @Test

--- a/src/test/resources/preferences/get-preferences-initial-response.json
+++ b/src/test/resources/preferences/get-preferences-initial-response.json
@@ -6,6 +6,6 @@
   },
   "spec": {
     "tls_pem_paths": [],
-    "trust_all_certificates": true
+    "trust_all_certificates": false
   }
 }


### PR DESCRIPTION
## Summary of Changes

Set the preference `trust_all_certificates` to `false` by default.

Also, set the pemTrustOptions of the Vert.x Web Client only if custom certs are present; otherwise, we'll no longer be able to validate the server's certificate and experience failed SSL handshakes.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

