### PR TITLE
Add support for Kafka REST, SR and message consumer APIs using direct connections

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConsumeStrategyProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConsumeStrategyProcessor.java
@@ -30,10 +30,9 @@ public class ConsumeStrategyProcessor
   public ConsumeStrategy chooseStrategy(MessageViewerContext context) {
     var connectionType = context.getConnectionState().getType();
     return switch (connectionType) {
-      case LOCAL -> nativeConsumeStrategy;
+      case DIRECT, LOCAL -> nativeConsumeStrategy;
       case CCLOUD -> confluentCloudConsumeStrategy;
-      // TODO: DIRECT connection strategy is needed
-      case PLATFORM, DIRECT -> throw new ProcessorFailedException(
+      case PLATFORM -> throw new ProcessorFailedException(
           context.failf(
               501,
               "This endpoint does not yet support connection-type=%s",

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterAuthenticationProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterAuthenticationProcessor.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.restapi.proxy.clusters.processors;
 
 import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
+import io.confluent.idesidecar.restapi.connections.DirectConnectionState;
 import io.confluent.idesidecar.restapi.connections.LocalConnectionState;
 import io.confluent.idesidecar.restapi.connections.PlatformConnectionState;
 import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
@@ -31,6 +32,9 @@ public class ClusterAuthenticationProcessor extends
       }
       case LocalConnectionState localConnection -> {
         // Do nothing
+      }
+      case DirectConnectionState directConnection -> {
+        // TODO: DIRECT check auth status and fail if not connected/authenticated
       }
       case PlatformConnectionState platformConnection -> {
         // Do nothing

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
@@ -10,6 +10,8 @@ import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentCloudKaf
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentCloudSchemaRegistryClusterStrategy;
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentLocalKafkaClusterStrategy;
 import io.confluent.idesidecar.restapi.proxy.clusters.strategy.ConfluentLocalSchemaRegistryClusterStrategy;
+import io.confluent.idesidecar.restapi.proxy.clusters.strategy.DirectKafkaClusterStrategy;
+import io.confluent.idesidecar.restapi.proxy.clusters.strategy.DirectSchemaRegistryClusterStrategy;
 import io.vertx.core.Future;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,10 +30,16 @@ public class ClusterStrategyProcessor extends
   ConfluentLocalKafkaClusterStrategy confluentLocalKafkaClusterStrategy;
 
   @Inject
+  DirectKafkaClusterStrategy directKafkaClusterStrategy;
+
+  @Inject
   ConfluentCloudSchemaRegistryClusterStrategy confluentCloudSchemaRegistryClusterStrategy;
 
   @Inject
   ConfluentLocalSchemaRegistryClusterStrategy confluentLocalSchemaRegistryClusterStrategy;
+
+  @Inject
+  DirectSchemaRegistryClusterStrategy directSchemaRegistryClusterStrategy;
 
 
   @Override
@@ -57,8 +65,9 @@ public class ClusterStrategyProcessor extends
       case LOCAL ->
           clusterType == ClusterType.KAFKA
               ? confluentLocalKafkaClusterStrategy : confluentLocalSchemaRegistryClusterStrategy;
-      // TODO: DIRECT proxy strategy
-      case DIRECT -> null;
+      case DIRECT ->
+          clusterType == ClusterType.KAFKA
+          ? directKafkaClusterStrategy : directSchemaRegistryClusterStrategy;
       case PLATFORM -> null;
     };
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectKafkaClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectKafkaClusterStrategy.java
@@ -1,0 +1,73 @@
+package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
+
+import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
+
+import io.confluent.idesidecar.restapi.application.SidecarAccessTokenBean;
+import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Strategy for processing requests and responses for a Kafka cluster.
+ */
+@ApplicationScoped
+public class DirectKafkaClusterStrategy extends ClusterStrategy {
+
+  @ConfigProperty(name = "ide-sidecar.api.host")
+  String sidecarHost;
+
+  @Inject
+  SidecarAccessTokenBean accessToken;
+
+  /**
+   * We require the connection ID header to be passed to our implementation of the Kafka REST API
+   * at the /internal/kafka path. This is used to identify the connection that the request is
+   * associated with. We also pass the access token as a Bearer token in the Authorization header.
+   * @param context The context of the proxy request.
+   * @return The headers to be passed to our implementation of the Kafka REST API.
+   */
+  @Override
+  public MultiMap constructProxyHeaders(ClusterProxyContext context) {
+    var headers = super.constructProxyHeaders(context);
+    return headers
+        .add(CONNECTION_ID_HEADER, context.getConnectionId())
+        .add(HttpHeaders.AUTHORIZATION, "Bearer %s".formatted(accessToken.getToken()));
+  }
+
+  /**
+   * Route the request back to ourselves at the /internal/kafka path.
+   * Context: We used to send this proxy request to the Kafka REST server running in the
+   * confluent-local container, but now we route the request to our own implementation of the
+   * Kafka REST API, served at the /internal/kafka path. This was done to get early feedback
+   * on our in-house implementation of the Kafka REST API.
+   * @param requestUri The URI of the incoming request.
+   * @param clusterUri The Kafka REST URI running alongside the Kafka cluster.
+   *                   (unused here)
+   * @return The URI of the Kafka REST API running in the sidecar.
+   */
+  @Override
+  public String constructProxyUri(String requestUri, String clusterUri) {
+    return uriUtil.combine(
+        sidecarHost, requestUri.replaceFirst("^(/kafka|kafka)", "/internal/kafka")
+    );
+  }
+
+  /**
+   * In addition to replacing the cluster URLs with the sidecar host, we also need to replace
+   * the internal Kafka REST path /internal/kafka with the external facing /kafka path.
+   * @param proxyResponse The response body from the Kafka REST API.
+   * @param clusterUri The URI of the Kafka REST API running alongside the Kafka cluster.
+   *                   (unused here)
+   * @param sidecarHost The host of the sidecar.
+   * @return The response body with the internal Kafka REST path replaced with the external path.
+   */
+  @Override
+  public String processProxyResponse(String proxyResponse, String clusterUri, String sidecarHost) {
+    return super
+        .processProxyResponse(proxyResponse, sidecarHost, sidecarHost)
+        .replaceAll("%s/internal/kafka".formatted(sidecarHost), "%s/kafka".formatted(sidecarHost));
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectSchemaRegistryClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectSchemaRegistryClusterStrategy.java
@@ -1,0 +1,11 @@
+package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Strategy for processing requests and responses for a Confluent local Kafka cluster.
+ */
+@ApplicationScoped
+public class DirectSchemaRegistryClusterStrategy extends ClusterStrategy {
+  // No specific configuration for this strategy
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
@@ -75,12 +75,26 @@ class RecordsV3ApiImplIT {
   @Nested
   @Tag("io.confluent.common.utils.IntegrationTest")
   @TestProfile(NoAccessFilterProfile.class)
-  class SadPath extends AbstractSidecarIT {
+  class SadPathWithLocal extends SadPath {
 
     @BeforeEach
     public void beforeEach() {
-      setupLocalConnection(SadPath.class);
+      setupLocalConnection(this);
     }
+  }
+
+  @Nested
+  @Tag("io.confluent.common.utils.IntegrationTest")
+  @TestProfile(NoAccessFilterProfile.class)
+  class SadPathWithDirect extends SadPath {
+
+    @BeforeEach
+    public void beforeEach() {
+      setupDirectConnection(this);
+    }
+  }
+
+  abstract class SadPath extends AbstractSidecarIT {
 
     @Test
     void shouldThrowNotFoundWhenClusterDoesNotExist() {
@@ -264,15 +278,30 @@ class RecordsV3ApiImplIT {
     }
   }
 
+
   @Nested
   @Tag("io.confluent.common.utils.IntegrationTest")
   @TestProfile(NoAccessFilterProfile.class)
-  class HappyPath extends AbstractSidecarIT {
+  class HappyPathWithLocal extends HappyPath {
 
     @BeforeEach
     public void beforeEach() {
-      setupLocalConnection(HappyPath.class);
+      setupLocalConnection(this);
     }
+  }
+
+  @Nested
+  @Tag("io.confluent.common.utils.IntegrationTest")
+  @TestProfile(NoAccessFilterProfile.class)
+  class HappyPathWithDirect extends HappyPath {
+
+    @BeforeEach
+    public void beforeEach() {
+      setupDirectConnection(this);
+    }
+  }
+
+  abstract class HappyPath extends AbstractSidecarIT {
 
     private static RecordData jsonData(Object data) {
       return new RecordData(null, null, data);

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplDirectIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplDirectIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class ClusterV3ApiImplDirectIT extends ClusterV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplIT.java
@@ -2,24 +2,11 @@ package io.confluent.idesidecar.restapi.kafkarest.api;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.AbstractSidecarIT;
 import io.confluent.idesidecar.restapi.util.ConfluentLocalKafkaWithRestProxyContainer;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@QuarkusIntegrationTest
-@Tag("io.confluent.common.utils.IntegrationTest")
-@TestProfile(NoAccessFilterProfile.class)
-public class ClusterV3ApiImplIT extends AbstractSidecarIT {
-
-  @BeforeEach
-  public void beforeEach() {
-    setupLocalConnection(ClusterV3ApiImplIT.class);
-  }
+abstract class ClusterV3ApiImplIT extends AbstractSidecarIT {
 
   @Test
   void shouldListKafkaClusters() {

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplLocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3ApiImplLocalIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class ClusterV3ApiImplLocalIT extends ClusterV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplDirectIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplDirectIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class PartitionV3ApiImplDirectIT extends PartitionV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplIT.java
@@ -3,23 +3,10 @@ package io.confluent.idesidecar.restapi.kafkarest.api;
 import static io.confluent.idesidecar.restapi.util.ConfluentLocalKafkaWithRestProxyContainer.CLUSTER_ID;
 import static org.hamcrest.Matchers.equalTo;
 
-import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.AbstractSidecarIT;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@QuarkusIntegrationTest
-@Tag("io.confluent.common.utils.IntegrationTest")
-@TestProfile(NoAccessFilterProfile.class)
-public class PartitionV3ApiImplIT extends AbstractSidecarIT {
-
-  @BeforeEach
-  public void beforeEach() {
-    setupLocalConnection(PartitionV3ApiImplIT.class);
-  }
+abstract class PartitionV3ApiImplIT extends AbstractSidecarIT {
 
   @Test
   void shouldListTopicPartitions() {

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplLocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/PartitionV3ApiImplLocalIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class PartitionV3ApiImplLocalIT extends PartitionV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupLocalConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplDirectIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplDirectIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class TopicV3ApiImplDirectIT extends TopicV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplIT.java
@@ -3,24 +3,10 @@ package io.confluent.idesidecar.restapi.kafkarest.api;
 import static io.confluent.idesidecar.restapi.util.ConfluentLocalKafkaWithRestProxyContainer.CLUSTER_ID;
 import static org.hamcrest.Matchers.equalTo;
 
-import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.AbstractSidecarIT;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@QuarkusIntegrationTest
-@Tag("io.confluent.common.utils.IntegrationTest")
-@TestProfile(NoAccessFilterProfile.class)
-class TopicV3ApiImplIT extends AbstractSidecarIT {
-
-  @BeforeEach
-  public void beforeEach() {
-    setupLocalConnection(TopicV3ApiImplIT.class);
-  }
+abstract class TopicV3ApiImplIT extends AbstractSidecarIT {
 
   @Test
   void shouldCreateKafkaTopic() {

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplLocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplLocalIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.kafkarest.api;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class TopicV3ApiImplLocalIT extends TopicV3ApiImplIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupLocalConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerDirectIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerDirectIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.messageviewer;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class SimpleConsumerDirectIT extends SimpleConsumerIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerIT.java
@@ -8,25 +8,16 @@ import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPart
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeData;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.PartitionConsumeRecord;
 import io.confluent.idesidecar.restapi.proto.Message.MyMessage;
-import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.AbstractSidecarIT;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
-import java.util.*;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-@QuarkusIntegrationTest
-@Tag("io.confluent.common.utils.IntegrationTest")
-@TestProfile(NoAccessFilterProfile.class)
-public class SimpleConsumerIT extends AbstractSidecarIT {
-
-  @BeforeEach
-  public void beforeEach() {
-    setupLocalConnection(SimpleConsumerIT.class);
-  }
+abstract class SimpleConsumerIT extends AbstractSidecarIT {
 
   @Test
   void testAvroProduceAndConsume() {

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerLocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerLocalIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.messageviewer;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class SimpleConsumerLocalIT extends SimpleConsumerIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupLocalConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceDirectIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceDirectIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.resources;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class KafkaConsumeResourceDirectIT extends KafkaConsumeResourceIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupDirectConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceIT.java
@@ -11,27 +11,17 @@ import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPart
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequestBuilder;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
 import io.confluent.idesidecar.restapi.proto.Message.MyMessage;
-import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.AbstractSidecarIT;
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import io.quarkus.test.junit.TestProfile;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@QuarkusIntegrationTest
-@Tag("io.confluent.common.utils.IntegrationTest")
-@TestProfile(NoAccessFilterProfile.class)
-public class KafkaConsumeResourceIT extends AbstractSidecarIT {
-
-  @BeforeEach
-  public void beforeEach() {
-    setupLocalConnection(KafkaConsumeResourceIT.class);
-  }
+abstract class KafkaConsumeResourceIT extends AbstractSidecarIT {
 
   void createTopicAndProduceRecords(
       String topicName,
@@ -298,12 +288,12 @@ public class KafkaConsumeResourceIT extends AbstractSidecarIT {
    */
   @Test
   public void testShouldDecodeProfobufMessagesUsingSRInMessageViewer() throws Exception {
-    var topic = "myProtobufTopic";
+    var topic = "myProtobufTopic" + UUID.randomUUID();
     createTopicAndProduceRecords(topic, 1, null);
 
     // Create the schema version for the Protobuf message
     createSchema(
-        "myProtobufTopic-value",
+        topic + "-value",
         "PROTOBUF",
         "syntax = \"proto3\"; package io.confluent.idesidecar.restapi; message MyMessage { string name = 1; int32 age = 2; bool is_active = 3; }"
     );

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceLocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResourceLocalIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2024 - 2024] Confluent Inc.
+ */
+
+package io.confluent.idesidecar.restapi.resources;
+
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+
+@QuarkusIntegrationTest
+@Tag("io.confluent.common.utils.IntegrationTest")
+@TestProfile(NoAccessFilterProfile.class)
+public class KafkaConsumeResourceLocalIT extends KafkaConsumeResourceIT {
+
+  @BeforeEach
+  public void beforeEach() {
+    setupLocalConnection(this);
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/util/AbstractSidecarIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/AbstractSidecarIT.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.AfterEach;
@@ -37,7 +36,8 @@ import org.junit.jupiter.api.AfterEach;
  *
  * <p>Most subclasses will use the same connection for all tests, often because the connection
  * is needed to test other APIs. In these cases, the test class' {@code @BeforeEach} method
- * should call {@link #setupLocalConnection(Class)} and/or {@link #setupDirectConnection(Class)}.
+ * should call {@link #setupLocalConnection(AbstractSidecarIT)} and/or
+ * {@link #setupDirectConnection(AbstractSidecarIT)}.
  * This minimizes the setup time for each test, as only the first test will need to create the
  * (shared) connection. (The sidecar will be terminated after all tests in the test class are run,
  * so deleting the connection is not necessary.)
@@ -137,13 +137,14 @@ public abstract class AbstractSidecarIT extends SidecarClient {
    * different test scope for each test. In those cases, {@link #setupLocalConnection(String)}
    * may be a better choice.
    *
-   * @param testClass the class under test
+   * @param testClass the test class instance
+   * @param <T> the type of {@link AbstractSidecarIT} subclass
    * @see #setupDirectConnection(String)
-   * @see #setupDirectConnection(Class)
+   * @see #setupDirectConnection(AbstractSidecarIT)
    * @see #setupLocalConnection(String)
    */
-  protected <T extends AbstractSidecarIT> void setupLocalConnection(Class<T> testClass) {
-    setupLocalConnection(testClass.getSimpleName());
+  protected <T extends AbstractSidecarIT> void setupLocalConnection(T testClass) {
+    setupLocalConnection(testClass.getClass().getSimpleName());
   }
 
   /**
@@ -152,15 +153,15 @@ public abstract class AbstractSidecarIT extends SidecarClient {
    *
    * <p>Each unique test scope will reuse the same local connection, and most subclasses will
    * use the same test scope for all tests. In those cases, using the name of the subclass
-   * is an easy way for tests to share the same scope, and {@link #setupLocalConnection(Class)}
-   * may be an easier way to do this.
+   * is an easy way for tests to share the same scope, and
+   * {@link #setupLocalConnection(AbstractSidecarIT)} may be an easier way to do this.
    *
    * <p>Other test classes may need new/different connections for each test may want to use a
    * different test scope for each test. In those cases, this method may be a better choice.
    *
    * @see #setupDirectConnection(String)
-   * @see #setupDirectConnection(Class)
-   * @see #setupLocalConnection(Class)
+   * @see #setupDirectConnection(AbstractSidecarIT)
+   * @see #setupLocalConnection(AbstractSidecarIT)
    */
   protected void setupLocalConnection(String testScope) {
     current = REUSABLE_CONNECTIONS_BY_TEST_SCOPE.computeIfAbsent(testScope, key -> {
@@ -192,13 +193,14 @@ public abstract class AbstractSidecarIT extends SidecarClient {
    * different test scope for each test. In those cases, {@link #setupDirectConnection(String)}
    * may be a better choice.
    *
-   * @param testClass the class under test
+   * @param testClass the test class instance
+   * @param <T> the type of {@link AbstractSidecarIT} subclass
    * @see #setupDirectConnection(String)
    * @see #setupLocalConnection(String)
-   * @see #setupLocalConnection(Class)
+   * @see #setupLocalConnection(AbstractSidecarIT)
    */
-  protected <T extends AbstractSidecarIT> void setupDirectConnection(Class<T> testClass) {
-    setupDirectConnection(testClass.getSimpleName());
+  protected <T extends AbstractSidecarIT> void setupDirectConnection(T testClass) {
+    setupDirectConnection(testClass.getClass().getSimpleName());
   }
 
   /**
@@ -207,14 +209,14 @@ public abstract class AbstractSidecarIT extends SidecarClient {
    *
    * <p>Each unique test scope will reuse the same local connection, and most subclasses will
    * use the same test scope for all tests. In those cases, using the name of the subclass
-   * is an easy way for tests to share the same scope, and {@link #setupDirectConnection(Class)}
-   * may be an easier way to do this.
+   * is an easy way for tests to share the same scope, and
+   * {@link #setupDirectConnection(AbstractSidecarIT)} may be an easier way to do this.
    *
    * <p>Other test classes may need new/different connections for each test may want to use a
    * different test scope for each test. In those cases, this method may be a better choice.
    *
-   * @see #setupDirectConnection(Class)
-   * @see #setupLocalConnection(Class)
+   * @see #setupDirectConnection(AbstractSidecarIT)
+   * @see #setupLocalConnection(AbstractSidecarIT)
    * @see #setupLocalConnection(String)
    */
   protected void setupDirectConnection(String testScope) {

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.loadResource;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -278,6 +279,8 @@ public class CCloudTestUtil {
   ) {
     if (connectionType == ConnectionType.CCLOUD) {
       createAuthedCCloudConnection(connectionId, connectionName);
+    } else if (connectionType == ConnectionType.DIRECT) {
+      fail("Unable to create a direct connection without specifying the cluster and schema registry");
     } else {
       createConnection(connectionId, connectionName, connectionType);
     }

--- a/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
@@ -95,11 +95,11 @@ public class LocalTestEnvironment implements TestEnvironment {
             "direct-to-local-connection",
             "Direct to Local",
             new ConnectionSpec.KafkaClusterConfig(
-                "local-kafka",
+                kafkaWithRestProxy.getClusterId(),
                 kafkaWithRestProxy.getKafkaBootstrapServers()
             ),
             new ConnectionSpec.SchemaRegistryConfig(
-                "local-schema-registry",
+                schemaRegistry.getClusterId(),
                 schemaRegistry.endpoint()
             )
         )


### PR DESCRIPTION
## Summary of Changes

Modified the `ClusterStrategyProcessor` and `ConsumeStrategyProcessor` implementations to support proxying requests to Kafka and SR clusters defined on direct connections.

Limitations: the `status` on direct connections does not yet reflect the ability to connect (see https://github.com/confluentinc/ide-sidecar/issues/123), and direct connections do not yet have authentication credentials (see https://github.com/confluentinc/ide-sidecar/issues/124).

Also slightly refactors the ITs for these APIs that run against local connections, so that we can easily run these tests against local connections and direct connections.

Resolves #122

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

