### PR TITLE
Consider baked-in default certs when using PEM file

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/WebClientFactory.java
@@ -95,6 +95,12 @@ public class WebClientFactory {
       if (pemTrustOptions == null) {
         pemTrustOptions = new PemTrustOptions();
       }
+      // Make sure that we don't lose access to certs baked into the native executable. On Windows,
+      // we perform this action when calling WebClientFactory#getDefaultWebClientOptions(), allowing
+      // us to skip it here.
+      if (OperatingSystemType.current() != OperatingSystemType.Windows) {
+        addCertsFromBuiltInTrustStore(pemTrustOptions);
+      }
       for (var pemPath : tlsPemPaths) {
         pemTrustOptions.addCertPath(pemPath);
       }


### PR DESCRIPTION
When using a PEM file to verify the server-side TLS certs, make sure that we do not lose access to the default certs baked into the native executable.

We do not expect this change to introduce a regression because we won't skip any certs but add a few additional ones.

Fixes https://github.com/confluentinc/vscode/issues/523

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

