### PR TITLE
Populate the status for direct connections and ensure Kafka and SR proxies use credentials in headers

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/application/ReflectionConfiguration.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/application/ReflectionConfiguration.java
@@ -6,8 +6,17 @@ import com.sun.security.auth.module.KeyStoreLoginModule;
 import io.confluent.idesidecar.scaffolding.models.TemplateManifest;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ExtendedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Mode;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
@@ -82,7 +91,18 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
         OAuthBearerUnsecuredValidatorCallbackHandler.class,
         OAuthBearerUnsecuredLoginCallbackHandler.class,
         SaslClientCallbackHandler.class,
-        ScramServerCallbackHandler.class
+        ScramServerCallbackHandler.class,
+        // Schema Registry client classes that are not registered in
+        // https://github.com/quarkusio/quarkus/blob/3.16.3/extensions/schema-registry/confluent/common/deployment/src/main/java/io/quarkus/confluent/registry/common/ConfluentRegistryClientProcessor.java
+        Mode.class,
+        ExtendedSchema.class,
+        Rule.class,
+        RuleKind.class,
+        RuleMode.class,
+        RuleSet.class,
+        SchemaEntity.class,
+        SchemaTags.class,
+        SchemaRegistryServerVersion.class,
     }
 )
 public class ReflectionConfiguration {

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/AdminClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/AdminClients.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.restapi.cache;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -34,9 +35,15 @@ public class AdminClients extends Clients<AdminClient> {
         clusterId,
         () -> {
           // Generate the Kafka admin client configuration
-          var config = configurator.getAdminClientConfig(connectionId, clusterId, false);
+          var config = configurator.getAdminClientConfig(connectionId, clusterId);
+          Log.debugf(
+              "Creating schema registry client for connection %s and cluster %s with configuration:\n  %s",
+              connectionId,
+              clusterId,
+              config
+          );
           // Create the admin client
-          return AdminClient.create(config);
+          return AdminClient.create(config.asMap());
         }
     );
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/ClusterCache.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/ClusterCache.java
@@ -395,8 +395,7 @@ public class ClusterCache {
         // It's not found, so try to load it
         var newCluster = loadKafkaCluster(kafkaClusterId, loadTimeout);
         if (newCluster != null) {
-          result = add(newCluster);
-          return result;
+          return add(newCluster);
         }
       }
       if (result == null) {
@@ -439,7 +438,7 @@ public class ClusterCache {
         // Try and load the schema registry for this connection
         var registry = loadSchemaRegistryWithId(id, loadTimeout);
         if (registry != null) {
-          add(registry);
+          return add(registry);
         }
       }
       if (result == null) {
@@ -465,7 +464,7 @@ public class ClusterCache {
       }
       var info = new ClusterInfo<SchemaRegistry>(
           registry.id(),
-          ClusterType.KAFKA,
+          ClusterType.SCHEMA_REGISTRY,
           registry,
           path
       );

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/KafkaProducerClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/KafkaProducerClients.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.restapi.cache;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -29,11 +30,16 @@ public class KafkaProducerClients extends Clients<KafkaProducer<byte[], byte[]>>
           var config = configurator.getProducerClientConfig(
               connectionId,
               clusterId,
-              true,
-              false
+              true
           );
           // Create the producer
-          return new KafkaProducer<>(config, BYTE_ARRAY_SERIALIZER, BYTE_ARRAY_SERIALIZER);
+          Log.debugf(
+              "Creating producer client for connection %s and cluster %s with configuration:\n  %s",
+              connectionId,
+              clusterId,
+              config
+          );
+          return new KafkaProducer<>(config.asMap(), BYTE_ARRAY_SERIALIZER, BYTE_ARRAY_SERIALIZER);
         }
     );
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClients.java
@@ -7,6 +7,7 @@ import io.confluent.idesidecar.restapi.application.SidecarAccessTokenBean;
 import io.confluent.idesidecar.restapi.util.RequestHeadersConstants;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
@@ -46,8 +47,7 @@ public class SchemaRegistryClients extends Clients<SchemaRegistryClient> {
           // Generate the Schema Registry client configuration
           var config = configurator.getSchemaRegistryClientConfig(
               connectionId,
-              clusterId,
-              false
+              clusterId
           );
           var headers = Map.of(
               RequestHeadersConstants.CONNECTION_ID_HEADER, connectionId,
@@ -55,7 +55,15 @@ public class SchemaRegistryClients extends Clients<SchemaRegistryClient> {
               AUTHORIZATION, "Bearer %s".formatted(accessTokenBean.getToken())
           );
           // Create the Schema Registry client
-          return createClient(sidecarHost, config, headers);
+          var client = createClient(sidecarHost, config.asMap(), headers);
+          Log.debugf(
+              "Created SR client %s for connection %s and cluster %s with configuration:\n  %s",
+              client,
+              connectionId,
+              clusterId,
+              config
+          );
+          return client;
         });
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -99,10 +99,9 @@ public abstract class ConnectionState {
   /**
    * Get the Kafka connection options for the Kafka cluster with the supplied ID.
    *
-   * @param clusterId the ID of the Kafka cluster
    * @return the connection options; never null
    */
-  public KafkaConnectionOptions getKafkaConnectionOptions(String clusterId) {
+  public KafkaConnectionOptions getKafkaConnectionOptions() {
     if (spec.kafkaClusterConfig() != null) {
       return new KafkaConnectionOptions(
           spec.kafkaClusterConfig().sslOrDefault(),
@@ -120,22 +119,20 @@ public abstract class ConnectionState {
   /**
    * Get the {@link Credentials} for the Kafka cluster with the supplied ID.
    *
-   * @param clusterId the Kafka cluster ID
    * @return the credentials or empty if the cluster ID is not known or
    *         the cluster requires no credentials
    */
-  public Optional<Credentials> getKafkaCredentials(String clusterId) {
+  public Optional<Credentials> getKafkaCredentials() {
     return Optional.empty();
   }
 
   /**
    * Get the {@link Credentials} for the Schema Registry with the supplied ID.
    *
-   * @param clusterId the Kafka cluster ID
    * @return the credentials or empty if the cluster ID is not known or
    *         the cluster requires no credentials
    */
-  public Optional<Credentials> getSchemaRegistryCredentials(String clusterId) {
+  public Optional<Credentials> getSchemaRegistryCredentials() {
     return Optional.empty();
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -1,14 +1,30 @@
 package io.confluent.idesidecar.restapi.connections;
 
+import io.confluent.idesidecar.restapi.auth.AuthErrors;
+import io.confluent.idesidecar.restapi.cache.ClientConfigurator;
 import io.confluent.idesidecar.restapi.credentials.Credentials;
+import io.confluent.idesidecar.restapi.models.ClusterType;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.KafkaClusterStatus;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.SchemaRegistryStatus;
+import io.confluent.idesidecar.restapi.models.ConnectionStatusBuilder;
+import io.confluent.idesidecar.restapi.models.ConnectionStatusKafkaClusterStatusBuilder;
+import io.confluent.idesidecar.restapi.models.ConnectionStatusSchemaRegistryStatusBuilder;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.smallrye.common.constraint.NotNull;
 import io.smallrye.common.constraint.Nullable;
+import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
 
 /**
  * Implementation of the connection state for ({@link ConnectionType#DIRECT} connections where the
@@ -27,9 +43,23 @@ public class DirectConnectionState extends ConnectionState {
     super(spec, listener);
   }
 
-  public MultiMap getAuthenticationHeaders() {
-    // Direct connections do not require authentication headers
-    return HttpHeaders.headers();
+  public MultiMap getAuthenticationHeaders(ClusterType clusterType) {
+    var headers = HttpHeaders.headers();
+    var credentials = switch (clusterType) {
+      case KAFKA ->
+          spec.kafkaClusterConfig() != null
+          ? spec.kafkaClusterConfig().credentials()
+          : null;
+      case SCHEMA_REGISTRY ->
+          spec.schemaRegistryConfig() != null
+          ? spec.schemaRegistryConfig().credentials()
+          : null;
+      default -> null;
+    };
+    if (credentials != null) {
+      credentials.httpClientHeaders().ifPresent(map -> map.forEach(headers::add));
+    }
+    return headers;
   }
 
   @Override
@@ -48,5 +78,126 @@ public class DirectConnectionState extends ConnectionState {
     return Optional.ofNullable(credentials);
   }
 
-  // TODO: DIRECT connections need validation checks
+  @Override
+  public Future<ConnectionStatus> getConnectionStatus() {
+    return Future.join(
+        getKafkaConnectionStatus(),
+        getSchemaRegistryConnectionStatus()
+    ).map(cf -> {
+      var futures = cf.list();
+      var kafkaStatus = (KafkaClusterStatus) futures.get(0);
+      var srStatus = (SchemaRegistryStatus) futures.get(1);
+      return ConnectionStatusBuilder
+          .builder()
+          .kafkaCluster(kafkaStatus)
+          .schemaRegistry(srStatus)
+          .build();
+    });
+  }
+
+  protected Future<KafkaClusterStatus> getKafkaConnectionStatus() {
+    var kafkaConfig = spec.kafkaClusterConfig();
+    if (kafkaConfig == null) {
+      return Future.succeededFuture(
+          ConnectionStatusKafkaClusterStatusBuilder
+              .builder()
+              .state(ConnectedState.NONE)
+              .build()
+      );
+    }
+    // There is a Kafka configuration, so validate the connection by creating an AdminClient
+    // and describing the cluster.
+    try (var adminClient = createAdminClient(kafkaConfig)) {
+      var clusterDesc = adminClient.describeCluster();
+      var actualClusterId = clusterDesc.clusterId().get(5, TimeUnit.SECONDS);
+      // Set the cluster ID
+      getSpec().kafkaClusterConfig().withId(actualClusterId);
+      return Future.succeededFuture(
+          ConnectionStatusKafkaClusterStatusBuilder
+              .builder()
+              .state(ConnectedState.SUCCESS)
+              .build()
+      );
+    } catch (Exception e) {
+      // The connection failed, so successfully return the failed state
+      return Future.succeededFuture(
+          ConnectionStatusKafkaClusterStatusBuilder
+              .builder()
+              .state(ConnectedState.FAILED)
+              .errors(
+                  new AuthErrors().withSignIn(
+                      "Failed to connect to Kafka cluster: %s".formatted(e.getMessage())
+                  )
+              ).build()
+      );
+    }
+  }
+
+  protected Future<SchemaRegistryStatus> getSchemaRegistryConnectionStatus() {
+
+    var schemaRegistryConfig = spec.schemaRegistryConfig();
+    if (schemaRegistryConfig == null) {
+      return Future.succeededFuture(
+          ConnectionStatusSchemaRegistryStatusBuilder
+              .builder()
+              .state(ConnectedState.NONE)
+              .build()
+      );
+    }
+    // There is a Schema Registry configuration, so validate the connection by creating a
+    // SchemaRegistryClient and getting the mode.
+    try (var srClient = createSchemaRegistryClient(schemaRegistryConfig)) {
+      srClient.getMode();
+      return Future.succeededFuture(
+          ConnectionStatusSchemaRegistryStatusBuilder
+              .builder()
+              .state(ConnectedState.SUCCESS)
+              .build()
+      );
+    } catch (Exception e) {
+      // The connection failed, so successfully return the failed state
+      return Future.succeededFuture(
+          ConnectionStatusSchemaRegistryStatusBuilder
+              .builder()
+              .state(ConnectedState.FAILED)
+              .errors(
+                  new AuthErrors().withSignIn(
+                      "Failed to connect to Schema Registry: %s".formatted(e.getMessage())
+                  )
+              ).build()
+      );
+    }
+  }
+
+  AdminClient createAdminClient(
+      ConnectionSpec.KafkaClusterConfig config
+  ) {
+    // Create the configuration for an AdminClient
+    var adminConfig = ClientConfigurator.getKafkaClientConfig(
+        this,
+        "temporary-kafka-id",
+        config.bootstrapServers(),
+        null,
+        null,
+        false,
+        Map.of()
+    );
+    return AdminClient.create(adminConfig);
+  }
+
+  SchemaRegistryClient createSchemaRegistryClient(
+      ConnectionSpec.SchemaRegistryConfig config
+  ) {
+    var srClientConfig = ClientConfigurator.getSchemaRegistryClientConfig(
+        this,
+        "temporary-sr-id",
+        config.uri(),
+        false
+    );
+    return new CachedSchemaRegistryClient(
+        Collections.singletonList(config.uri()),
+        10,
+        srClientConfig
+    );
+  }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
@@ -106,7 +106,7 @@ public record ApiKeyAndSecret(
     var headers = MultiMap.caseInsensitiveMultiMap();
     if (key != null || secret != null) {
       // base64 encode the username and password
-      var value = "%s:%s".formatted(key, secret.asCharArray());
+      var value = "%s:%s".formatted(key, secret.asString());
       value = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
       headers.add(AUTHORIZATION, "Basic %s".formatted(value));
     }

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
@@ -101,7 +101,7 @@ public record BasicCredentials(
     var headers = MultiMap.caseInsensitiveMultiMap();
     if (username != null || password != null) {
       // base64 encode the username and password
-      var value = "%s:%s".formatted(username, password.asCharArray());
+      var value = "%s:%s".formatted(username, password.asString());
       value = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
       headers.add(AUTHORIZATION, "Basic %s".formatted(value));
     }

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/Redactable.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/Redactable.java
@@ -68,7 +68,7 @@ public abstract class Redactable {
    */
   @JsonIgnore
   public final String asString() {
-    return new String(this.asCharArray());
+    return new String(raw);
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/KafkaConsumerFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/KafkaConsumerFactory.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.restapi.messageviewer;
 
 import io.confluent.idesidecar.restapi.cache.ClientConfigurator;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Properties;
@@ -31,13 +32,18 @@ public class KafkaConsumerFactory {
     var config = configurator.getConsumerClientConfig(
         connectionId,
         clusterId,
-        false,
         false
     );
     // And apply the overrides
     configOverrides.forEach((key, value) -> config.put(key.toString(), value.toString()));
 
+    Log.debugf(
+        "Creating consumer for connection %s and cluster %s with configuration:\n  %s",
+        connectionId,
+        clusterId,
+        config
+    );
     // And create the consumer
-    return new KafkaConsumer<>(config, BYTE_ARRAY_DESERIALIZER, BYTE_ARRAY_DESERIALIZER);
+    return new KafkaConsumer<>(config.asMap(), BYTE_ARRAY_DESERIALIZER, BYTE_ARRAY_DESERIALIZER);
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -16,6 +16,7 @@ import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
 import io.confluent.idesidecar.restapi.util.CCloud.KafkaEndpoint;
 import io.confluent.idesidecar.restapi.util.CCloud.SchemaRegistryEndpoint;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.soabase.recordbuilder.core.RecordBuilder;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Size;
@@ -30,6 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "The connection details that can be set or changed.")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RecordBuilder
 public record ConnectionSpec(
     @Schema(description = "The unique identifier of the connection resource.")
     @Size(min = 1, max = 64)
@@ -48,7 +50,7 @@ public record ConnectionSpec(
     @JsonProperty(KAFKA_CLUSTER_CONFIG_FIELD_NAME) KafkaClusterConfig kafkaClusterConfig,
     @Schema(description = "The details for connecting to a Schema Registry.")
     @JsonProperty(SCHEMA_REGISTRY_CONFIG_FIELD_NAME) SchemaRegistryConfig schemaRegistryConfig
-) {
+) implements ConnectionSpecBuilder.With {
 
   public static final String CCLOUD_CONFIG_FIELD_NAME = "ccloud_config";
   public static final String LOCAL_CONFIG_FIELD_NAME = "local_config";
@@ -274,6 +276,7 @@ public record ConnectionSpec(
 
   @Schema(description = "Kafka cluster configuration.")
   @RegisterForReflection
+  @RecordBuilder
   public record KafkaClusterConfig(
       @Schema(description = "The identifier of the Kafka cluster, if known.")
       @Null
@@ -320,7 +323,7 @@ public record ConnectionSpec(
       @JsonProperty(value = "verify_ssl_certificates")
       @Null
       Boolean verifySslCertificates
-  ) {
+  ) implements ConnectionSpecKafkaClusterConfigBuilder.With {
 
     // Constants used in annotations above
     private static final int ID_MAX_LEN = 64;
@@ -384,6 +387,7 @@ public record ConnectionSpec(
 
   @Schema(description = "Schema Registry configuration.")
   @RegisterForReflection
+  @RecordBuilder
   public record SchemaRegistryConfig(
       @Schema(description = "The identifier of the Schema Registry cluster, if known.")
       @Null
@@ -407,7 +411,8 @@ public record ConnectionSpec(
       )
       @Null
       Credentials credentials
-  ) {
+  ) implements ConnectionSpecSchemaRegistryConfigBuilder.With {
+
     private static final int ID_MAX_LEN = 64;
     private static final int URI_MAX_LEN = 256;
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/ConfluentRestClient.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/ConfluentRestClient.java
@@ -220,7 +220,7 @@ public abstract class ConfluentRestClient {
    * If the response is paginated, this stream will continue to get additional pages as
    * needed until there are no more results or the supplied limits are reached.
    *
-   * @param connectionId   the ID of the connection to use
+   * @param headers        the headers to use for the request
    * @param firstUrl       the URL of the first page of Confluent API resources
    * @param limits         the page limits; may be null if there are no limits
    * @param responseParser the parser for the items on the page
@@ -228,13 +228,12 @@ public abstract class ConfluentRestClient {
    * @return the stream of items
    */
   protected <T> Multi<T> listItems(
-      String connectionId,
+      MultiMap headers,
       String firstUrl,
       PageLimits limits,
       ListParser<T> responseParser
   ) {
     try {
-      MultiMap headers = headersFor(connectionId);
       return Multi
           .createBy()
           .repeating()
@@ -262,18 +261,17 @@ public abstract class ConfluentRestClient {
   /**
    * Get the Confluent API resource at the given URL.
    *
-   * @param connectionId   the ID of the connection to use
+   * @param headers        the headers to use for the request
    * @param responseParser the parser for the items on the page
    * @param <T>            the type of items being returned
    * @return the item
    */
   protected <T> Uni<T> getItem(
-      String connectionId,
+      MultiMap headers,
       String url,
       ItemParser<T> responseParser
   ) {
     try {
-      MultiMap headers = headersFor(connectionId);
       var response = webClientFactory
           .getWebClient()
           .getAbs(url)

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ClusterStrategyProcessor.java
@@ -59,16 +59,19 @@ public class ClusterStrategyProcessor extends
 
   public ClusterStrategy chooseStrategy(
       ClusterType clusterType, ConnectionType connectionType) {
-    return switch (connectionType) {
-      case CCLOUD -> clusterType == ClusterType.KAFKA
-          ? confluentCloudKafkaClusterStrategy : confluentCloudSchemaRegistryClusterStrategy;
-      case LOCAL ->
-          clusterType == ClusterType.KAFKA
-              ? confluentLocalKafkaClusterStrategy : confluentLocalSchemaRegistryClusterStrategy;
-      case DIRECT ->
-          clusterType == ClusterType.KAFKA
-          ? directKafkaClusterStrategy : directSchemaRegistryClusterStrategy;
-      case PLATFORM -> null;
+    return switch(clusterType) {
+      case KAFKA -> switch (connectionType) {
+        case CCLOUD -> confluentCloudKafkaClusterStrategy;
+        case LOCAL -> confluentLocalKafkaClusterStrategy;
+        case DIRECT -> directKafkaClusterStrategy;
+        case PLATFORM -> null;
+      };
+      case SCHEMA_REGISTRY -> switch (connectionType) {
+        case CCLOUD -> confluentCloudSchemaRegistryClusterStrategy;
+        case LOCAL -> confluentLocalSchemaRegistryClusterStrategy;
+        case DIRECT -> directSchemaRegistryClusterStrategy;
+        case PLATFORM -> null;
+      };
     };
   }
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectSchemaRegistryClusterStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/strategy/DirectSchemaRegistryClusterStrategy.java
@@ -1,11 +1,39 @@
 package io.confluent.idesidecar.restapi.proxy.clusters.strategy;
 
+import io.confluent.idesidecar.restapi.connections.DirectConnectionState;
+import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
+import io.vertx.core.MultiMap;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * Strategy for processing requests and responses for a Confluent local Kafka cluster.
+ * Strategy for forwarding incoming REST requests to the Schema Registry specified on a direct
+ * connection.
  */
 @ApplicationScoped
 public class DirectSchemaRegistryClusterStrategy extends ClusterStrategy {
-  // No specific configuration for this strategy
+  private static final String TARGET_SR_CLUSTER_HEADER = "target-sr-cluster";
+
+  /**
+   * Constructs the headers for the proxied request, and add the authentication headers from the
+   * credentials, and the `target-sr-cluster` header set to the connection's SR cluster ID.
+   * @param context the context of the proxy request
+   * @return the headers to be used in the proxy request to the Schema Registry
+   */
+  @Override
+  public MultiMap constructProxyHeaders(ClusterProxyContext context) {
+    var headers = super.constructProxyHeaders(context);
+    if (context.getConnectionState() instanceof DirectConnectionState directConnectionState) {
+      var srConfig = directConnectionState.getSpec().schemaRegistryConfig();
+      if (srConfig != null) {
+        var credentials = srConfig.credentials();
+        if (credentials != null) {
+          credentials.httpClientHeaders().ifPresent(map -> map.forEach(headers::add));
+        }
+      }
+    }
+    headers.add(TARGET_SR_CLUSTER_HEADER, context.getClusterId());
+
+    return headers;
+  }
 }
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,9 @@ ide-sidecar:
         brokers-list-uri: ${ide-sidecar.connections.confluent-local.default.kafkarest-uri}/v3/clusters/%s/brokers
         broker-adv-listeners-config-uri: ${ide-sidecar.connections.confluent-local.default.kafkarest-uri}/v3/clusters/%s/brokers/%s/configs/advertised.listeners
         kafka-topic-uri: ${outpost.connections.confluent-local.default.kafkarest-uri}/v3/clusters/%s/topics/%s
+
+    direct:
+      timeout-seconds: 5
   feature-flags:
     refresh-interval-seconds: 60
     ide-project:

--- a/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
@@ -272,7 +272,9 @@ class ClientConfiguratorStaticTest {
               // The Kafka config without SR should match
               var kafkaConfig = ClientConfigurator.getKafkaClientConfig(
                   connection,
-                  input.kafkaCluster,
+                  input.kafkaCluster.id(),
+                  input.kafkaCluster.bootstrapServers(),
+                  null,
                   null,
                   input.redact,
                   Map.of()
@@ -288,7 +290,8 @@ class ClientConfiguratorStaticTest {
                 var expectedSchemaRegistryConfig = loadProperties(input.expectedSchemaRegistryConfig);
                 var srConfig = ClientConfigurator.getSchemaRegistryClientConfig(
                     connection,
-                    input.schemaRegistry,
+                    input.schemaRegistry.id(),
+                    input.schemaRegistry.uri(),
                     input.redact
                 );
                 assertMapsEquals(
@@ -305,8 +308,10 @@ class ClientConfiguratorStaticTest {
                 });
                 var kafkaConfigWithSr = ClientConfigurator.getKafkaClientConfig(
                     connection,
-                    input.kafkaCluster,
-                    input.schemaRegistry,
+                    input.kafkaCluster.id(),
+                    input.kafkaCluster.bootstrapServers(),
+                    input.schemaRegistry.id(),
+                    input.schemaRegistry.uri(),
                     input.redact,
                     Map.of()
                 );

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.credentials;
 
+import static io.vertx.core.http.HttpHeaders.AUTHORIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,18 @@ class ApiKeyAndSecretTest extends RedactedTestBase<ApiKeyAndSecret> {
         "credentials/api_key_and_secret.json",
         "credentials/api_key_and_secret_redacted.json",
         ApiKeyAndSecret.class
+    );
+  }
+
+  @Test
+  void shouldGetHttpClientHeaders() {
+    var key = "ABCDEFGH12345678";
+    var keyAndSecret = new ApiKeyAndSecret(key, new ApiSecret("K1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0".toCharArray()));
+    var headers = keyAndSecret.httpClientHeaders();
+    var authValue = headers.orElseThrow().get(AUTHORIZATION);
+    assertEquals(
+        "Basic QUJDREVGR0gxMjM0NTY3ODpLMTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVow",
+        authValue
     );
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.credentials;
 
+import static io.vertx.core.http.HttpHeaders.AUTHORIZATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,18 @@ class BasicCredentialsTest extends RedactedTestBase<BasicCredentials> {
         "credentials/basic_credentials.json",
         "credentials/basic_credentials_redacted.json",
         BasicCredentials.class
+    );
+  }
+
+  @Test
+  void shouldGetHttpClientHeaders() {
+    var username = "ABCDEFGH12345678";
+    var basicCreds = new BasicCredentials(username, new Password("K1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0".toCharArray()));
+    var headers = basicCreds.httpClientHeaders();
+    var authValue = headers.orElseThrow().get(AUTHORIZATION);
+    assertEquals(
+        "Basic QUJDREVGR0gxMjM0NTY3ODpLMTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVow",
+        authValue
     );
   }
 }


### PR DESCRIPTION
Resolves #123

## Summary of Changes

Completes the functionality of direct connections, though we will add more integration tests as follow-ons. For example, the existing ITs use `LocalTestEnvironment` that runs containers without authN, and the recently-added ITs for direct connections use no credentials. We'll need another `ConfluentPlatformTestEnvironment` that runs CP clusters with several authN mechanisms enabled, and then we'll run additional tests against that.

## Any additional details or context that should be provided?

This PR modifies the `DirectConnectionState` class to properly populate the status for direct connections, after verifying the ability to connect to Kafka using an AdminClient and to SR using an SR client.

It also fixes a few issues with how we compute the authentication-related headers using the credentials. These headers are used in the Kafka REST proxy and SR proxy implementations.

It adds some debug log messages to the ‘KafkaProducerClients’, `KafkaConsumerFactory`, `SchemaRegistryClients` and `AdminClients` beans, including logging at debug level the (redacted) configuration properties for these clients. To make it easier to log the redacted configurations, the `ClientConfigurator` class was changed to return a `Configuration` object rather than a `Map<String, Object>`. The `Configuration` object has one method to get the configuration properties as a map, while the `toString()` and other methods ensure that only the redacted form of the configuration is otherwise exposed.

Finally, fixed a bug in `BasicCredentials` and `ApiKeyAndSecret` classes in the `httpClientHeaders()` implementations. This method returns the authorization-related HTTP headers, and the base64-encoded value was not being created correctly. A few unit tests were added, using obviously-fake secret values.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

