### PR TITLE
Disable Apicurio in Quarkus dev services and in our tests

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -177,6 +177,9 @@ ide-sidecar:
     max-retries: 5
 
 quarkus:
+  apicurio-registry:
+    devservices:
+      enabled: false
   application:
     name: ide-sidecar
   banner:


### PR DESCRIPTION
## Summary of Changes

Some recent PR builds got an [OOM error](https://semaphore.ci.confluent.io/workflows/35edd177-dcc0-4b7f-8fd4-4e3a87fbd338/summary?pipeline_id=d340edb7-0962-43b7-bbf8-4d06405101f3&report_id=17990af8-cb17-371c-9a8e-215e0e201902&test_id=65549b00-f3e8-3f9a-afbd-a509e385e6e4) when starting the testcontainer for Apicurio. We really aren't using Apicurio and should be able to [disable the starting of this container in our tests](https://quarkus.io/guides/apicurio-registry-dev-services#enabling-disabling-dev-services-for-apicurio-registry).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```
This should affect only the tests and should not affect the sidecar functionality or native executable.
