### PR TITLE
Support `subject` and `subject_name_strategy` in Produce Records API

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
@@ -412,7 +412,7 @@ public class ClientConfigurator {
     var configs = new LinkedHashMap<>(SERDE_CONFIGS);
     configs.put(
       (isKey ? "key.subject.name.strategy" : "value.subject.name.strategy"),
-      schema.get().subjectNameStrategy().strategyClassName
+      schema.get().subjectNameStrategy().className()
     );
 
     // No need to pass SR auth properties since it will hit

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
@@ -410,13 +410,10 @@ public class ClientConfigurator {
     }
 
     var configs = new LinkedHashMap<>(SERDE_CONFIGS);
-    if (schema.get().subjectNameStrategy() != null) {
-      // Override the default
-      configs.put(
-          (isKey ? "key.subject.name.strategy" : "value.subject.name.strategy"),
-          schema.get().subjectNameStrategy().strategyClassName
-      );
-    }
+    configs.put(
+      (isKey ? "key.subject.name.strategy" : "value.subject.name.strategy"),
+      schema.get().subjectNameStrategy().strategyClassName
+    );
 
     // No need to pass SR auth properties since it will hit
     // the SR REST proxy in the sidecar, which handles any

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/ClientConfigurator.java
@@ -9,16 +9,19 @@ import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.credentials.Credentials;
 import io.confluent.idesidecar.restapi.exceptions.ClusterNotFoundException;
 import io.confluent.idesidecar.restapi.exceptions.ConnectionNotFoundException;
+import io.confluent.idesidecar.restapi.kafkarest.SchemaManager;
 import io.confluent.idesidecar.restapi.models.graph.KafkaCluster;
 import io.confluent.idesidecar.restapi.models.graph.SchemaRegistry;
 import io.confluent.idesidecar.restapi.util.CCloud;
 import io.quarkus.logging.Log;
+import io.confluent.idesidecar.restapi.util.ConfigUtil;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @ApplicationScoped
@@ -386,5 +389,38 @@ public class ClientConfigurator {
             null
         )
     );
