### PR TITLE
fix: Use larger Semaphore agent for building the Linux ARM64 executable

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -162,7 +162,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu20-04-amd64-2
       prologue:
         commands_file: build_native_executable_prologue.sh
       env_vars:


### PR DESCRIPTION
Use the larger Semaphore agent `s1-prod-ubuntu20-04-amd64-2` for building the Linux ARM64 executable to prevent us from running out of memory.
We [recently did the same change](https://github.com/confluentinc/ide-sidecar/commit/0101a491cc7ecdc4aacd76b9cd3fcb50a9812999) for building the Linux AMD64 executable.

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

