### PR TITLE
Update Quarkus to release 3.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <license.current.year>2024</license.current.year>
     <project.inceptionYear>2024</project.inceptionYear>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <vertx.version>4.5.7</vertx.version>
+    <vertx.version>4.5.10</vertx.version>
     <wiremock.version>1.3.2</wiremock.version>
     <netty.version>4.1.109.Final</netty.version>
     <commons-codec.version>1.17.0</commons-codec.version>
@@ -68,7 +68,7 @@
     <build-tools.dir>${project.basedir}/build-tools</build-tools.dir>
     <spotbugs.maven.plugin.version>4.8.5.0</spotbugs.maven.plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <quarkus.platform.version>3.13.3</quarkus.platform.version>
+    <quarkus.platform.version>3.15.1</quarkus.platform.version>
     <io.confluent.common.version>7.7.0</io.confluent.common.version>
     <avro.version>1.12.0</avro.version>
     <jackson-dataformat.version>2.17.1</jackson-dataformat.version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,11 +152,10 @@ quarkus:
       includes: templates/callback.html,templates/callback_failure.html,static/templates.zip
   smallrye-health:
     root-path: /gateway/v1/health
-  ssl:
-    native: true
-  health:
     openapi:
       included: true
+  ssl:
+    native: true
   smallrye-openapi:
     path: /openapi
     info-title: Confluent ide-sidecar API


### PR DESCRIPTION
## Summary of Changes

This PR updates the Quarkus dependency to the [LTS release 3.15](https://quarkus.io/blog/quarkus-3-15-1-released/).

As part of the Quarkus update, it also:
* updates the Vert.x dependency to the release `4.5.10`, which is used by Quarkus 3.15.1.
* renames the configuration option `quarkus.health.openapi.included`, which has been deprecated, to `quarkus.smallrye-health.openapi.included` (see [Quarkus migration guide](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.14#smallrye-health))

Fixes #54

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

