### PR TITLE
Retry get topic after creating topic

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
@@ -64,7 +64,7 @@ public class TopicManagerImpl implements TopicManager {
             .retry()
             .atMost(3)
         );
-    }
+  }
 
   @Override
   public Uni<Void> deleteKafkaTopic(String clusterId, String topicName) {

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
@@ -9,6 +9,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -62,6 +64,9 @@ public class TopicManagerImpl implements TopicManager {
             // subsequently be created."
             .onFailure(UnknownTopicOrPartitionException.class)
             .retry()
+            // Exponential backoff with a max of 3 retries
+            // Initial delay of 150ms, max delay of 1s
+            .withBackOff(Duration.ofMillis(150), Duration.ofMillis(1000))
             .atMost(3)
         );
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
@@ -9,7 +9,6 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Resolves #114 

This first manifested as flakiness in our integration tests. We need to retry the get topic operation after creating a topic.