### PR TITLE
fix: Use double quotes in f-string in Python template (#32)

### DIFF
--- a/src/main/resources/static/templates/python-consumer/src/consumer.py
+++ b/src/main/resources/static/templates/python-consumer/src/consumer.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
             else:
                 # Extract the (optional) key and value, and print.
                 print((f'topic: {record.topic()} '
-                       f'key: {record.key().decode('utf-8')} '
-                       f'value: {record.value().decode('utf-8')}'))
+                       f'key: {record.key().decode("utf-8")} '
+                       f'value: {record.value().decode("utf-8")}'))
     except KeyboardInterrupt:
         pass
     finally:


### PR DESCRIPTION
## Summary of Changes

Use double quotes inside the f-strings in the Python template so that users don't run into syntax errors on older Python versions.

Fixes https://github.com/confluentinc/vscode/issues/313

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

