### PR TITLE
Load certificates from the Windows trust store `WINDOWS-MY` (#36)

### DIFF
--- a/.semaphore/windows.yml
+++ b/.semaphore/windows.yml
@@ -67,8 +67,6 @@ global_job_config:
 
 blocks:
   - name: "Build and Test Native Executable (Windows x64)"
-    run:
-      when: "branch =~ '.*'"
     task:
       prologue:
         commands:

--- a/.semaphore/windows.yml
+++ b/.semaphore/windows.yml
@@ -67,6 +67,8 @@ global_job_config:
 
 blocks:
   - name: "Build and Test Native Executable (Windows x64)"
+    run:
+      when: "branch =~ '.*'"
     task:
       prologue:
         commands:

--- a/src/main/java/io/confluent/idesidecar/restapi/util/OsUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/OsUtil.java
@@ -1,0 +1,25 @@
+package io.confluent.idesidecar.restapi.util;
+
+/**
+ * Utility for implementing OS-specific functionality.
+ */
+public class OsUtil {
+
+  public enum OS {
+    WINDOWS, MAC, LINUX, UNKNOWN
+  }
+
+  static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+
+  public static OS getOperatingSystem() {
+    if (OS_NAME.contains("mac")) {
+      return OS.MAC;
+    } else if (OS_NAME.contains("win")) {
+      return OS.WINDOWS;
+    } else if (OS_NAME.contains("nix") || OS_NAME.contains("nux") || OS_NAME.contains("aix")) {
+      return OS.LINUX;
+    } else {
+      return OS.UNKNOWN;
+    }
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
@@ -2,15 +2,29 @@ package io.confluent.idesidecar.restapi.util;
 
 import io.confluent.idesidecar.restapi.models.Preferences;
 import io.confluent.idesidecar.restapi.models.Preferences.PreferencesSpec;
+import io.confluent.idesidecar.restapi.util.OsUtil.OS;
 import io.quarkus.arc.Arc;
 import io.quarkus.logging.Log;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Factory class for {@link WebClient}s. Returns a new Vert.x web client while making sure that a
@@ -18,6 +32,10 @@ import jakarta.inject.Inject;
  */
 @ApplicationScoped
 public class WebClientFactory {
+
+  static final String LINE_SEPARATOR = System.lineSeparator();
+  static final String CERT_HEADER = "-----BEGIN CERTIFICATE-----" + LINE_SEPARATOR;
+  static final String CERT_FOOTER = LINE_SEPARATOR + "-----END CERTIFICATE-----" + LINE_SEPARATOR;
 
   /**
    * It's important that we use the Quarkus-managed Vertx instance here
@@ -41,7 +59,7 @@ public class WebClientFactory {
 
   public synchronized WebClient getWebClient() {
     if (webClient == null) {
-      webClient = WebClient.create(getVertx());
+      webClient = WebClient.create(getVertx(), getDefaultWebClientOptions());
     }
 
     return webClient;
@@ -54,7 +72,7 @@ public class WebClientFactory {
    * @param preferences The new {@link Preferences}
    */
   public synchronized void updateWebClientOptions(@Observes PreferencesSpec preferences) {
-    var clientOptions = new WebClientOptions();
+    var clientOptions = getDefaultWebClientOptions();
 
     if (Boolean.TRUE.equals(preferences.trustAllCertificates())) {
       clientOptions.setTrustAll(true);
@@ -62,7 +80,10 @@ public class WebClientFactory {
 
     var tlsPemPaths = preferences.tlsPemPaths();
     if (tlsPemPaths != null && !tlsPemPaths.isEmpty()) {
-      var pemTrustOptions = new PemTrustOptions();
+      var pemTrustOptions = (PemTrustOptions) clientOptions.getSslOptions().getTrustOptions();
+      if (pemTrustOptions == null) {
+        pemTrustOptions = new PemTrustOptions();
+      }
       for (var pemPath : tlsPemPaths) {
         pemTrustOptions.addCertPath(pemPath);
       }
@@ -74,6 +95,23 @@ public class WebClientFactory {
     Log.debugf("Updated the Vert.x web client config to: %s", clientOptions);
   }
 
+  WebClientOptions getDefaultWebClientOptions() {
+    var clientOptions = new WebClientOptions();
+
+    if (OsUtil.getOperatingSystem() == OS.WINDOWS) {
+      var pemTrustOptions = new PemTrustOptions();
+      addCertsFromBuiltInTrustStore(pemTrustOptions);
+      addCertsFromSystemKeyStore("WINDOWS-MY", pemTrustOptions);
+      // We should not update the WebClient's PEM trust options if we haven't been able to read
+      // certs from the baked-in or system trust store.
+      if (!pemTrustOptions.getCertValues().isEmpty()) {
+        clientOptions.setPemTrustOptions(pemTrustOptions);
+      }
+    }
+
+    return clientOptions;
+  }
+
   private Vertx getVertx() {
     // Will be null when not injected via CDI.
     if (vertx == null) {
@@ -82,5 +120,90 @@ public class WebClientFactory {
     }
 
     return vertx;
+  }
+
+  /**
+   * Add all certificates from built-in trust store to a given {@link PemTrustOptions} object.
+   * @param pemTrustOptions The {@link PemTrustOptions} object to add the certificates to.
+   */
+  void addCertsFromBuiltInTrustStore(PemTrustOptions pemTrustOptions) {
+    try {
+      // Load certs from trust store baked into native executable so that we don't lose access to
+      // them
+      Log.info("Loading certificates from build-time trust store.");
+      var trustManagerFactory = TrustManagerFactory
+          .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init((KeyStore) null);
+      for (var trustManager : trustManagerFactory.getTrustManagers()) {
+        if (trustManager instanceof X509TrustManager x509TrustManager) {
+          for (var cert : x509TrustManager.getAcceptedIssuers()) {
+            pemTrustOptions.addCertValue(Buffer.buffer(certToString(cert)));
+          }
+        }
+      }
+    } catch (NoSuchAlgorithmException | KeyStoreException | CertificateEncodingException e) {
+      var stringWriter = new StringWriter();
+      e.printStackTrace(new PrintWriter(stringWriter));
+      Log.errorf(
+          "Error loading cert from built-in trust store: %s - %s %s",
+          e.getClass(),
+          e.getMessage(),
+          stringWriter
+      );
+    }
+  }
+
+  /**
+   * Add all certificates from a given key store to a given {@link PemTrustOptions} object.
+   *
+   * @param keyStoreType The key store type to read the certificates from.
+   * @param pemTrustOptions The {@link PemTrustOptions} object to add the certificates to.
+   */
+  void addCertsFromSystemKeyStore(String keyStoreType, PemTrustOptions pemTrustOptions) {
+    try {
+      // Load certs from provided trust store
+      Log.info("Loading certificates from system key store.");
+      var keyStore = KeyStore.getInstance(keyStoreType);
+      keyStore.load(null, null);
+      var it = keyStore.aliases().asIterator();
+      while (it.hasNext()) {
+        var certAlias = it.next();
+        var cert = keyStore.getCertificate(certAlias);
+        Log.infof(
+            "Adding certificate %s of type %s",
+            certAlias,
+            cert.getClass().getCanonicalName()
+        );
+        pemTrustOptions.addCertValue(Buffer.buffer(certToString(cert)));
+      }
+    } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+      var stringWriter = new StringWriter();
+      e.printStackTrace(new PrintWriter(stringWriter));
+      Log.errorf(
+          "Error loading cert from system key store: %s - %s %s",
+          e.getClass(),
+          e.getMessage(),
+          stringWriter
+      );
+    }
+  }
+
+  /**
+   * Convert a {@link Certificate} to the PEM format.
+   *
+   * @param cert The {@link Certificate}
+   * @return The certificate in the PEM format
+   * @throws CertificateEncodingException when failing to encode the {@link Certificate}
+   */
+  String certToString(Certificate cert) throws CertificateEncodingException {
+    var sw = new StringWriter();
+    sw.write(CERT_HEADER);
+    sw.write(
+        DatatypeConverter
+            .printBase64Binary(cert.getEncoded())
+            .replaceAll("(.{64})", "$1" + LINE_SEPARATOR)
+    );
+    sw.write(CERT_FOOTER);
+    return sw.toString();
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
@@ -36,6 +36,7 @@ public class WebClientFactory {
   static final String LINE_SEPARATOR = System.lineSeparator();
   static final String CERT_HEADER = "-----BEGIN CERTIFICATE-----" + LINE_SEPARATOR;
   static final String CERT_FOOTER = LINE_SEPARATOR + "-----END CERTIFICATE-----" + LINE_SEPARATOR;
+  static final String WINDOWS_TRUST_STORE_NAME = "WINDOWS-MY";
 
   /**
    * It's important that we use the Quarkus-managed Vertx instance here
@@ -101,7 +102,7 @@ public class WebClientFactory {
     if (OsUtil.getOperatingSystem() == OS.WINDOWS) {
       var pemTrustOptions = new PemTrustOptions();
       addCertsFromBuiltInTrustStore(pemTrustOptions);
-      addCertsFromSystemKeyStore("WINDOWS-MY", pemTrustOptions);
+      addCertsFromSystemKeyStore(WINDOWS_TRUST_STORE_NAME, pemTrustOptions);
       // We should not update the WebClient's PEM trust options if we haven't been able to read
       // certs from the baked-in or system trust store.
       if (!pemTrustOptions.getCertValues().isEmpty()) {

--- a/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
@@ -130,7 +130,7 @@ public class WebClientFactory {
     try {
       // Load certs from trust store baked into native executable so that we don't lose access to
       // them
-      Log.info("Loading certificates from build-time trust store.");
+      Log.debug("Loading certificates from build-time trust store.");
       var trustManagerFactory = TrustManagerFactory
           .getInstance(TrustManagerFactory.getDefaultAlgorithm());
       trustManagerFactory.init((KeyStore) null);
@@ -162,14 +162,14 @@ public class WebClientFactory {
   void addCertsFromSystemKeyStore(String keyStoreType, PemTrustOptions pemTrustOptions) {
     try {
       // Load certs from provided trust store
-      Log.info("Loading certificates from system key store.");
+      Log.debug("Loading certificates from system key store.");
       var keyStore = KeyStore.getInstance(keyStoreType);
       keyStore.load(null, null);
       var it = keyStore.aliases().asIterator();
       while (it.hasNext()) {
         var certAlias = it.next();
         var cert = keyStore.getCertificate(certAlias);
-        Log.infof(
+        Log.debugf(
             "Adding certificate %s of type %s",
             certAlias,
             cert.getClass().getCanonicalName()


### PR DESCRIPTION
## Summary of Changes

This PR adds support for loading certificates from the Windows trust store `WINDOWS-MY`.

Fixes #69 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

