### PR TITLE
test:add awaitility dependency and update SidecarClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.awaitility.Awaitility.*;
 
 import io.confluent.idesidecar.restapi.kafkarest.model.CreateTopicRequestData;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
@@ -31,6 +32,7 @@ import io.restassured.config.DecoderConfig;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -506,12 +508,7 @@ public class SidecarClient {
           assertEquals(200, createSchemaVersionResp.statusCode());
         }
 
-        // Sleep for a bit to allow the schema to be registered
-        try {
-          Thread.sleep(50);
-        } catch (InterruptedException e) {
-          // Ignore
-        }
+      await().pollDelay(Duration.ofMillis(20)).pollInterval(Duration.ofMillis(10)).atMost(Duration.ofMillis(100)).until(()->getLatestSchemaVersion(subject, currentSchemaClusterId) != null);
 
         return getLatestSchemaVersion(subject, currentSchemaClusterId);
     });

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.awaitility.Awaitility.*;
+import static org.awaitility.Awaitility.await;
 
 import io.confluent.idesidecar.restapi.kafkarest.model.CreateTopicRequestData;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
@@ -508,7 +508,11 @@ public class SidecarClient {
           assertEquals(200, createSchemaVersionResp.statusCode());
         }
 
-      await().pollDelay(Duration.ofMillis(20)).pollInterval(Duration.ofMillis(10)).atMost(Duration.ofMillis(100)).until(()->getLatestSchemaVersion(subject, currentSchemaClusterId) != null);
+      await()
+           .pollDelay(Duration.ofMillis(20))
+           .pollInterval(Duration.ofMillis(10))
+           .atMost(Duration.ofMillis(100))
+           .until(()->getLatestSchemaVersion(subject, currentSchemaClusterId) != null);
 
         return getLatestSchemaVersion(subject, currentSchemaClusterId);
     });


### PR DESCRIPTION

## Summary of Changes

Adds [awaitility DSL](http://www.awaitility.org/) to pom.xml and updated the test utility SidecarClient to use it.


## Any additional details or context that should be provided?

Addresses https://github.com/confluentinc/ide-sidecar/issues/139

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:

    - [x] Updated existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

