### PR TITLE
Use sidecar SR proxy for Local SR

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClients.java
@@ -1,7 +1,20 @@
 package io.confluent.idesidecar.restapi.cache;
 
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+
+import io.confluent.idesidecar.restapi.application.SidecarAccessTokenBean;
+import io.confluent.idesidecar.restapi.util.RequestHeadersConstants;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Create an ApplicationScoped bean to cache SchemaRegistryClient instances
@@ -9,5 +22,47 @@ import jakarta.enterprise.context.ApplicationScoped;
  */
 @ApplicationScoped
 public class SchemaRegistryClients extends Clients<SchemaRegistryClient> {
+  private static final int SR_CACHE_SIZE = 10;
 
+  @Inject
+  SidecarAccessTokenBean accessTokenBean;
+
+  @ConfigProperty(name = "ide-sidecar.api.host")
+  String sidecarHost;
+
+  /**
+   * Get a SchemaRegistryClient for the given connection ID and cluster ID. We rely on the
+   * sidecar's Schema Registry proxy routes to forward the request to the correct Schema Registry
+   * instance.
+   */
+  public SchemaRegistryClient getClient(String connectionId, String clusterId) {
+    return getClient(
+        connectionId,
+        clusterId,
+        () -> createClient(
+            sidecarHost,
+            Map.of(
+                RequestHeadersConstants.CONNECTION_ID_HEADER, connectionId,
+                RequestHeadersConstants.CLUSTER_ID_HEADER, clusterId,
+                AUTHORIZATION, "Bearer %s".formatted(accessTokenBean.getToken())
+            )
+        ));
+  }
+
+  private SchemaRegistryClient createClient(
+      String srClusterUri,
+      Map<String, String> headers
+  ) {
+    return new CachedSchemaRegistryClient(
+        Collections.singletonList(srClusterUri),
+        SR_CACHE_SIZE,
+        Arrays.asList(
+            new ProtobufSchemaProvider(),
+            new AvroSchemaProvider(),
+            new JsonSchemaProvider()
+        ),
+        Collections.emptyMap(),
+        headers
+    );
+  }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumer.java
@@ -28,14 +28,12 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * Implements consuming records from Confluent Local Kafka topics for the message viewer API.
  */
-// CHECKSTYLE:OFF: ClassDataAbstractionCoupling
 public class SimpleConsumer {
   private static final Duration POLL_TIMEOUT = Duration.ofSeconds(1);
   private static final int MAX_POLLS = 5;
   private static final int MAX_POLL_RECORDS_LIMIT = 2_000;
   private static final int MAX_RESPONSE_BYTES = 20 * 1024 * 1024; // 20 MB
   private static final int DEFAULT_MESSAGE_MAX_BYTES = 4 * 1024 * 1024; // 4MB
-  private static final int SR_CACHE_SIZE = 10;
   private final SchemaRegistryClient schemaRegistryClient;
 
   final Properties baseConsumerConfig;

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/SchemaRegistry.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/SchemaRegistry.java
@@ -1,10 +1,11 @@
 package io.confluent.idesidecar.restapi.models.graph;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.smallrye.common.constraint.NotNull;
 import io.smallrye.graphql.api.DefaultNonNull;
 
 @RegisterForReflection
 @DefaultNonNull
 public interface SchemaRegistry extends Cluster {
-  String uri();
+  @NotNull String uri();
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
@@ -9,6 +9,7 @@ import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ClusterStrategy;
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentCloudKafkaClusterStrategy;
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentCloudSchemaRegistryClusterStrategy;
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentLocalKafkaClusterStrategy;
+import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentLocalSchemaRegistryClusterStrategy;
 import io.vertx.core.Future;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +29,9 @@ public class ClusterStrategyProcessor extends
 
   @Inject
   ConfluentCloudSchemaRegistryClusterStrategy confluentCloudSchemaRegistryClusterStrategy;
+
+  @Inject
+  ConfluentLocalSchemaRegistryClusterStrategy confluentLocalSchemaRegistryClusterStrategy;
 
 
   @Override
@@ -52,7 +56,7 @@ public class ClusterStrategyProcessor extends
           ? confluentCloudKafkaClusterStrategy : confluentCloudSchemaRegistryClusterStrategy;
       case LOCAL ->
           clusterType == ClusterType.KAFKA
-              ? confluentLocalKafkaClusterStrategy : null;
+              ? confluentLocalKafkaClusterStrategy : confluentLocalSchemaRegistryClusterStrategy;
       case PLATFORM -> null;
     };
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentLocalSchemaRegistryClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentLocalSchemaRegistryClusterStrategy.java
@@ -1,0 +1,11 @@
+package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Strategy for processing requests and responses for a Confluent local Kafka cluster.
+ */
+@ApplicationScoped
+public class ConfluentLocalSchemaRegistryClusterStrategy extends ClusterStrategy {
+  // No specific configuration for this strategy
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ClusterRestProxyResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ClusterRestProxyResourceTest.java
@@ -351,11 +351,6 @@ class ClusterRestProxyResourceTest {
 
   private static Stream<Arguments> invalidClusterRequests() {
     return Stream.of(
-        // Local Schema Registry is not supported
-        Arguments.of(ConnectionType.LOCAL, ClusterType.SCHEMA_REGISTRY,
-            "/subjects/fake-subject/versions/fake-version/schema"),
-        Arguments.of(ConnectionType.LOCAL, ClusterType.SCHEMA_REGISTRY,
-            "/schemas/id/fake-schema-id/subjects"),
         // Platform anything is not supported
         Arguments.of(ConnectionType.PLATFORM, ClusterType.KAFKA,
             "/kafka/v3/clusters/%s/topics".formatted(CLUSTER_ID)),


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add `ConfluentLocalSchemaRegistryClusterStrategy` as the REST proxy strategy for handling schema registry requests in confluent local connections.
- Centralize and remove duplicated logic to create a cached instance of `CachedSchemaRegistryClient` into `SchemaRegistryClients.getClient(...)`. Use this in both `ConfluentCloudConsumeStrategy` and `ConfluentLocalConsumeStrategy`.
- Before: `ConfluentLocalConsumeStrategy` directly hits the schema registry URI instead of going through sidecar SR rest proxy. After: `ConfluentLocalConsumeStrategy` goes through SR rest proxy.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

