### PR TITLE
doc: Mention SDKMAN's `sdkman_auto_env=true` [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,6 +219,8 @@ Then install GraalVM CE with SDKMAN! by running the following command in the roo
 
     sdk env install
 
+If you set `sdkman_auto_env=true` in the file `~/.sdkman/etc/config`, SDKMAN! will automatically
+switch to the SDKs specified in the `.sdkmanrc` file when you `cd` into this project's directory.
 
 #### Security and pre-commit
 


### PR DESCRIPTION
## Summary of Changes

Ask contributors to set `sdkman_auto_env=true` in the file `~/.sdkman/etc/config` so that SDKMAN! automatically switches to this project's SDKs when they `cd` into the project directory.
## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

