### PR TITLE
Fix the Connection API and Template API resource types to support deserializing

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -123,7 +123,7 @@ public class CCloudConnectionState extends ConnectionState {
    */
   @Override
   public ConnectionMetadata getConnectionMetadata() {
-    return new ConnectionMetadata(
+    return ConnectionMetadata.from(
         oauthContext.getSignInUri(),
         ConnectionsResource.API_RESOURCE_PATH,
         spec.id());

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -67,7 +67,7 @@ public abstract class ConnectionState {
   }
 
   public ConnectionMetadata getConnectionMetadata() {
-    return new ConnectionMetadata(
+    return ConnectionMetadata.from(
         null,
         ConnectionsResource.API_RESOURCE_PATH,
         spec.id());

--- a/src/main/java/io/confluent/idesidecar/restapi/models/BaseList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/BaseList.java
@@ -1,28 +1,40 @@
 package io.confluent.idesidecar.restapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
 import org.eclipse.microprofile.config.ConfigProvider;
 
-@JsonPropertyOrder({
-    "api_version",
-    "kind",
-    "metadata",
-    "data"
-})
 public abstract class BaseList<T> {
 
-  @JsonProperty(value = "api_version", required = true)
-  protected String apiVersion = ConfigProvider.getConfig()
+  protected static final String API_VERSION = ConfigProvider
+      .getConfig()
       .getValue("ide-sidecar.api.groupWithVersion", String.class);
 
-  @JsonProperty(required = true)
-  protected String kind = this.getClass().getSimpleName();
+  protected final CollectionMetadata metadata;
+  protected final List<T> data;
 
-  @JsonProperty(required = true)
-  protected CollectionMetadata metadata;
+  protected BaseList(List<T> data, CollectionMetadata metadata) {
+    this.data = List.copyOf(data); // defensive copy
+    this.metadata = metadata;
+  }
 
-  @JsonProperty(required = true)
-  protected List<T> data;
+  @JsonProperty(value = "api_version", required = true)
+  public String apiVersion() {
+    return API_VERSION;
+  }
+
+  @JsonProperty(value = "kind", required = true)
+  public String kind() {
+    return this.getClass().getSimpleName();
+  }
+
+  @JsonProperty(value = "metadata", required = true)
+  public CollectionMetadata metadata() {
+    return metadata;
+  }
+
+  @JsonProperty(value = "data", required = true)
+  public List<T> data() {
+    return data;
+  }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/BaseModel.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/BaseModel.java
@@ -1,35 +1,50 @@
 package io.confluent.idesidecar.restapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.eclipse.microprofile.config.ConfigProvider;
 
-@JsonPropertyOrder({
-    "api_version",
-    "kind",
-    "id",
-    "metadata",
-    "spec"
-})
-public abstract class BaseModel<SpecT> {
+public abstract class BaseModel<SpecT, MetadataT extends ObjectMetadata> {
 
-  @JsonProperty(value = "api_version", required = true)
-  protected String apiVersion = ConfigProvider.getConfig()
+  protected static final String API_VERSION = ConfigProvider
+      .getConfig()
       .getValue("ide-sidecar.api.groupWithVersion", String.class);
 
-  @JsonProperty(required = true)
-  protected String kind = this.getClass().getSimpleName();
+  protected final String id;
+  protected final MetadataT metadata;
+  protected final SpecT spec;
 
-  @JsonProperty(required = true)
-  protected String id;
+  protected BaseModel(
+      String id,
+      MetadataT metadata,
+      SpecT spec
+  ) {
+    this.id = id;
+    this.metadata = metadata;
+    this.spec = spec;
+  }
 
-  @JsonProperty(required = true)
-  protected ObjectMetadata metadata;
+  @JsonProperty(value = "api_version", required = true)
+  public String apiVersion() {
+    return API_VERSION;
+  }
 
-  @JsonProperty(required = true)
-  protected SpecT spec;
+  @JsonProperty(value = "kind", required = true)
+  public String kind() {
+    return this.getClass().getSimpleName();
+  }
 
-  public String getId() {
+  @JsonProperty(value = "id", required = true)
+  public String id() {
     return this.id;
+  }
+
+  @JsonProperty(value = "spec", required = true)
+  public SpecT spec() {
+    return this.spec;
+  }
+
+  @JsonProperty(value = "metadata", required = true)
+  public MetadataT metadata() {
+    return this.metadata;
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/CollectionMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/CollectionMetadata.java
@@ -1,31 +1,39 @@
 package io.confluent.idesidecar.restapi.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import org.eclipse.microprofile.config.ConfigProvider;
+import jakarta.validation.constraints.Null;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({
     "self",
     "next",
     "total_size"
 })
 public record CollectionMetadata(
+    @JsonProperty(value = "self")
+    @Null
+    String self,
+
+    @JsonProperty(value = "next")
+    @Null
+    String next,
+
     @JsonProperty(value = "total_size")
-    int totalSize,
-    @JsonIgnore
-    String resourcePath
+    int totalSize
 ) {
 
-  @JsonProperty
-  public String self() {
-    var apiHost = ConfigProvider.getConfig().getValue("ide-sidecar.api.host", String.class);
-
-    return String.format("%s%s", apiHost, resourcePath);
+  protected static String selfFromResourcePath(String resourcePath) {
+    return resourcePath == null ? null : String.format("%s%s", ObjectMetadata.API_HOST, resourcePath);
   }
 
-  @JsonProperty
-  public String next() {
-    return null;
+  public static CollectionMetadata from(int totalSize, String resourcePath) {
+    var self = selfFromResourcePath(resourcePath);
+    return new CollectionMetadata(self, null, totalSize);
+  }
+
+  public CollectionMetadata withTotalSize(int totalSize) {
+    return new CollectionMetadata(self, next, totalSize);
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -20,7 +20,8 @@ import java.util.Objects;
 public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
 
   /**
-   * Create a connection from the given connection state and resource path.
+   * Create a connection from the given connection state. The metadata and spec are obtained
+   * from the connection state, and the status is set to {@link ConnectionStatus#INITIAL_STATUS}.
    *
    * @param connectionState the state of the connection
    * @return the connection
@@ -28,6 +29,7 @@ public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
   public static Connection from(
       ConnectionState connectionState
   ) {
+    // By default, a connection does not hold any tokens
     return from(connectionState, ConnectionStatus.INITIAL_STATUS);
   }
 
@@ -43,11 +45,7 @@ public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
       ConnectionStatus status
   ) {
     return new Connection(
-        ConnectionMetadata.from(
-            null,
-            ConnectionsResource.API_RESOURCE_PATH,
-            connectionState.getSpec().id()
-        ),
+        connectionState.getConnectionMetadata(),
         connectionState.getSpec(),
         status
     );

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -1,29 +1,97 @@
 package io.confluent.idesidecar.restapi.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.connections.ConnectionState;
+import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
+import java.util.Objects;
 
-public class Connection extends BaseModel<ConnectionSpec> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+    "api_version",
+    "kind",
+    "id",
+    "metadata",
+    "spec",
+    "status"
+})
+public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
 
-  @JsonProperty(required = true)
-  protected ConnectionStatus status;
+  /**
+   * Create a connection from the given connection state and resource path.
+   *
+   * @param connectionState the state of the connection
+   * @return the connection
+   */
+  public static Connection from(
+      ConnectionState connectionState
+  ) {
+    return from(connectionState, ConnectionStatus.INITIAL_STATUS);
+  }
 
-  @JsonProperty(required = true)
-  protected ConnectionMetadata metadata;
+  /**
+   * Create a connection from the given connection state, resource path and status.
+   *
+   * @param connectionState the state of the connection
+   * @param status          the status of the connection
+   * @return the connection
+   */
+  public static Connection from(
+      ConnectionState connectionState,
+      ConnectionStatus status
+  ) {
+    return new Connection(
+        ConnectionMetadata.from(
+            null,
+            ConnectionsResource.API_RESOURCE_PATH,
+            connectionState.getSpec().id()
+        ),
+        connectionState.getSpec(),
+        status
+    );
+  }
 
-  public Connection(ConnectionState connectionState, ConnectionStatus status) {
-    spec = connectionState.getSpec();
-    id = spec.id();
-    metadata = connectionState.getConnectionMetadata();
+  protected final ConnectionStatus status;
+
+  @JsonCreator
+  public Connection(
+      @JsonProperty(value = "metadata") ConnectionMetadata metadata,
+      @JsonProperty(value = "spec", required = true) ConnectionSpec spec,
+      @JsonProperty(value = "status") ConnectionStatus status
+  ) {
+    super(spec.id(), metadata, spec);
     this.status = status;
   }
 
-  public static Connection from(ConnectionState connectionState) {
-    // By default, a connection does not hold any tokens
-    return new Connection(connectionState, ConnectionStatus.INITIAL_STATUS);
+  @JsonProperty(value = "status", required = true)
+  public ConnectionStatus status() {
+    return status;
   }
 
-  public static Connection from(ConnectionState connectionState, ConnectionStatus status) {
-    return new Connection(connectionState, status);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Connection that = (Connection) o;
+    return Objects.equals(metadata, that.metadata)
+        && Objects.equals(spec, that.spec)
+        && Objects.equals(status, that.status);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(spec, status, metadata);
+  }
+
+  @Override
+  public String toString() {
+    return "Connection{" + "id='" + id + '\'' + ", metadata=" + metadata
+           + ", spec=" + spec + ", status=" + status + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionMetadata.java
@@ -1,10 +1,14 @@
 package io.confluent.idesidecar.restapi.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({
     "self",
     "resource_name",
@@ -12,12 +16,58 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 public class ConnectionMetadata extends ObjectMetadata {
 
-  @JsonInclude(Include.NON_NULL)
-  @JsonProperty(value = "sign_in_uri")
+  public static ConnectionMetadata from(
+      String signInUri,
+      String resourcePath,
+      String id
+  ) {
+    return new ConnectionMetadata(
+        selfFromResourcePath(resourcePath, id),
+        null,
+        signInUri
+    );
+  }
+
   protected final String signInUri;
 
-  public ConnectionMetadata(String signInUri, String resourcePath, String resourceId) {
-    super(resourcePath, resourceId);
+  @JsonCreator
+  public ConnectionMetadata(
+      @JsonProperty(value = "self") String self,
+      @JsonProperty(value = "resource_name") String resourceName,
+      @JsonProperty(value = "sign_in_uri") String signInUri
+  ) {
+    super(self, resourceName);
     this.signInUri = signInUri;
+  }
+
+  @JsonInclude(Include.NON_NULL)
+  @JsonProperty(value = "sign_in_uri")
+  public String signInUri() {
+    return signInUri;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConnectionMetadata that = (ConnectionMetadata) o;
+    return Objects.equals(resourceName, that.resourceName)
+           && Objects.equals(self, that.self)
+           && Objects.equals(signInUri, that.signInUri);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceName, self, signInUri);
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectionMetadata{" + "resourceName='" + resourceName + ", self=" + self
+           + ", signInUri=" + signInUri + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -5,6 +5,7 @@ import static io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionTy
 import static io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType.LOCAL;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
@@ -21,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "The connection details that can be set or changed.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ConnectionSpec(
     @Schema(description = "The unique identifier of the connection resource.")
     @Size(min = 1, max = 64)

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,6 +11,7 @@ import java.time.Instant;
 /**
  * Represents the status of a connection.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ConnectionStatus(@JsonProperty(required = true) Authentication authentication) {
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionsList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionsList.java
@@ -1,14 +1,79 @@
 package io.confluent.idesidecar.restapi.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
 import java.util.List;
+import java.util.Objects;
 
-public class ConnectionsList extends
-    BaseList<Connection> {
-  public ConnectionsList(List<Connection> connections) {
-    this.data = connections;
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+    "api_version",
+    "kind",
+    "metadata",
+    "data"
+})
+public class ConnectionsList extends BaseList<Connection> {
+
+  public ConnectionsList() {
+    this(List.of(), null);
   }
 
-  public static ConnectionsList from(List<Connection> connections) {
-    return new ConnectionsList(connections);
+  public ConnectionsList(
+      List<Connection> connections
+  ) {
+    this(connections, null);
+  }
+
+  public ConnectionsList(
+      List<Connection> connections,
+      CollectionMetadata metadata
+  ) {
+    super(
+        connections,
+        metadata != null ? metadata : CollectionMetadata.from(
+            connections.size(),
+            ConnectionsResource.API_RESOURCE_PATH
+        )
+    );
+  }
+
+  @JsonCreator
+  public ConnectionsList(
+      @JsonProperty(value = "data", required = true) Connection[] data,
+      @JsonProperty(value = "metadata", required = true) CollectionMetadata metadata
+  ) {
+    this(
+        List.of(data),
+        metadata != null ? metadata.withTotalSize(data.length) : CollectionMetadata.from(
+            data.length,
+            ConnectionsResource.API_RESOURCE_PATH
+        )
+    );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ConnectionsList that = (ConnectionsList) o;
+    return Objects.equals(metadata, that.metadata)
+           && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, metadata);
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectionList{" + "metadata=" + metadata + ", data=" + data + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ObjectMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ObjectMetadata.java
@@ -1,36 +1,71 @@
 package io.confluent.idesidecar.restapi.models;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Objects;
 import org.eclipse.microprofile.config.ConfigProvider;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({
     "self",
     "resource_name"
 })
 public class ObjectMetadata {
 
-  @JsonIgnore
-  protected final String resourcePath;
+  static final String API_HOST = ConfigProvider
+      .getConfig()
+      .getValue("ide-sidecar.api.host", String.class);
 
-  @JsonIgnore
-  protected final String resourceId;
-
-  public ObjectMetadata(String resourcePath, String resourceId) {
-    this.resourcePath = resourcePath;
-    this.resourceId = resourceId;
+  protected static String selfFromResourcePath(String resourcePath, String id) {
+    return resourcePath == null ? null : String.format("%s%s/%s", API_HOST, resourcePath, id);
   }
 
-  @JsonProperty
-  public String self() {
-    var apiHost = ConfigProvider.getConfig().getValue("ide-sidecar.api.host", String.class);
+  protected final String resourceName;
+  protected final String self;
 
-    return String.format("%s%s/%s", apiHost, resourcePath, resourceId);
+  @JsonCreator
+  public ObjectMetadata(
+      @JsonProperty(value = "self") String self,
+      @JsonProperty(value = "resource_name") String resourceName
+  ) {
+    this.resourceName = resourceName;
+    this.self = self;
   }
 
   @JsonProperty(value = "resource_name")
   public String resourceName() {
-    return null;
+    return resourceName;
+  }
+
+  @JsonProperty(value = "self")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public String self() {
+    return self;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectMetadata that = (ObjectMetadata) o;
+    return Objects.equals(resourceName, that.resourceName)
+           && Objects.equals(self, that.self);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceName, self);
+  }
+
+  @Override
+  public String toString() {
+    return "ObjectMetadata{" + "resourceName='" + resourceName + ", self=" + self + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Template.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Template.java
@@ -1,18 +1,63 @@
 package io.confluent.idesidecar.restapi.models;
 
+import static io.confluent.idesidecar.restapi.models.ObjectMetadata.selfFromResourcePath;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.resources.TemplateResource;
 import io.confluent.idesidecar.scaffolding.models.TemplateManifest;
+import java.util.Objects;
 
-public class Template extends BaseModel<TemplateManifest> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+    "api_version",
+    "kind",
+    "id",
+    "metadata"
+})
+public class Template extends BaseModel<TemplateManifest, ObjectMetadata> {
 
-  private Template() {
+  @JsonCreator
+  public Template(
+      @JsonProperty(value = "spec", required = true) TemplateManifest templateManifest,
+      @JsonProperty(value = "metadata", required = true) ObjectMetadata metadata
+  ) {
+    super(templateManifest.name(), metadata, templateManifest);
   }
 
   public Template(TemplateManifest templateManifest) {
-    this.id = templateManifest.name();
-    this.spec = templateManifest;
-    this.metadata = new ObjectMetadata(
-        TemplateResource.API_RESOURCE_PATH,
-        templateManifest.name());
+    this(
+        templateManifest,
+        new ObjectMetadata(
+            selfFromResourcePath(TemplateResource.API_RESOURCE_PATH, templateManifest.name()),
+            null
+        )
+    );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Template that = (Template) o;
+    return Objects.equals(metadata, that.metadata)
+           && Objects.equals(spec, that.spec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(spec, metadata);
+  }
+
+  @Override
+  public String toString() {
+    return "Template{" + "id='" + id + '\'' + ", metadata=" + metadata
+           + ", spec=" + spec + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/TemplateList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/TemplateList.java
@@ -1,17 +1,67 @@
 package io.confluent.idesidecar.restapi.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
 import io.confluent.idesidecar.restapi.resources.TemplateResource;
 import java.util.List;
+import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({
+    "api_version",
+    "kind",
+    "metadata",
+    "data"
+})
 public class TemplateList extends BaseList<Template> {
 
-  private TemplateList() {
+  public TemplateList(List<Template> templateList) {
+    super(
+        templateList,
+        CollectionMetadata.from(
+            templateList.size(),
+            TemplateResource.API_RESOURCE_PATH
+        )
+    );
   }
 
-  public TemplateList(List<Template> templateList) {
-    this.metadata = new CollectionMetadata(
-        templateList.size(),
-        TemplateResource.API_RESOURCE_PATH);
-    this.data = templateList;
+  @JsonCreator
+  public TemplateList(
+      @JsonProperty(value = "data", required = true) Template[] data,
+      @JsonProperty(value = "metadata", required = true) CollectionMetadata metadata
+  ) {
+    super(
+        List.of(data),
+        metadata != null ? metadata.withTotalSize(data.length) : CollectionMetadata.from(
+            data.length,
+            TemplateResource.API_RESOURCE_PATH
+        )
+    );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TemplateList that = (TemplateList) o;
+    return Objects.equals(metadata, that.metadata)
+           && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, metadata);
+  }
+
+  @Override
+  public String toString() {
+    return "TemplateList{" + "metadata=" + metadata + ", data=" + data + '}';
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -8,7 +8,6 @@ import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.models.Connection;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionsList;
-import io.quarkus.logging.Log;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
@@ -60,12 +59,10 @@ public class ConnectionsResource {
                   .completionStage(() -> getConnectionModel(connection.getSpec().id())))
               .collect(Collectors.toList());
           if (connectionFutures.isEmpty()) {
-            Log.error("Returning no connections");
             return Uni
                 .createFrom()
                 .item(new ConnectionsList());
           }
-          Log.errorf("Returning %d connections", connectionFutures.size());
           return Uni
               .combine()
               .all()

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/TemplateResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/TemplateResource.java
@@ -44,7 +44,7 @@ public class TemplateResource {
     var templateManifests = templateRegistryService.listTemplates();
     var templateList = templateManifests.stream()
         .map(Template::new)
-        .sorted(Comparator.comparing(Template::getId))
+        .sorted(Comparator.comparing(Template::id))
         .toList();
     return new TemplateList(templateList);
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/CollectionMetadataTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/CollectionMetadataTest.java
@@ -10,12 +10,14 @@ public class CollectionMetadataTest {
 
   @Test
   void selfShouldReturnAValidApiPath() {
-    var collectionMetadata = new CollectionMetadata(
+    var collectionMetadata = CollectionMetadata.from(
         0,
-        "/gateway/v1/fake-resource-path");
+        "/gateway/v1/fake-resource-path"
+    );
 
     assertEquals(
         "http://localhost:26637/gateway/v1/fake-resource-path",
-        collectionMetadata.self());
+        collectionMetadata.self()
+    );
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/ConnectionsListTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/ConnectionsListTest.java
@@ -1,0 +1,45 @@
+package io.confluent.idesidecar.restapi.models;
+
+import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.deserializeAndSerialize;
+import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.serializeAndDeserialize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class ConnectionsListTest {
+
+  @Test
+  void shouldCreateEmptyListWithMetadata() {
+    var connectionsList = new ConnectionsList();
+    assertEquals(0, connectionsList.data().size());
+
+    assertNotNull(connectionsList.metadata());
+    assertNotNull(connectionsList.metadata().self());
+    assertNull(connectionsList.metadata().next());
+    assertEquals(0, connectionsList.metadata().totalSize());
+  }
+
+  @Test
+  void shouldSerializeAndDeserializeEmptyList() {
+    var connectionsList = new ConnectionsList();
+    serializeAndDeserialize(connectionsList);
+  }
+
+  @Test
+  void shouldDeserializeAndSerializeEmptyList() {
+    deserializeAndSerialize(
+        "connections/empty-list-connections-response.json",
+        ConnectionsList.class
+    );
+  }
+
+  @Test
+  void shouldDeserializeAndSerializeNonEmptyList() {
+    deserializeAndSerialize(
+        "connections/list-connections-response.json",
+        ConnectionsList.class
+    );
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/models/ObjectMetadataTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/ObjectMetadataTest.java
@@ -1,25 +1,16 @@
 package io.confluent.idesidecar.restapi.models;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
-import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
-@QuarkusTest
 public class ObjectMetadataTest {
 
   @Test
   void selfShouldReturnAValidApiPath() {
-    var objectMetadata = new ObjectMetadata("/gateway/v1/fake-resource-path", "fake-resource-id");
-    assertEquals(
-        "http://localhost:26637/gateway/v1/fake-resource-path/fake-resource-id",
-        objectMetadata.self());
-  }
-
-  @Test
-  void resourceNameShouldBeNull() {
-    var objectMetadata = new ObjectMetadata("/gateway/v1/fake-resource-path", "fake-resource-id");
-    assertNull(objectMetadata.resourceName());
+    var resourceName = "fake-resource-path";
+    var self = "http://localhost:26637/gateway/v1/fake-resource-path";
+    var objectMetadata = new ObjectMetadata(self, resourceName);
+    assertEquals(self, objectMetadata.self());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/models/TemplateListTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/TemplateListTest.java
@@ -1,0 +1,38 @@
+package io.confluent.idesidecar.restapi.models;
+
+import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.deserializeAndSerialize;
+import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.serializeAndDeserialize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TemplateListTest {
+
+  @Test
+  void shouldCreateEmptyListWithMetadata() {
+    var templateList = new TemplateList(List.of());
+    assertEquals(0, templateList.data().size());
+
+    assertNotNull(templateList.metadata());
+    assertNotNull(templateList.metadata().self());
+    assertNull(templateList.metadata().next());
+    assertEquals(0, templateList.metadata().totalSize());
+  }
+
+  @Test
+  void shouldSerializeAndDeserializeEmptyList() {
+    var templateList = new TemplateList(List.of());
+    serializeAndDeserialize(templateList);
+  }
+
+  @Test
+  void shouldDeserializeAndSerializeNonEmptyList() {
+    deserializeAndSerialize(
+        "templates-api-responses/list-templates-response.json",
+        ConnectionsList.class
+    );
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.restapi.resources;
 
 import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.asJson;
+import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.asObject;
 import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.loadResource;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
@@ -17,12 +18,17 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
+import io.confluent.idesidecar.restapi.models.CollectionMetadata;
+import io.confluent.idesidecar.restapi.models.Connection;
+import io.confluent.idesidecar.restapi.models.ConnectionMetadata;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.CCloudConfig;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.SchemaRegistryConfig;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
+import io.confluent.idesidecar.restapi.models.ConnectionsList;
+import io.confluent.idesidecar.restapi.models.ObjectMetadata;
 import io.confluent.idesidecar.restapi.util.CCloudTestUtil.AccessToken;
 import io.confluent.idesidecar.restapi.util.UuidFactory;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
@@ -36,10 +42,8 @@ import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import jakarta.inject.Inject;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -96,27 +100,28 @@ public class ConnectionsResourceTest {
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void listConnections_emptyListResponse() throws IOException {
-    JsonNode expectedJson = asJson(
-        loadResource("connections/empty-list-connections-response.json")
-    );
+  void listConnections_emptyListResponse() {
+    var expectedContent = loadResource("connections/empty-list-connections-response.json");
+    JsonNode expectedJson = asJson(expectedContent);
 
     var actualResponse = given()
         .when()
         .get()
         .then()
         .statusCode(200)
-        .contentType(ContentType.JSON)
-        .extract().body().asString();
+        .contentType(ContentType.JSON);
 
-    JsonNode actualJson = asJson(actualResponse);
+    JsonNode actualJson = asJson(actualResponse.extract().body().asString());
+    assertConnectionList(expectedJson, actualJson, 0);
 
-    assertEquals(expectedJson, actualJson);
+    ConnectionsList actualList = actualResponse.extract().body().as(ConnectionsList.class);
+    ConnectionsList expectedList = asObject(expectedContent, ConnectionsList.class);
+    assertConnectionList(expectedList, actualList);
   }
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void createConnection_createsAndReturnsConnection() throws IOException {
+  void createConnection_createsAndReturnsConnection() {
     var requestBody = loadResource("connections/create-connection-request.json");
     var expectedJson = asJson(
         loadResource("connections/create-connection-response.json")
@@ -132,7 +137,7 @@ public class ConnectionsResourceTest {
         .extract().body().asString();
 
     JsonNode actualJson = asJson(actualResponse);
-    assertEquals(expectedJson, actualJson);
+    assertConnection(expectedJson, actualJson);
 
     //  Fail the recreating the same connection
     given()
@@ -147,7 +152,7 @@ public class ConnectionsResourceTest {
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void getConnection_withoutToken_shouldReturnWithStatus() throws IOException {
+  void getConnection_withoutToken_shouldReturnWithStatus() {
     List<ConnectionSpec> specs = Arrays.asList(
         new ConnectionSpec("c-1", "Connection 1", ConnectionType.CCLOUD)
     );
@@ -193,7 +198,7 @@ public class ConnectionsResourceTest {
   }
 
   @Test
-  void getConnection_withToken_shouldReturnWithStatusIncludingUserAndOrg() throws IOException {
+  void getConnection_withToken_shouldReturnWithStatusIncludingUserAndOrg() {
     var connectionId = "c-1";
     var connectionName = "Connection 1";
     var connectionType = ConnectionType.CCLOUD;
@@ -279,7 +284,7 @@ public class ConnectionsResourceTest {
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void listConnections_returnsAllConnections() throws IOException {
+  void listConnections_returnsAllConnections() {
     List<ConnectionSpec> specs = Arrays.asList(
         new ConnectionSpec("1", "Connection 1", ConnectionType.LOCAL),
         new ConnectionSpec("2", "Connection 2", ConnectionType.CCLOUD)
@@ -310,36 +315,22 @@ public class ConnectionsResourceTest {
         .when().get()
         .then()
         .statusCode(200)
-        .contentType(ContentType.JSON)
-        .extract().body().asString();
+        .contentType(ContentType.JSON);
 
     // should return both resources
-    var actualJson = asJson(actualResponse1);
-    var expectedJson = asJson(
-        loadResource("connections/list-connections-response.json")
+    var actualJson = asJson(
+        actualResponse1.extract().body().asString()
     );
+    var expectedContent = loadResource("connections/list-connections-response.json");
+    var expectedJson = asJson(expectedContent);
 
     assertNotNull(actualJson);
     assertNotNull(expectedJson);
-    assertEquals(expectedJson.get("api_version"), actualJson.get("api_version"));
-    assertEquals(expectedJson.get("kind"), actualJson.get("kind"));
-    assertEquals(expectedJson.get("metadata"), actualJson.get("metadata"));
-    assertEquals(2, actualJson.get("data").size());
+    assertConnectionList(expectedJson, actualJson, 2);
 
-    // The local connection should match exactly
-    var expectedConnection1 = expectedJson.get("data").get(0);
-    var actualConnection1 = actualJson.get("data").get(0);
-    assertEquals(expectedConnection1, actualConnection1);
-
-    // but don't compare the sign-in URI since that contains a variable token
-    var expectedConnection2 = expectedJson.get("data").get(1);
-    var actualConnection2 = actualJson.get("data").get(1);
-    assertTrue(actualConnection2.has("metadata"));
-    assertTrue(actualConnection2.get("metadata").has("sign_in_uri"));
-    assertEquals(expectedConnection2.get("api_version"), actualConnection2.get("api_version"));
-    assertEquals(expectedConnection2.get("kind"), actualConnection2.get("kind"));
-    assertEquals(expectedConnection2.get("spec"), actualConnection2.get("spec"));
-    assertEquals(expectedConnection2.get("status"), actualConnection2.get("status"));
+    var actualList = actualResponse1.extract().body().as(ConnectionsList.class);
+    var expectedList = asObject(expectedContent, ConnectionsList.class);
+    assertConnectionList(expectedList, actualList);
   }
 
   @ParameterizedTest
@@ -1282,7 +1273,7 @@ public class ConnectionsResourceTest {
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void updateConnection_FailUpdateNonExistingConnection() throws IOException {
+  void updateConnection_FailUpdateNonExistingConnection() {
     ConnectionSpec spec = new ConnectionSpec(
         "1",
         "Connection 1",
@@ -1310,40 +1301,144 @@ public class ConnectionsResourceTest {
 
   @Test
   @TestHTTPEndpoint(ConnectionsResource.class)
-  void deleteConnection_shouldDeleteAndSecondDeleteFails() throws IOException {
+  void deleteConnection_shouldDeleteAndSecondDeleteFails() {
     // Two scenarios are tested here for delete connection.
     // 1. Deletion of existing connection
     // 2. Deletion of non-existent connection.
-    String requestBodyPath = "connections/create-connection-request.json";
 
-    var requestBody = new String(
-        Objects.requireNonNull(Thread.currentThread().getContextClassLoader()
-            .getResourceAsStream(requestBodyPath)).readAllBytes());
-
-    var actualResponse = given()
+    // When we create a connection
+    var requestBody = loadResource("connections/create-connection-request.json");
+    var newConnection = given()
         .contentType(ContentType.JSON)
         .body(requestBody)
         .when().post()
         .then()
         .statusCode(200)
         .contentType(ContentType.JSON)
-        .extract().body().asString();
+        .extract().body().as(Connection.class);
+    var id = newConnection.id();
 
+    // Then we can delete it
     given()
-        .when().delete("/{id}", "3")
+        .when().delete("/{id}", id)
         .then()
         .statusCode(204); // Expecting HTTP 204 status code for no content
 
+    // And cannot delete it again
     given().when()
-        .get("/{id}", "3")
+        .get("/{id}", id)
         .then()
         .statusCode(404); // Expection HTTP 404 not found.
 
+    // And cannot delete it yet again
     given()
-        .when().delete("/{id}", "3")
+        .when().delete("/{id}", id)
         .then()
         .statusCode(404); // Expecting HTTP 404 status code for no content
   }
 
+  protected void assertConnectionList(ConnectionsList expected, ConnectionsList actual) {
+    if (expected != null && actual != null) {
+      assertEquals(expected.apiVersion(), actual.apiVersion());
+      assertEquals(expected.kind(), actual.kind());
+      assertMetadata(expected.metadata(), actual.metadata());
+
+      // Check the elements individually, since metadata checks deal with port differences
+      assertEquals(expected.data().size(), actual.data().size());
+      for (int i = 0; i != expected.data().size(); i++) {
+        assertConnection(expected.data().get(i), actual.data().get(i));
+      }
+    } else {
+      assertEquals(expected, actual);
+    }
+  }
+
+  protected void assertConnectionList(JsonNode expected, JsonNode actual, int expectedSize) {
+    assertEquals(expected.get("api_version"), actual.get("api_version"));
+    assertEquals(expected.get("kind"), actual.get("kind"));
+    assertMetadata(expected.get("metadata"), actual.get("metadata"));
+    assertEquals(expectedSize, expected.get("data").size());
+    assertEquals(expectedSize, actual.get("data").size());
+
+    for (int i = 0; i != expectedSize; i++) {
+      assertConnection(expected.get("data").get(i), actual.get("data").get(i));
+    }
+  }
+
+  protected void assertConnection(Connection expected, Connection actual) {
+    if (expected != null && actual != null) {
+      assertEquals(expected.apiVersion(), actual.apiVersion());
+      assertEquals(expected.kind(), actual.kind());
+      assertMetadata(expected.metadata(), actual.metadata());
+      assertEquals(expected.spec(), actual.spec());
+      assertEquals(expected.status(), actual.status());
+    } else {
+      assertEquals(expected, actual);
+    }
+  }
+
+  protected void assertConnection(JsonNode expected, JsonNode actual) {
+    assertEquals(expected.get("api_version"), actual.get("api_version"));
+    assertEquals(expected.get("kind"), actual.get("kind"));
+    assertMetadata(expected.get("metadata"), actual.get("metadata"));
+    assertEquals(expected.get("spec"), actual.get("spec"));
+    assertEquals(expected.get("status"), actual.get("status"));
+  }
+
+  protected void assertMetadata(CollectionMetadata expected, CollectionMetadata actual) {
+    if (expected != null && actual != null) {
+      assertEquals(expected.totalSize(), actual.totalSize());
+      assertEquals(
+          linkWithoutPort(expected.self()),
+          linkWithoutPort(actual.self())
+      );
+      assertEquals(
+          linkWithoutPort(expected.next()),
+          linkWithoutPort(actual.next())
+      );
+    } else {
+      assertEquals(expected, actual);
+    }
+  }
+
+  protected void assertMetadata(ObjectMetadata expected, ObjectMetadata actual) {
+    if (expected != null && actual != null) {
+      assertEquals(expected.self(), actual.self());
+      assertEquals(expected.resourceName(), actual.resourceName());
+      if (expected instanceof ConnectionMetadata expectedConnectionMetadata) {
+        if (actual instanceof ConnectionMetadata actualConnectionMetadata) {
+          assertEquals(
+              linkWithoutPort(expectedConnectionMetadata.signInUri()),
+              linkWithoutPort(actualConnectionMetadata.signInUri())
+          );
+        } else {
+          assertEquals(expected.getClass(), actual.getClass());
+        }
+      }
+    } else {
+      assertEquals(expected, actual);
+    }
+  }
+
+  protected void assertMetadata(JsonNode expected, JsonNode actual) {
+    assertEquals(
+        linkWithoutPort(expected.get("sign_in_uri")),
+        linkWithoutPort(actual.get("sign_in_uri"))
+    );
+    assertEquals(expected.get("resource_name"), actual.get("resource_name"));
+    // The actual port is dynamic and will likely differ from the expected port read from files
+    assertEquals(
+        linkWithoutPort(expected.get("self")),
+        linkWithoutPort(actual.get("self"))
+    );
+  }
+
+  protected String linkWithoutPort(JsonNode node) {
+    return node == null ? null : linkWithoutPort(node.asText());
+  }
+
+  protected String linkWithoutPort(String url) {
+    return url == null ? null : url.replaceAll("localhost:\\d+", "");
+  }
 }
 

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -1407,9 +1407,11 @@ public class ConnectionsResourceTest {
       assertEquals(expected.resourceName(), actual.resourceName());
       if (expected instanceof ConnectionMetadata expectedConnectionMetadata) {
         if (actual instanceof ConnectionMetadata actualConnectionMetadata) {
+          var expectedSignInUri = expectedConnectionMetadata.signInUri();
+          var actualSignInUri = actualConnectionMetadata.signInUri();
           assertEquals(
-              linkWithoutPort(expectedConnectionMetadata.signInUri()),
-              linkWithoutPort(actualConnectionMetadata.signInUri())
+              expectedSignInUri == null || !expectedSignInUri.trim().isEmpty(),
+              actualSignInUri == null || !actualSignInUri.trim().isEmpty()
           );
         } else {
           assertEquals(expected.getClass(), actual.getClass());
@@ -1421,15 +1423,28 @@ public class ConnectionsResourceTest {
   }
 
   protected void assertMetadata(JsonNode expected, JsonNode actual) {
-    assertEquals(
-        linkWithoutPort(expected.get("sign_in_uri")),
-        linkWithoutPort(actual.get("sign_in_uri"))
-    );
-    assertEquals(expected.get("resource_name"), actual.get("resource_name"));
+    // Don't compare the values of the sign-in URI since that contains a variable token
+    // and instead just ensure that both have or do not have the field
+    assertNullOrNonBlankText(expected.get("sign_in_uri"), actual.get("sign_in_uri"));
+    assertEqualsOrNull(expected.get("resource_name"), actual.get("resource_name"));
     // The actual port is dynamic and will likely differ from the expected port read from files
     assertEquals(
         linkWithoutPort(expected.get("self")),
         linkWithoutPort(actual.get("self"))
+    );
+  }
+
+  protected void assertNullOrNonBlankText(JsonNode expected, JsonNode actual) {
+    assertEquals(
+        expected == null || expected.isNull() || !expected.asText().trim().isEmpty(),
+        actual == null || actual.isNull() || !actual.asText().trim().isEmpty()
+    );
+  }
+
+  protected void assertEqualsOrNull(JsonNode expected, JsonNode actual) {
+    assertEquals(
+        expected == null || expected.isNull() ? null : expected,
+        actual == null || actual.isNull() ? null : actual
     );
   }
 

--- a/src/test/resources/connections/empty-list-connections-response.json
+++ b/src/test/resources/connections/empty-list-connections-response.json
@@ -1,6 +1,9 @@
 {
   "api_version": "gateway/v1",
   "kind": "ConnectionsList",
-  "metadata": null,
+  "metadata": {
+    "self": "http://localhost:26637/gateway/v1/connections",
+    "total_size": 0
+  },
   "data": []
 }

--- a/src/test/resources/connections/list-connections-response.json
+++ b/src/test/resources/connections/list-connections-response.json
@@ -13,8 +13,7 @@
       "id": "1",
       "metadata":
       {
-        "self": "http://localhost:26637/gateway/v1/connections/1",
-        "resource_name": null
+        "self": "http://localhost:26637/gateway/v1/connections/1"
       },
       "spec":
       {
@@ -36,7 +35,7 @@
       "metadata":
       {
         "self": "http://localhost:26637/gateway/v1/connections/2",
-        "resource_name": null
+        "sign_in_uri": "https://login.confluent-dev.io/oauth/authorize?response_type=code&code_challenge_method=S256&code_challenge=f0883e0c8257e80f15d993a26e498da93ce2e1922a04cdc54bce6a0de0127281&state=2&client_id=cUmAgrkbAZSqSiy38JE7Ya3i7FwXmyUF&redirect_uri=http://127.0.0.1:26637/gateway/v1/callback-vscode-docs&scope=email+openid+offline_access"
       },
       "spec":
       {

--- a/src/test/resources/connections/list-connections-response.json
+++ b/src/test/resources/connections/list-connections-response.json
@@ -1,7 +1,10 @@
 {
   "api_version": "gateway/v1",
   "kind": "ConnectionsList",
-  "metadata": null,
+  "metadata": {
+    "self": "http://localhost:26637/gateway/v1/connections",
+    "total_size": 2
+  },
   "data":
   [
     {
@@ -33,8 +36,7 @@
       "metadata":
       {
         "self": "http://localhost:26637/gateway/v1/connections/2",
-        "resource_name": null,
-        "sign_in_uri": "https://login.confluent-dev.io/oauth/authorize?response_type=code&code_challenge_method=S256&code_challenge=f0883e0c8257e80f15d993a26e498da93ce2e1922a04cdc54bce6a0de0127281&state=2&client_id=cUmAgrkbAZSqSiy38JE7Ya3i7FwXmyUF&redirect_uri=http://127.0.0.1:26637/gateway/v1/callback-vscode-docs&scope=email+openid+offline_access"
+        "resource_name": null
       },
       "spec":
       {


### PR DESCRIPTION
## Summary of Changes

The `ConnectionList` and `TemplateList` did not fully support deserializing, since production code doesn’t require it. However, this is needed when using REST Easy to deserialize these API responses with:
```
var connectionsList = given()
        .when()
        .get()
        .then()
        .statusCode(200)
        .contentType(ContentType.JSON)
        .extract().body()as(ConnectionsList.class);
```
Prior to this change, most of our tests extracted the body as a JSON representation, then parsed it into `JsonNode`, and manipulated the result. But extracting the body into its deserialized form is far simpler.

This PR does **not** otherwise change API behavior or the OpenAPI specification, and only changes how the Connection API and Template API resource types are implemented and tested. Specifically, it refactors the `BaseList`, `BaseModel` classes and their subtypes to be more conventional (e.g., storing the serialized fields, rather than deriving serialized fields transiently from other hidden fields) and adds new creator methods and additional annotations. The PR changes a few tests to use the type-specific deserialization approach, and adds new tests to verify the types could be deserialized, serialized, and then deserialized again without losing any information. These changes make it very easy to add in the future new tests that use the type-specific deserialization.

This PR does not rewrite the numerous tests that use the JSON approach.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

