### PR TITLE
Fix the native image not including the `sign_in_uri` on CCloud connections

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/models/BaseList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/BaseList.java
@@ -1,9 +1,11 @@
 package io.confluent.idesidecar.restapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 import org.eclipse.microprofile.config.ConfigProvider;
 
+@RegisterForReflection
 public abstract class BaseList<T> {
 
   protected static final String API_VERSION = ConfigProvider

--- a/src/main/java/io/confluent/idesidecar/restapi/models/BaseModel.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/BaseModel.java
@@ -1,8 +1,10 @@
 package io.confluent.idesidecar.restapi.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.microprofile.config.ConfigProvider;
 
+@RegisterForReflection
 public abstract class BaseModel<SpecT, MetadataT extends ObjectMetadata> {
 
   protected static final String API_VERSION = ConfigProvider

--- a/src/main/java/io/confluent/idesidecar/restapi/models/CollectionMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/CollectionMetadata.java
@@ -3,6 +3,7 @@ package io.confluent.idesidecar.restapi.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.Null;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -11,6 +12,7 @@ import jakarta.validation.constraints.Null;
     "next",
     "total_size"
 })
+@RegisterForReflection
 public record CollectionMetadata(
     @JsonProperty(value = "self")
     @Null

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.connections.ConnectionState;
 import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,6 +18,7 @@ import java.util.Objects;
     "spec",
     "status"
 })
+@RegisterForReflection
 public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionMetadata.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,6 +15,7 @@ import java.util.Objects;
     "resource_name",
     "sign_in_uri"
 })
+@RegisterForReflection
 public class ConnectionMetadata extends ObjectMetadata {
 
   public static ConnectionMetadata from(

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionsList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionsList.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 import java.util.Objects;
 
@@ -15,6 +16,7 @@ import java.util.Objects;
     "metadata",
     "data"
 })
+@RegisterForReflection
 public class ConnectionsList extends BaseList<Connection> {
 
   public ConnectionsList() {

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ObjectMetadata.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ObjectMetadata.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.Objects;
 import org.eclipse.microprofile.config.ConfigProvider;
 
@@ -13,6 +14,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
     "self",
     "resource_name"
 })
+@RegisterForReflection
 public class ObjectMetadata {
 
   static final String API_HOST = ConfigProvider

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Template.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Template.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.resources.TemplateResource;
 import io.confluent.idesidecar.scaffolding.models.TemplateManifest;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,6 +18,7 @@ import java.util.Objects;
     "id",
     "metadata"
 })
+@RegisterForReflection
 public class Template extends BaseModel<TemplateManifest, ObjectMetadata> {
 
   @JsonCreator

--- a/src/main/java/io/confluent/idesidecar/restapi/models/TemplateList.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/TemplateList.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
 import io.confluent.idesidecar.restapi.resources.TemplateResource;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,6 +17,7 @@ import java.util.Objects;
     "metadata",
     "data"
 })
+@RegisterForReflection
 public class TemplateList extends BaseList<Template> {
 
   public TemplateList(List<Template> templateList) {


### PR DESCRIPTION
Not sure why `metadata` in the response of a newly-created CCloud connections was empty, but only in the native image (worked fine in dev-mode and in the unit+integration tests).

To fix, I added `@RegisterForReflection` to all of the resource classes that extend any of the `BaseList` or `BaseModel`. Probably over-cautious, but this fixes the problem.

I’ll add an integration test in a subsequent PR to try and catch this kind of regression in the future.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

