### PR TITLE
Introduce new authentication status `FAILED` to CCloud connections

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -609,6 +609,9 @@
           },
           "message" : {
             "type" : "string"
+          },
+          "is_transient" : {
+            "type" : "boolean"
           }
         }
       },
@@ -1143,7 +1146,7 @@
         }
       },
       "Status" : {
-        "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN" ],
+        "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN", "FAILED" ],
         "type" : "string"
       },
       "Template" : {

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -414,6 +414,8 @@ components:
           $ref: "#/components/schemas/Instant"
         message:
           type: string
+        is_transient:
+          type: boolean
     AuthErrors:
       type: object
       properties:
@@ -805,6 +807,7 @@ components:
       - NO_TOKEN
       - VALID_TOKEN
       - INVALID_TOKEN
+      - FAILED
       type: string
     Template:
       required:

--- a/src/main/java/io/confluent/idesidecar/restapi/auth/AuthErrors.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/AuthErrors.java
@@ -42,7 +42,7 @@ public record AuthErrors(
 
   public AuthErrors withAuthStatusCheck(String message) {
     return new AuthErrors(
-        // Always consider errors that occurred when signing in as transient
+        // Always consider errors that occurred when checking the auth status as transient
         new AuthError(Instant.now(), message, true),
         signIn,
         tokenRefresh

--- a/src/main/java/io/confluent/idesidecar/restapi/auth/RefreshCCloudTokensBean.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/RefreshCCloudTokensBean.java
@@ -50,14 +50,6 @@ public class RefreshCCloudTokensBean {
         .filter(connection -> connection.getOauthContext().shouldAttemptTokenRefresh())
         // Attempt token refresh
         .forEach(this::refreshAuthContext);
-
-    // Reset auth contexts with too many failed token refresh attempts
-    connectionsWithAuthContexts.get()
-        .map(CCloudConnectionState::getOauthContext)
-        .filter(authContext ->
-            authContext.getFailedTokenRefreshAttempts() >= MAX_TOKEN_REFRESH_ATTEMPTS
-        )
-        .forEach(CCloudOAuthContext::reset);
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -43,6 +43,8 @@ public class CCloudConnectionState extends ConnectionState {
    * must re-authenticate with CCloud.</li>
    * <li>{@link Status#INVALID_TOKEN}, if the connection holds all tokens but cannot perform API
    * requests against the CCloud API.</li>
+   * <li>{@link Status#FAILED}, if the connection experienced a non-transient error from which it
+   * cannot recover.</li>
    * </ul>
    *
    * @return status of connection

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -63,11 +63,22 @@ public class CCloudConnectionState extends ConnectionState {
     if (!missingTokens.isEmpty()) {
       Log.infof(
           "Authentication flow for connection with ID=%s seems to be not completed because "
-          + "it does not hold the following tokens: %s.",
+              + "it does not hold the following tokens: %s.",
           getId(),
           String.join(", ", missingTokens));
 
       return getInitialStatusWithErrors(getAuthErrors(oauthContext));
+    } else if (oauthContext.hasNonTransientError()) {
+      return Future.succeededFuture(
+          new ConnectionStatus(
+              new Authentication(
+                  Status.FAILED,
+                  null,
+                  null,
+                  getAuthErrors(oauthContext)
+              )
+          )
+      );
     } else {
       return oauthContext
           .checkAuthenticationStatus()

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
@@ -40,16 +40,19 @@ public record ConnectionStatus(@JsonProperty(required = true) Authentication aut
   ) {
 
     /**
-     * A connection can be in one of three states: Initially, a connection does not hold any tokens
+     * A connection can be in one of four states: Initially, a connection does not hold any tokens
      * and is in the state NO_TOKEN. If the connection holds tokens, these tokens can be valid or
      * invalid. Depending on the health of the tokens, the connection is in the state VALID_TOKEN or
-     * INVALID_TOKEN. If tokens are invalid, consumers of our API are advised to trigger a new
-     * authentication flow.
+     * INVALID_TOKEN. The connection will regularly refresh tokens before they expire to keep them
+     * valid. If the connection experienced a non-transient error, it will enter the state
+     * FAILED from which it can't recover automatically. Consumers of the API are advised to trigger
+     * a new authentication flow to recover from the FAILED state.
      */
     public enum Status {
       NO_TOKEN,
       VALID_TOKEN,
-      INVALID_TOKEN
+      INVALID_TOKEN,
+      FAILED
     }
   }
 

--- a/src/test/java/io/confluent/idesidecar/restapi/auth/AuthErrorsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/auth/AuthErrorsTest.java
@@ -18,9 +18,15 @@ public class AuthErrorsTest {
   }
 
   @Test
+  void hasNonTransientErrorsShouldReturnFalseIfAllErrorsAreNull() {
+    var authErrorsWithoutErrors = new AuthErrors(null, null, null);
+    assertFalse(authErrorsWithoutErrors.hasNonTransientErrors());
+  }
+
+  @Test
   void hasErrorsShouldReturnTrueIfAuthStatusCheckIsNotNull() {
     var authErrorsWithAuthStatusCheck = new AuthErrors(
-        new AuthError(Instant.now(), "error"),
+        new AuthError(Instant.now(), "error", true),
         null,
         null);
     assertTrue(authErrorsWithAuthStatusCheck.hasErrors());
@@ -30,7 +36,7 @@ public class AuthErrorsTest {
   void hasErrorsShouldReturnTrueIfSignInIsNotNull() {
     var authErrorsWithSignIn = new AuthErrors(
         null,
-        new AuthError(Instant.now(), "error"),
+        new AuthError(Instant.now(), "error", false),
         null);
     assertTrue(authErrorsWithSignIn.hasErrors());
   }
@@ -40,7 +46,7 @@ public class AuthErrorsTest {
     var authErrorsWithTokenRefresh = new AuthErrors(
         null,
         null,
-        new AuthError(Instant.now(), "error"));
+        new AuthError(Instant.now(), "error", false));
     assertTrue(authErrorsWithTokenRefresh.hasErrors());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContextTest.java
@@ -338,7 +338,7 @@ class CCloudOAuthContextTest {
   }
 
   @Test
-  void shouldAttemptTokenRefreshShouldReturnFalseIfTooManyTokenRefreshAttempts() {
+  void shouldAttemptTokenRefreshShouldReturnFalseIfNonTransientErrorHasBeenExperienced() {
     var authContext = Mockito.spy(CCloudOAuthContext.class);
 
     // tokens have not yet expired
@@ -347,9 +347,8 @@ class CCloudOAuthContextTest {
     Mockito.when(authContext.getEndOfLifetime())
         .thenReturn(Instant.now().plusSeconds(5));
 
-    // has experienced too many token refresh attempts
-    Mockito.when(authContext.getFailedTokenRefreshAttempts())
-            .thenReturn(50);
+    // connection has experienced non transient error
+    Mockito.when(authContext.hasNonTransientError()).thenReturn(true);
 
     assertFalse(authContext.shouldAttemptTokenRefresh());
   }


### PR DESCRIPTION
## Summary of Changes

This change introduces the property `isTransient` to the `AuthErrors`, which can be used to model if an auth-related error is transient or not. It also introduces a new `ConnectionStatus.Status`, `FAILED`, which is returned if a CCloud connection holds at least one error that is marked as non-transient (`isTransient=false`). We assume that CCloud connections cannot recover from non-transient errors and advise the extension to trigger a new authentication flow if the connection reports the state `FAILED`. The sidecar does not attempt to refresh tokens of a CCloud connection that holds a non-transient error.

We determine if an error is transient as follows:
* Any error related to the `authStatusCheck` is considered to be transient
* Any error related to the `signIn` is considered to be non-transient
* Errors related to the `tokenRefresh` are considered to be non-transient if more than `CCloudOAuthConfig.MAX_TOKEN_REFRESH_ATTEMPTS` token refresh attempts have failed in a row or if the CCloud API has reported that the refresh token is invalid or expired; otherwise, errors related to the `tokenRefresh` are considered to be transient

After merging this change into `main`, CCloud connections will have four authentication states:

| Authentication state | Description |
| -------------------- | ------------ |
| `NO_TOKEN` | Initial state returned when the CCloud connection does not hold all three tokens (refresh token, control plane token, data plane token). |
| `VALID_TOKEN` | Returned if the CCloud connections holds all three tokens (refresh token, control plane token, data plane token) and can perform requests against the CCloud API. |
| `INVALID_TOKEN` | Returned if the CCloud connections holds all three tokens (refresh token, control plane token, data plane token) and cannot perform requests against the CCloud API. |
| `FAILED` | Returned if the CCloud connection experienced a non-transient error from which it cannot recover. |

Example authentication status of a connection for which the CCloud API has reported that the refresh token is invalid or expired:

```shell
$ curl http://localhost:26636/gateway/v1/connections/1

{
  "api_version": "gateway/v1",
  "kind": "Connection",
  "id": "1",
  "metadata": {
    "self": "http://localhost:26636/gateway/v1/connections/1",
    "resource_name": null,
    "sign_in_uri": "https://login.confluent.io/oauth/authorize?..."
  },
  "spec": {
    "id": "1",
    "name": "1",
    "type": "CCLOUD"
  },
  "status": {
    "authentication": {
      "status": "FAILED",
      "errors": {
        "token_refresh": {
          "message": "Retrieving the ID token failed for the following reason: invalid_grant - Unknown or invalid refresh token.",
          "created_at": "2024-10-17T13:42:46.469860Z",
          "is_transient": false
        }
      }
    }
  }
}
```

This PR fixes #86 but slightly updated its proposal because it implemented the new authentication state in a more generic way. This implementation allows any kind of error (`signIn`, `authStatusCheck`, or `tokenRefresh`) to be marked as non-transient. Consequently, it calls the introduced state `FAILED` not `TOKEN_REFRESH_FAILED`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [x] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

