### PR TITLE
chore: Bump absolute lifetime of refresh tokens to 28800 seconds (#39)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ ide-sidecar:
       check-token-expiration:
         interval-seconds: 5
       refresh-token:
-        absolute-lifetime-seconds: 14401
+        absolute-lifetime-seconds: 28800
         max-refresh-attempts: 50
       id-token:
         exchange-uri: https://login.confluent.io/oauth/token


### PR DESCRIPTION
## Summary of Changes

We've updated the absolute lifetime of the refresh tokens to 28800 seconds. Bump the corresponding config option so that the sidecar reports the updated value to the extension.

## Any additional details or context that should be provided?


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