+  }
+
+  private static final Map<String, String> SERDE_CONFIGS = ConfigUtil
+      .asMap("ide-sidecar.serde-configs");
+
+  /**
+   * Get the Kafka Serializer/Deserializer configuration for a given
+   * {@link SchemaManager.RegisteredSchema}, or the default configuration if no schema is provided.
+   * @param schema the schema to use, if present
+   * @param isKey  whether the schema is for a key or value
+   * @return the Serde configuration properties as a map
+   */
+  public Map<String, String> getSerdeConfigs(
+      Optional<SchemaManager.RegisteredSchema> schema,
+      boolean isKey
+  ) {
+    if (schema.isEmpty()) {
+      return SERDE_CONFIGS;
+    }
+
+    var configs = new LinkedHashMap<>(SERDE_CONFIGS);
+    if (schema.get().subjectNameStrategy() != null) {
+      // Override the default
+      configs.put(
+          (isKey ? "key.subject.name.strategy" : "value.subject.name.strategy"),
+          schema.get().subjectNameStrategy().strategyClassName
+      );
+    }
+
+    // No need to pass SR auth properties since it will hit
+    // the SR REST proxy in the sidecar, which handles any
+    // necessary auth.
+    return configs;
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/exceptions/ExceptionMappers.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/exceptions/ExceptionMappers.java
@@ -292,7 +292,7 @@ public class ExceptionMappers {
   public Response mapRestClientException(RestClientException exception) {
     var error = io.confluent.idesidecar.restapi.kafkarest.model.Error
         .builder()
-        .errorCode(exception.getStatus())
+        .errorCode(exception.getErrorCode())
         .message(exception.getMessage()).build();
     return Response
         .status(exception.getStatus())

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
@@ -179,14 +179,14 @@ public class RecordsV3ApiImpl {
     return combineUnis(
         () -> recordSerializer.serialize(
             c.srClient,
-            c.keySchema.map(SchemaManager.RegisteredSchema::parsedSchema).orElse(null),
+            c.keySchema,
             c.topicName,
             c.produceRequest.getKey().getData(),
             true
         ),
         () -> recordSerializer.serialize(
             c.srClient,
-            c.valueSchema.map(SchemaManager.RegisteredSchema::parsedSchema).orElse(null),
+            c.valueSchema,
             c.topicName,
             c.produceRequest.getValue().getData(),
             false

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
@@ -12,6 +12,7 @@ import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceResponse;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceResponseData;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.soabase.recordbuilder.core.RecordBuilder;
@@ -71,7 +72,17 @@ public class RecordsV3ApiImpl {
         .chain(this::getSchemas)
         .chain(this::serialize)
         .chain(this::sendSerializedRecord)
+        .onFailure(RuntimeException.class)
+        .transform(this::unwrapRootCause)
         .map(this::toProduceResponse);
+  }
+
+  private Throwable unwrapRootCause(Throwable throwable) {
+    if (throwable.getCause() instanceof RestClientException) {
+      return throwable.getCause();
+    }
+
+    return throwable;
   }
 
   /**
@@ -158,8 +169,6 @@ public class RecordsV3ApiImpl {
         // The SchemaRegistryClient uses java.net.HttpURLConnection under the hood
         // which is a synchronous I/O blocking client, so we run this on a worker pool of threads.
         .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
-        .onFailure(RuntimeException.class)
-        .transform(Throwable::getCause)
         .map(tuple -> c
             .with()
             .keySchema(tuple.getItem1())

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
@@ -36,7 +36,7 @@ public class SchemaManager {
     // If any of the other schema related fields are set, disallow the request
     // Note: We can implement support for various combinations of these fields as we see fit.
     if (!produceRequestIsValid(produceRequestData)) {
-      throw new UnsupportedOperationException(
+      throw new BadRequestException(
           "This endpoint does not support specifying "
               + "schema ID, type, schema, standalone subject or subject name strategy."
       );

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
@@ -22,6 +22,9 @@ public class SchemaManager {
       )
   );
 
+  private static final SubjectNameStrategyEnum DEFAULT_SUBJECT_NAME_STRATEGY =
+      SubjectNameStrategyEnum.TOPIC_NAME;
+
   public Optional<RegisteredSchema> getSchema(
       SchemaRegistryClient schemaRegistryClient,
       String topicName,
@@ -111,8 +114,7 @@ public class SchemaManager {
       boolean isKey
   ) {
     var schema = schemaRegistryClient.getByVersion(
-        // Note: We default to TopicNameStrategy for the subject name for the sake of simplicity.
-        (isKey ? topicName + "-key" : topicName + "-value"),
+        DEFAULT_SUBJECT_NAME_STRATEGY.subjectName(topicName, isKey, null),
         schemaVersion,
         // do not lookup deleted schemas
         false
@@ -122,7 +124,7 @@ public class SchemaManager {
 
     return new RegisteredSchema(
         schema.getSubject(),
-        SubjectNameStrategyEnum.TOPIC_NAME,
+        DEFAULT_SUBJECT_NAME_STRATEGY,
         schema.getId(),
         schema.getVersion(),
         parsedSchema

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SchemaManager.java
@@ -67,9 +67,9 @@ public class SchemaManager {
 
   private static void ensureSchemaRegistryClientExists(SchemaRegistryClient schemaRegistryClient) {
     if (schemaRegistryClient == null) {
-      throw new BadRequestException(
-          "Could not find schema registry client to fetch requested schema"
-      );
+      throw new BadRequestException("SchemaRegistryClient required but not provided. " +
+          "This connection may not have access to a Schema Registry. Please update " +
+          "the connection configuration to include a Schema Registry.");
     }
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SubjectNameStrategyEnum.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SubjectNameStrategyEnum.java
@@ -1,22 +1,24 @@
 package io.confluent.idesidecar.restapi.kafkarest;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 
 import java.util.Optional;
 
 public enum SubjectNameStrategyEnum {
-  TOPIC_NAME("topic_name", TopicNameStrategy.class.getName()),
-  TOPIC_RECORD_NAME("topic_record_name", TopicRecordNameStrategy.class.getName()),
-  RECORD_NAME("record_name", RecordNameStrategy.class.getName());
+  TOPIC_NAME("topic_name", new TopicNameStrategy()),
+  TOPIC_RECORD_NAME("topic_record_name", new TopicRecordNameStrategy()),
+  RECORD_NAME("record_name", new RecordNameStrategy());
 
   private final String value;
-  public final String strategyClassName;
+  private final SubjectNameStrategy strategy;
 
-  SubjectNameStrategyEnum(String value, String strategyClassName) {
+  SubjectNameStrategyEnum(String value, SubjectNameStrategy strategy) {
     this.value = value;
-    this.strategyClassName = strategyClassName;
+    this.strategy = strategy;
   }
 
   public static Optional<SubjectNameStrategyEnum> parse(String subjectNameStrategy) {
@@ -26,5 +28,15 @@ public enum SubjectNameStrategyEnum {
       }
     }
     return Optional.empty();
+  }
+
+  public String className() {
+    return strategy.getClass().getName();
+  }
+
+  public String subjectName(
+      String topic, boolean isKey, ParsedSchema schema
+  ) {
+    return strategy.subjectName(topic, isKey, schema);
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SubjectNameStrategyEnum.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/SubjectNameStrategyEnum.java
@@ -1,0 +1,30 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import io.confluent.kafka.serializers.subject.RecordNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
+
+import java.util.Optional;
+
+public enum SubjectNameStrategyEnum {
+  TOPIC_NAME("topic_name", TopicNameStrategy.class.getName()),
+  TOPIC_RECORD_NAME("topic_record_name", TopicRecordNameStrategy.class.getName()),
+  RECORD_NAME("record_name", RecordNameStrategy.class.getName());
+
+  private final String value;
+  public final String strategyClassName;
+
+  SubjectNameStrategyEnum(String value, String strategyClassName) {
+    this.value = value;
+    this.strategyClassName = strategyClassName;
+  }
+
+  public static Optional<SubjectNameStrategyEnum> parse(String subjectNameStrategy) {
+    for (var r : SubjectNameStrategyEnum.values()) {
+      if (r.value.equalsIgnoreCase(subjectNameStrategy)) {
+        return Optional.of(r);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
@@ -202,12 +202,12 @@ class RecordsV3ApiImplIT {
       createSchema(
           "%s-key".formatted(topic),
           "JSON",
-          loadResource("schemas/product.schema.json")
+          loadResource("schemas/product-key.schema.json")
       );
       createSchema(
           "%s-value".formatted(topic),
           "PROTOBUF",
-          loadResource("schemas/product.proto")
+          loadResource("schemas/product-value.proto")
       );
       // Schema version 1 would be created by the above calls,
       // but the following call should fail to find version 40

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
@@ -2,6 +2,9 @@ package io.confluent.idesidecar.restapi.kafkarest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
+import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequestData;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequestBuilder;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
@@ -18,6 +21,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.cartesian.ArgumentSets;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -37,37 +41,70 @@ class RecordsV3ApiImplIT {
 
   record RecordData(
       SchemaFormat schemaFormat,
+      SubjectNameStrategyEnum subjectNameStrategy,
       String rawSchema,
       Object data
   ) {
 
+    public RecordData(SchemaFormat schemaFormat, String rawSchema, Object data) {
+      this(schemaFormat, null, rawSchema, data);
+    }
+
+    RecordData withSubjectNameStrategy(SubjectNameStrategyEnum subjectNameStrategy) {
+      return new RecordData(schemaFormat, subjectNameStrategy, rawSchema, data);
+    }
+
     @Override
     public String toString() {
-      return "(data = %s, schemaFormat = %s, schema = %s)"
-          .formatted(data, schemaFormat, rawSchema);
+      return "(data = %s, schemaFormat = %s, subjectNameStrategy = %s)"
+          .formatted(data, schemaFormat, subjectNameStrategy);
+    }
+
+    public boolean hasSchema() {
+      return schemaFormat != null && rawSchema != null && subjectNameStrategy != null;
     }
   }
 
-  static RecordData schemaData(SchemaFormat format, String jsonData) {
-    var schema = getProductSchema(format);
+  private static String getSubjectName(
+      String topicName,
+      SubjectNameStrategyEnum strategy,
+      boolean isKey
+  ) {
+    /*
+    https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#how-the-naming-strategies-work
+    */
+    return switch (strategy) {
+      case TOPIC_NAME -> (isKey ? "%s-key" : "%s-value").formatted(topicName);
+      case RECORD_NAME -> (isKey ? "ProductKey" : "ProductValue");
+      case TOPIC_RECORD_NAME -> (isKey ? "%s-ProductKey" : "%s-ProductValue").formatted(topicName);
+    };
+  }
+
+  static RecordData schemaData(SchemaFormat format, Boolean isKey) {
+    var schema = getProductSchema(format, isKey);
 
     try {
-      return new RecordData(format, schema, OBJECT_MAPPER.readTree(jsonData));
+      return new RecordData(
+          format,
+          schema,
+          OBJECT_MAPPER.readTree(HappyPath.PRODUCT_DATA)
+      );
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  private static String getProductSchema(SchemaFormat format) {
+  private static String getProductSchema(SchemaFormat format, boolean isKey) {
+    var suffix = isKey ? "key" : "value";
     return switch (format) {
       case JSON: {
-        yield loadResource("schemas/product.schema.json").translateEscapes();
+        yield loadResource("schemas/product-%s.schema.json".formatted(suffix)).translateEscapes();
       }
       case AVRO: {
-        yield loadResource("schemas/product.avsc").translateEscapes();
+        yield loadResource("schemas/product-%s.avsc".formatted(suffix)).translateEscapes();
       }
       case PROTOBUF: {
-        yield loadResource("schemas/product.proto").translateEscapes();
+        yield loadResource("schemas/product-%s.proto".formatted(suffix)).translateEscapes();
       }
     };
   }
@@ -234,7 +271,7 @@ class RecordsV3ApiImplIT {
       var keySchema = createSchema(
           "%s-key".formatted(topic),
           keyFormat.schemaProvider().schemaType(),
-          getProductSchema(keyFormat)
+          getProductSchema(keyFormat, true)
       );
 
       produceRecordThen(
@@ -245,7 +282,7 @@ class RecordsV3ApiImplIT {
       var valueSchema = createSchema(
           "%s-value".formatted(topic),
           keyFormat.schemaProvider().schemaType(),
-          getProductSchema(keyFormat)
+          getProductSchema(keyFormat, false)
       );
 
       produceRecordThen(
@@ -303,7 +340,7 @@ class RecordsV3ApiImplIT {
 
   abstract class HappyPath extends AbstractSidecarIT {
 
-    private static RecordData jsonData(Object data) {
+    private static RecordData schemalessData(Object data) {
       return new RecordData(null, null, data);
     }
 
@@ -316,17 +353,32 @@ class RecordsV3ApiImplIT {
       }
       """;
 
-    private final static List<RecordData> RECORD_DATA_VALUES = List.of(
-        jsonData(null),
-        jsonData("hello"),
-        jsonData(123),
-        jsonData(123.45),
-        jsonData(true),
-        jsonData(List.of("hello", "world")),
-        jsonData(Collections.singletonMap("hello", "world")),
-        schemaData(SchemaFormat.JSON, PRODUCT_DATA),
-        schemaData(SchemaFormat.PROTOBUF, PRODUCT_DATA),
-        schemaData(SchemaFormat.AVRO, PRODUCT_DATA)
+    /**
+     * Generate cartesian product of all schema formats and subject name strategies.
+     * @param isKey whether the schema is for a key or value. This changes the schema name.
+     * @return the list of all possible schema data
+     */
+    private static List<RecordData> getSchemaData(boolean isKey) {
+      return Lists.cartesianProduct(
+              Arrays.stream(SchemaFormat.values()).toList(),
+              Arrays.stream(SubjectNameStrategyEnum.values()).toList())
+          .stream()
+          .map(t ->
+              schemaData(
+                  (SchemaFormat) t.getFirst(), isKey
+              ).withSubjectNameStrategy((SubjectNameStrategyEnum) t.getLast())
+          )
+          .toList();
+    }
+
+    private final static List<RecordData> SCHEMALESS_RECORD_DATA_VALUES = List.of(
+        schemalessData(null),
+        schemalessData("hello"),
+        schemalessData(123),
+        schemalessData(123.45),
+        schemalessData(true),
+        schemalessData(List.of("hello", "world")),
+        schemalessData(Collections.singletonMap("hello", "world"))
     );
 
     /**
@@ -335,8 +387,20 @@ class RecordsV3ApiImplIT {
      */
     static ArgumentSets validKeysAndValues() {
       return ArgumentSets
-          .argumentsForFirstParameter(RECORD_DATA_VALUES)
-          .argumentsForNextParameter(RECORD_DATA_VALUES);
+          // Key
+          .argumentsForFirstParameter(
+              Stream.concat(
+                  SCHEMALESS_RECORD_DATA_VALUES.stream(),
+                  getSchemaData(true).stream()
+              )
+          )
+          // Value
+          .argumentsForNextParameter(
+              Stream.concat(
+                  SCHEMALESS_RECORD_DATA_VALUES.stream(),
+                  getSchemaData(false).stream()
+              )
+          );
     }
 
     private static void assertSame(JsonNode actual, Object expected) {
@@ -359,21 +423,23 @@ class RecordsV3ApiImplIT {
       createTopic(topicName);
 
       Schema keySchema = null, valueSchema = null;
+      String keySubject = null, valueSubject = null;
 
-      // Use TopicNameStrategy by default for subject names
       // Create key schema if not null
-      if (key.rawSchema() != null) {
+      if (key.hasSchema()) {
+        keySubject = getSubjectName(topicName, key.subjectNameStrategy(), true);
         keySchema = createSchema(
-            topicName + "-key",
+            keySubject,
             key.schemaFormat().name(),
             key.rawSchema()
         );
       }
 
       // Create value schema if not null
-      if (value.rawSchema() != null) {
+      if (value.hasSchema()) {
+        valueSubject = getSubjectName(topicName, value.subjectNameStrategy(), false);
         valueSchema = createSchema(
-            topicName + "-value",
+            valueSubject,
             value.schemaFormat().name(),
             value.rawSchema()
         );
@@ -381,12 +447,33 @@ class RecordsV3ApiImplIT {
 
       // Produce record to topic
       var resp = produceRecordThen(
-          null,
           topicName,
-          key.data(),
-          Optional.ofNullable(keySchema).map(Schema::getVersion).orElse(null),
-          value.data(),
-          Optional.ofNullable(valueSchema).map(Schema::getVersion).orElse(null)
+          ProduceRequest
+              .builder()
+              .partitionId(null)
+              .key(
+                  ProduceRequestData
+                      .builder()
+                      .schemaVersion(Optional.ofNullable(keySchema).map(Schema::getVersion).orElse(null))
+                      .data(key.data())
+                      .subject(keySubject)
+                      .subjectNameStrategy(
+                          Optional.ofNullable(key.subjectNameStrategy).map(Enum::toString).orElse(null)
+                      )
+                      .build()
+              )
+              .value(
+                  ProduceRequestData
+                      .builder()
+                      .schemaVersion(Optional.ofNullable(valueSchema).map(Schema::getVersion).orElse(null))
+                      .data(value.data())
+                      .subject(valueSubject)
+                      .subjectNameStrategy(
+                          Optional.ofNullable(value.subjectNameStrategy).map(Enum::toString).orElse(null)
+                      )
+                      .build()
+              )
+              .build()
       );
 
       if (key.data() != null || value.data() != null) {

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImplIT.java
@@ -381,7 +381,7 @@ class RecordsV3ApiImplIT {
               .value(data)
               .build()
       )
-          .statusCode(501)
+          .statusCode(400)
           .body("message", equalTo(
               "This endpoint does not support specifying schema ID, type, schema, standalone subject or subject name strategy."
           ));

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3ApiImplIT.java
@@ -26,8 +26,6 @@ abstract class TopicV3ApiImplIT extends AbstractSidecarIT {
         .statusCode(200)
         // Could be at any index
         .body("data.find { it.topic_name == 'test-topic-1' }.topic_name", equalTo("test-topic-1"));
-
-    deleteTopic("test-topic-1");
   }
 
   @Test
@@ -80,8 +78,6 @@ abstract class TopicV3ApiImplIT extends AbstractSidecarIT {
         .statusCode(409)
         .body("error_code", equalTo(409))
         .body("message", equalTo("Topic 'test-topic-2' already exists."));
-
-    deleteTopic("test-topic-2");
   }
 
   @Test

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -430,6 +430,18 @@ public class SidecarClient {
     );
   }
 
+  public ValidatableResponse produceRecordThen(
+      String topicName,
+      ProduceRequest request
+  ) {
+    return fromCluster(currentKafkaClusterId, () ->
+        givenDefault()
+            .body(request)
+            .post("/kafka/v3/clusters/{cluster_id}/topics/%s/records".formatted(topicName))
+            .then()
+    );
+  }
+
   public ProduceRequest createProduceRequest(
       Integer partitionId,
       Object key,

--- a/src/test/resources/schemas/product-key.avsc
+++ b/src/test/resources/schemas/product-key.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "ProductKey",
+  "fields": [
+    {"name": "id", "type": "int"},
+    {"name": "name", "type": "string"},
+    {"name": "price", "type": "double"},
+    {"name": "tags", "type": {"type": "array", "items": "string"}}
+  ]
+}

--- a/src/test/resources/schemas/product-key.proto
+++ b/src/test/resources/schemas/product-key.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message ProductKey {
+  int32 id = 1;
+  string name = 2;
+  double price = 3;
+  repeated string tags = 4;
+}

--- a/src/test/resources/schemas/product-key.schema.json
+++ b/src/test/resources/schemas/product-key.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "title": "ProductKey",
   "properties": {
     "id": { "type": "integer" },
     "name": { "type": "string" },

--- a/src/test/resources/schemas/product-value.avsc
+++ b/src/test/resources/schemas/product-value.avsc
@@ -1,7 +1,6 @@
 {
   "type": "record",
-  "name": "Product",
-  "namespace": "example.avro",
+  "name": "ProductValue",
   "fields": [
     {"name": "id", "type": "int"},
     {"name": "name", "type": "string"},

--- a/src/test/resources/schemas/product-value.proto
+++ b/src/test/resources/schemas/product-value.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-message Product {
+message ProductValue {
   int32 id = 1;
   string name = 2;
   double price = 3;

--- a/src/test/resources/schemas/product-value.schema.json
+++ b/src/test/resources/schemas/product-value.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "ProductValue",
+  "properties": {
+    "id": { "type": "integer" },
+    "name": { "type": "string" },
+    "price": { "type": "number" },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["id", "name", "price"]
+}


### PR DESCRIPTION
Resolves #111 

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- A new method `ClientConfigurator.getSerdeConfigs` holds logic for constructing SerDe configs from an `Optional<RegisteredSchema>`. 
- `SchemaManager.getSchema` was refactored to support the combination of (`schema_version`, `subject` and `subjectNameStrategy`) specified for a key/value schema.
- Existing happy path test for producing all sorts of key/value was updated. It additionally tests (all schema formats X all subject name strategies X isKey={true, false}) -- where X is cartesian product.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Changes made to the Produce Records API:

### Before

Only `schema_version` could be specified for the key or value schema, and the subject name strategy was "hardcoded" to the default of `TopicNameStrategy`. 

Example payload:

```
curl http://localhost:26636/kafka/v3/clusters/foo-cluster/topics/foo-topic/records \
-H "Authorization: Bearer <dtx-access-token>" \
-H "X-connection-id: whatever" \
-d '
{
  "key": {
     "data": 123
  },
  "value": {
    "schema_version": 2,
    "data":  {
      "ordertime": 1505510136717,
      "orderid": 1238,
      "itemid": "Item_92",
      "orderunits": 6.302653935989815,
      "address": {
        "city": "City_",
        "state": "State_47",
        "zipcode": 91197
      }
    }
  }
}
'
```


### After

Along with `schema_version`, clients can now also pass `subject` and `subject_name_strategy` (must be set together) to use any subject name strategy for the key or value schema.

Example payload:

```
curl http://localhost:26636/kafka/v3/clusters/foo-cluster/topics/foo-topic/records \
-H "Authorization: Bearer <dtx-access-token>" \
-H "X-connection-id: whatever" \
-d '
{
  "key": {
     "data": 123
  },
  "value": {
    "schema_version": 2,
    "subject": "foo-topic-io.confluent.MyAvroSchema",
    "subject_name_strategy": "topic_record_name",
    "data":  {
      "ordertime": 1505510136717,
      "orderid": 1238,
      "itemid": "Item_92",
      "orderunits": 6.302653935989815,
      "address": {
        "city": "City_",
        "state": "State_47",
        "zipcode": 91197
      }
    }
  }
}
'
```

Important: If only the `schema_version` is specified, the sidecar continues to assume default subject name strategy of `TopicNameStrategy`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

