### PR TITLE
Evolve the schema of the Connection resource `status`

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -716,6 +716,7 @@
         }
       },
       "Authentication" : {
+        "description" : "The authentication-related status (deprecated).",
         "required" : [ "status" ],
         "type" : "object",
         "properties" : {
@@ -768,6 +769,41 @@
           }
         }
       },
+      "CCloudStatus" : {
+        "description" : "The status related to CCloud.",
+        "required" : [ "state" ],
+        "type" : "object",
+        "properties" : {
+          "state" : {
+            "description" : "The state of the connection to CCloud.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
+          },
+          "requires_authentication_at" : {
+            "description" : "If the connection's auth context holds a valid token, this attribute holds the time at which the user must re-authenticate because, for instance, the refresh token reached the end of its absolute lifetime.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Instant"
+            } ]
+          },
+          "user" : {
+            "description" : "Information about the authenticated principal, if known.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
+          },
+          "errors" : {
+            "description" : "Errors related to the connection to the Kafka cluster.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
+          }
+        }
+      },
       "CollectionMetadata" : {
         "type" : "object",
         "properties" : {
@@ -782,6 +818,10 @@
             "type" : "integer"
           }
         }
+      },
+      "ConnectedState" : {
+        "enum" : [ "NONE", "ATTEMPTING", "SUCCESS", "EXPIRED", "FAILED" ],
+        "type" : "string"
       },
       "Connection" : {
         "required" : [ "api_version", "kind", "id", "metadata", "spec", "status" ],
@@ -877,6 +917,15 @@
         "required" : [ "authentication" ],
         "type" : "object",
         "properties" : {
+          "ccloud" : {
+            "$ref" : "#/components/schemas/CCloudStatus"
+          },
+          "kafka_cluster" : {
+            "$ref" : "#/components/schemas/KafkaClusterStatus"
+          },
+          "schema_registry" : {
+            "$ref" : "#/components/schemas/SchemaRegistryStatus"
+          },
           "authentication" : {
             "$ref" : "#/components/schemas/Authentication"
           }
@@ -1089,6 +1138,34 @@
             "default" : true,
             "type" : "boolean",
             "nullable" : true
+          }
+        }
+      },
+      "KafkaClusterStatus" : {
+        "description" : "The status related to the specified Kafka cluster.",
+        "required" : [ "state" ],
+        "type" : "object",
+        "properties" : {
+          "state" : {
+            "description" : "The state of the connection to the Kafka cluster.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
+          },
+          "user" : {
+            "description" : "Information about the authenticated principal, if known.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
+          },
+          "errors" : {
+            "description" : "Errors related to the connection to the Kafka cluster.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
           }
         }
       },
@@ -1307,6 +1384,34 @@
               "$ref" : "#/components/schemas/ApiKeyAndSecret"
             } ],
             "nullable" : true
+          }
+        }
+      },
+      "SchemaRegistryStatus" : {
+        "description" : "The status related to the specified Schema Registry.",
+        "required" : [ "state" ],
+        "type" : "object",
+        "properties" : {
+          "state" : {
+            "description" : "The state of the connection to the Schema Registry.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
+          },
+          "user" : {
+            "description" : "Information about the authenticated principal, if known.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
+          },
+          "errors" : {
+            "description" : "Errors related to the connection to the Schema Registry.",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
           }
         }
       },

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -487,6 +487,7 @@ components:
         token_refresh:
           $ref: "#/components/schemas/AuthError"
     Authentication:
+      description: The authentication-related status (deprecated).
       required:
       - status
       type: object
@@ -530,6 +531,34 @@ components:
           maxLength: 36
           minLength: 36
           type: string
+    CCloudStatus:
+      description: The status related to CCloud.
+      required:
+      - state
+      type: object
+      properties:
+        state:
+          description: The state of the connection to CCloud.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
+        requires_authentication_at:
+          description: "If the connection's auth context holds a valid token, this\
+            \ attribute holds the time at which the user must re-authenticate because,\
+            \ for instance, the refresh token reached the end of its absolute lifetime."
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Instant"
+        user:
+          description: "Information about the authenticated principal, if known."
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
+        errors:
+          description: Errors related to the connection to the Kafka cluster.
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     CollectionMetadata:
       type: object
       properties:
@@ -540,6 +569,14 @@ components:
         total_size:
           format: int32
           type: integer
+    ConnectedState:
+      enum:
+      - NONE
+      - ATTEMPTING
+      - SUCCESS
+      - EXPIRED
+      - FAILED
+      type: string
     Connection:
       required:
       - api_version
@@ -615,6 +652,12 @@ components:
       - authentication
       type: object
       properties:
