### PR TITLE
Avoid potential out of memory issues with Semaphore CI/CD builds by using next larger machine

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu20-04-amd64-2
 
 auto_cancel:
   running:


### PR DESCRIPTION
Change from `s1-prod-ubuntu20-04-amd64-1` machine type (for on-prem Semaphore CI/CD) to `s1-prod-ubuntu20-04-amd64-2`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```
This change should not affect the sidecar functionality or native executable.
