### PR TITLE
[v0.49.x] Fix: Add @Blocking annotation to ConnectionsResource

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -120,12 +120,6 @@ public class CCloudOAuthContext implements AuthContext {
         return Future.failedFuture(new CCloudAuthenticationFailedException(errorMessage));
       }
 
-      try {
-        Thread.sleep(5000);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-
       return webClientFactory.getWebClient()
           .getAbs(CCloudOAuthConfig.CCLOUD_CONTROL_PLANE_CHECK_JWT_URI)
           .putHeaders(getControlPlaneAuthenticationHeaders())

--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import java.nio.charset.StandardCharsets;
@@ -89,8 +90,15 @@ public class CCloudOAuthContext implements AuthContext {
 
   /**
    * Performs an API call against CCloud's <code>/api/check_jwt</code> endpoint to see if the
-   * control plane token is valid.
-   *
+   * control plane token is valid. Note that this method may block the calling thread on the
+   * following conditions:
+   * <ul>
+   *   <li>When another task holds the write lock</li>
+   *   <li>When the host machine is unable to resolve the CCloud server's hostname
+   *       due to DNS issues. The {@link HttpRequest#send()} method synchronously tries to
+   *       resolve the hostname before sending the request.
+   *   </li>
+   * </ul>
    * @return Succeeded future holding the boolean value true if the token is valid. Succeeded future
    *         holding the boolean value false if the token is not valid. Failed future holding the
    *         cause of the failure if any error occurred while interacting with the CCloud API, e.g.,
@@ -112,9 +120,17 @@ public class CCloudOAuthContext implements AuthContext {
         return Future.failedFuture(new CCloudAuthenticationFailedException(errorMessage));
       }
 
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+
       return webClientFactory.getWebClient()
           .getAbs(CCloudOAuthConfig.CCLOUD_CONTROL_PLANE_CHECK_JWT_URI)
           .putHeaders(getControlPlaneAuthenticationHeaders())
+          // Synchronously tries to DNS resolve the hostname before sending the request
+          // Calling threads beware!
           .send()
           .map(result -> {
             try {

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.resources;
 
+import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniItem;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 
 import io.confluent.idesidecar.restapi.connections.ConnectionState;
@@ -59,16 +60,19 @@ public class ConnectionsResource {
               .stream()
               .map(connection -> uniStage(() -> getConnectionModel(connection.getSpec().id())))
               .collect(Collectors.toList());
-
+          if (connectionFutures.isEmpty()) {
+            return uniItem(ConnectionsList.from(List.of()));
+          }
           return Uni
               .combine()
               .all()
               .unis(connectionFutures)
               .with(connections -> {
-                List<Connection> connectionList = connections.stream()
+                var connectionList = connections
+                    .stream()
                     .map(connection -> (Connection) connection)
                     .collect(Collectors.toList());
-                return new ConnectionsList(connectionList);
+                return ConnectionsList.from(connectionList);
               });
         });
   }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The VS Code extension issues get connection requests for every connection at a period of 10 seconds. These requests may block due to lock contention or DNS issues and hence we should run them on the Quarkus worker thread pool instead of the event loop threads so other requests made to the sidecar are not affected.

## Background/Context

A user reported that they were unable to view topics in a message. From their logs, we gleaned that their host machine was not able to resolve DNS for the CCloud server (reason still unknown) when trying to check authentication status. This request then blocked one of the event loop threads, while holding the write lock. VS Code then issues get connection requests for the CCloud connection, which blocks other event loop threads, and eventually, all event loop threads get blocked with the sidecar becomeing completely unresponsive (very sad). Once the 5 minute timeout (unsure where in the Java stack this is set) is hit, the originally blocked thread releases the lock, allowing _all_ other threads to resume.

Follow up to the DNS issue: We need to reduce client timeout to something like 10 seconds when issuing HTTP request to check authentication status. See #106