+        ccloud:
+          $ref: "#/components/schemas/CCloudStatus"
+        kafka_cluster:
+          $ref: "#/components/schemas/KafkaClusterStatus"
+        schema_registry:
+          $ref: "#/components/schemas/SchemaRegistryStatus"
         authentication:
           $ref: "#/components/schemas/Authentication"
     ConnectionType:
@@ -787,6 +830,27 @@ components:
           default: true
           type: boolean
           nullable: true
+    KafkaClusterStatus:
+      description: The status related to the specified Kafka cluster.
+      required:
+      - state
+      type: object
+      properties:
+        state:
+          description: The state of the connection to the Kafka cluster.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
+        user:
+          description: "Information about the authenticated principal, if known."
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
+        errors:
+          description: Errors related to the connection to the Kafka cluster.
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     LocalConfig:
       description: Configuration when using Confluent Local and optionally a local
         Schema Registry.
@@ -946,6 +1010,27 @@ components:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
           nullable: true
+    SchemaRegistryStatus:
+      description: The status related to the specified Schema Registry.
+      required:
+      - state
+      type: object
+      properties:
+        state:
+          description: The state of the connection to the Schema Registry.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
+        user:
+          description: "Information about the authenticated principal, if known."
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
+        errors:
+          description: Errors related to the connection to the Schema Registry.
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     SidecarAccessToken:
       type: object
       properties:

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
@@ -32,12 +32,12 @@ public record ConnectionStatus(
   @JsonProperty(required = true)
   public Authentication authentication() {
     if (ccloud != null) {
-    return new Authentication(
-        Status.from(ccloud.state()),
-        ccloud.requiresAuthenticationAt(),
-        ccloud.user(),
-        ccloud.errors()
-    );
+      return new Authentication(
+          Status.from(ccloud.state()),
+          ccloud.requiresAuthenticationAt(),
+          ccloud.user(),
+          ccloud.errors()
+      );
     }
     return new Authentication(Status.NO_TOKEN, null, null, null);
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
@@ -39,7 +39,7 @@ public class CCloudConnectionTest {
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
-                  assertEquals(ConnectionStatus.INITIAL_STATUS, connectionStatus);
+                  assertEquals(ConnectionStatus.INITIAL_CCLOUD_STATUS, connectionStatus);
                   testContext.completeNow();
                 })));
 

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -191,7 +191,7 @@ public class ConnectionsResourceTest {
     assertEquals(expectedSpecAsJson, treeActual.get("spec"));
 
     // Verify ConnectionStatus
-    ConnectionStatus expectedStatus = ConnectionStatus.INITIAL_STATUS;
+    ConnectionStatus expectedStatus = ConnectionStatus.INITIAL_CCLOUD_STATUS;
     JsonNode expectedStatusAsJson = asJson(expectedStatus);
     assertTrue(treeActual.has("status"));
     assertEquals(expectedStatusAsJson, treeActual.get("status"));

--- a/src/test/resources/connections/list-connections-response.json
+++ b/src/test/resources/connections/list-connections-response.json
@@ -47,6 +47,9 @@
       {
         "authentication": {
           "status": "NO_TOKEN"
+        },
+        "ccloud": {
+          "state": "NONE"
         }
       }
     }


### PR DESCRIPTION
Part 1 of 2 to address #123 

## Summary of Changes

Change the `status` object in `Connection` resources to able to represent the statuses of the different external clusters/resources that connections can define.

## Any additional details or context that should be provided?

The `ConnectionStatus` OpenAPI spec schema now looks like:
```
    ConnectionStatus:
      required:
      - authentication
      type: object
      properties:
        ccloud:
          $ref: "#/components/schemas/CCloudStatus"
        kafka_cluster:
          $ref: "#/components/schemas/KafkaClusterStatus"
        schema_registry:
          $ref: "#/components/schemas/SchemaRegistryStatus"
        authentication:
          $ref: "#/components/schemas/Authentication"
```
The `status.authentication` object is unchanged, but is being deprecated and replaced with the `status.ccloud` object. The `status.ccloud`, `status.kafka_clsuter` and `status.schema_registry` nested objects all use the `ConnectedState` enum:
```
    ConnectedState:
      enum:
      - NONE
      - ATTEMPTING
      - SUCCESS
      - EXPIRED
      - FAILED
      type: string
```
and there is a direct mapping from the older `Status` enumeration to this new enum.

The `status.authentication` object is being generated from the `status.ccloud` object, and the sidecar code has already transitioned to only using `status.ccloud`; the `status.kafka_cluster` and `status.schema_registry` objects will be set in a subsequent PR.

We will keep the `status.authentication` object for a time being, so the extension has time to migrate to the `status.ccloud`, `status.kafka_cluster` and `status.schema_registry` objects. Once that migration has been performed, we will remote the `status.authentication` object altogether, in a future PR.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

