### PR TITLE
Proxy HTTP request headers from VS Code

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
@@ -25,11 +25,8 @@ public abstract class ClusterStrategy {
 
   public MultiMap constructProxyHeaders(ClusterProxyContext context) {
     var headers = HttpHeaders.headers();
-    context.getRequestHeaders().forEach(header -> {
-      if (!httpHeaderExclusions.contains(header.getKey())) {
-        headers.add(header.getKey(), header.getValue());
-      }
-    });
+    headers.addAll(context.getRequestHeaders());
+    httpHeaderExclusions.forEach(headers::remove);
     return headers;
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
@@ -4,6 +4,9 @@ import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
 import io.confluent.idesidecar.restapi.util.UriUtil;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -18,8 +21,17 @@ public abstract class ClusterStrategy {
 
   static UriUtil uriUtil = new UriUtil();
 
+  @ConfigProperty(name = "ide-sidecar.cluster-proxy.http-header-exclusions")
+  List<String> httpHeaderExclusions;
+
   public MultiMap constructProxyHeaders(ClusterProxyContext context) {
-    return HttpHeaders.headers();
+    var headers = HttpHeaders.headers();
+    context.getRequestHeaders().forEach(header -> {
+      if (!httpHeaderExclusions.contains(header.getKey())) {
+        headers.add(header.getKey(), header.getValue());
+      }
+    });
+    return headers;
   }
 
   public String constructProxyUri(String requestUri, String clusterUri) {

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ClusterStrategy.java
@@ -4,10 +4,9 @@ import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
 import io.confluent.idesidecar.restapi.util.UriUtil;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import java.util.List;
 import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Holds default implementations for processing constructing the proxy URI, headers before

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentCloudKafkaClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentCloudKafkaClusterStrategy.java
@@ -3,7 +3,6 @@ package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
 import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
 import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpHeaders;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
@@ -15,7 +14,7 @@ public class ConfluentCloudKafkaClusterStrategy extends ClusterStrategy {
 
   @Override
   public MultiMap constructProxyHeaders(ClusterProxyContext context) {
-    var headers = HttpHeaders.headers();
+    var headers = super.constructProxyHeaders(context);
     if (context.getConnectionState() instanceof CCloudConnectionState cCloudConnectionState) {
       cCloudConnectionState.getOauthContext()
           .getDataPlaneAuthenticationHeaders()

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentCloudSchemaRegistryClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentCloudSchemaRegistryClusterStrategy.java
@@ -3,7 +3,6 @@ package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
 import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
 import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
 import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpHeaders;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
@@ -16,7 +15,7 @@ public class ConfluentCloudSchemaRegistryClusterStrategy extends ClusterStrategy
 
   @Override
   public MultiMap constructProxyHeaders(ClusterProxyContext context) {
-    var headers = HttpHeaders.headers();
+    var headers = super.constructProxyHeaders(context);
     if (context.getConnectionState() instanceof CCloudConnectionState cCloudConnectionState) {
       cCloudConnectionState.getOauthContext()
           .getDataPlaneAuthenticationHeaders()

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentLocalKafkaClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/ConfluentLocalKafkaClusterStrategy.java
@@ -31,8 +31,8 @@ public class ConfluentLocalKafkaClusterStrategy extends ClusterStrategy {
    */
   @Override
   public MultiMap constructProxyHeaders(ClusterProxyContext context) {
-    return HttpHeaders
-        .headers()
+    var headers = super.constructProxyHeaders(context);
+    return headers
         .add(CONNECTION_ID_HEADER, context.getConnectionId())
         .add(HttpHeaders.AUTHORIZATION, "Bearer %s".formatted(accessToken.getToken()));
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,6 +144,12 @@ ide-sidecar:
     http-header-exclusions:
       - x-connection-id
       - x-cluster-id
+      - Authorization
+      - Host
+      - Connection
+      # This may contradict UTF-8 decoding done in the proxy response processing
+      # https://github.com/confluentinc/ide-sidecar/issues/102
+      - Accept-Encoding
 
 quarkus:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,6 +138,12 @@ ide-sidecar:
     "auto.register.schemas": "false"
     # Do not try to fetch the latest version of the schema from the registry
     "use.latest.version": "false"
+  cluster-proxy:
+    # Exclude these HTTP headers when proxying requests to the remote cluster (Kafka or Schema Registry)
+    # It shouldn't really hurt if we _don't_ exclude these headers, but it's just cleaner to do so.
+    http-header-exclusions:
+      - x-connection-id
+      - x-cluster-id
 
 quarkus:
   application:

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
@@ -77,6 +77,7 @@ class RecordsV3ApiImplIT extends ConfluentLocalTestBed {
     @Test
     void shouldThrowNotFoundWhenClusterDoesNotExist() {
       givenConnectionId()
+          .header("Content-Type", "application/json")
           .body(createProduceRequest(
               null, "key", null, "value", null
           ))


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Include all headers passed from VS Code when proxying requests to a target Kafka/SR cluster, except for sidecar-specific headers (specified as config in `application.yml`).

Resolves #92 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

