### PR TITLE
create folder move files and make some methods protected

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/cache/Clients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/cache/Clients.java
@@ -68,7 +68,7 @@ public abstract class Clients<T extends AutoCloseable> {
     return clientsByIdByConnections.computeIfAbsent(connectionId, k -> createCache());
   }
 
-  int clientCount() {
+  protected int clientCount() {
     return clientsByIdByConnections
         .values()
         .stream()
@@ -78,11 +78,11 @@ public abstract class Clients<T extends AutoCloseable> {
         .sum();
   }
 
-  int clientCount(String connectionId) {
+  protected int clientCount(String connectionId) {
     return clientsForConnection(connectionId).asMap().size();
   }
 
-  void clearClients(String connectionId) {
+  protected void clearClients(String connectionId) {
     var oldCache = clientsByIdByConnections.put(connectionId, createCache());
     if (oldCache != null) {
       // Invalidation will trigger the removal listener, which will close the clients

--- a/src/main/java/io/confluent/idesidecar/restapi/clients/AdminClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/AdminClients.java
@@ -1,6 +1,7 @@
-package io.confluent.idesidecar.restapi.cache;
+package io.confluent.idesidecar.restapi.clients;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import io.confluent.idesidecar.restapi.cache.Clients;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/io/confluent/idesidecar/restapi/clients/ClientConfigurator.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/ClientConfigurator.java
@@ -2,8 +2,9 @@
  * Copyright [2024 - 2024] Confluent Inc.
  */
 
-package io.confluent.idesidecar.restapi.cache;
+package io.confluent.idesidecar.restapi.clients;
 
+import io.confluent.idesidecar.restapi.cache.ClusterCache;
 import io.confluent.idesidecar.restapi.connections.ConnectionState;
 import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.credentials.Credentials;

--- a/src/main/java/io/confluent/idesidecar/restapi/clients/KafkaProducerClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/KafkaProducerClients.java
@@ -1,6 +1,8 @@
-package io.confluent.idesidecar.restapi.cache;
+package io.confluent.idesidecar.restapi.clients;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
+import io.confluent.idesidecar.restapi.cache.Clients;
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
@@ -1,9 +1,11 @@
-package io.confluent.idesidecar.restapi.cache;
+package io.confluent.idesidecar.restapi.clients;
 
 import static io.confluent.idesidecar.restapi.kafkarest.SchemaManager.SCHEMA_PROVIDERS;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 
 import io.confluent.idesidecar.restapi.application.SidecarAccessTokenBean;
+import io.confluent.idesidecar.restapi.cache.Clients;
+import io.confluent.idesidecar.restapi.cache.ClusterCache;
 import io.confluent.idesidecar.restapi.util.RequestHeadersConstants;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -1,7 +1,7 @@
 package io.confluent.idesidecar.restapi.connections;
 
 import io.confluent.idesidecar.restapi.auth.AuthErrors;
-import io.confluent.idesidecar.restapi.cache.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.confluent.idesidecar.restapi.credentials.Credentials;
 import io.confluent.idesidecar.restapi.models.ClusterType;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * Implementation of the connection state for ({@link ConnectionType#DIRECT} connections where the

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
@@ -13,7 +13,7 @@ import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniItem;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
 
-import io.confluent.idesidecar.restapi.cache.AdminClients;
+import io.confluent.idesidecar.restapi.clients.AdminClients;
 import io.confluent.idesidecar.restapi.cache.ClusterCache;
 import io.confluent.idesidecar.restapi.exceptions.ClusterNotFoundException;
 import io.confluent.idesidecar.restapi.kafkarest.model.ClusterData;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ConfigManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ConfigManager.java
@@ -5,7 +5,7 @@ import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
 import static java.util.Collections.singletonMap;
 
-import io.confluent.idesidecar.restapi.cache.AdminClients;
+import io.confluent.idesidecar.restapi.clients.AdminClients;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.http.HttpServerRequest;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
-import io.confluent.idesidecar.restapi.cache.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ApiImpl.java
@@ -6,8 +6,8 @@ import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
 
 import com.google.protobuf.ByteString;
-import io.confluent.idesidecar.restapi.cache.KafkaProducerClients;
-import io.confluent.idesidecar.restapi.cache.SchemaRegistryClients;
+import io.confluent.idesidecar.restapi.clients.KafkaProducerClients;
+import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceResponse;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceResponseData;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicManagerImpl.java
@@ -3,7 +3,7 @@ package io.confluent.idesidecar.restapi.kafkarest;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
 
-import io.confluent.idesidecar.restapi.cache.AdminClients;
+import io.confluent.idesidecar.restapi.clients.AdminClients;
 import io.confluent.idesidecar.restapi.kafkarest.model.CreateTopicRequestData;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.http.HttpServerRequest;

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/KafkaConsumerFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/KafkaConsumerFactory.java
@@ -1,6 +1,6 @@
 package io.confluent.idesidecar.restapi.messageviewer;
 
-import io.confluent.idesidecar.restapi.cache.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
@@ -5,7 +5,7 @@ import static io.quarkus.arc.impl.UncaughtExceptions.LOGGER;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.idesidecar.restapi.cache.SchemaRegistryClients;
+import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
 import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
 import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
 import io.confluent.idesidecar.restapi.messageviewer.MessageViewerContext;

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategy.java
@@ -1,7 +1,7 @@
 package io.confluent.idesidecar.restapi.messageviewer.strategy;
 
 import io.confluent.idesidecar.restapi.messageviewer.KafkaConsumerFactory;
-import io.confluent.idesidecar.restapi.cache.SchemaRegistryClients;
+import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
 import io.confluent.idesidecar.restapi.messageviewer.MessageViewerContext;
 import io.confluent.idesidecar.restapi.messageviewer.RecordDeserializer;
 import io.confluent.idesidecar.restapi.messageviewer.SimpleConsumer;

--- a/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.confluent.idesidecar.restapi.connections.ConnectionState;
 import io.confluent.idesidecar.restapi.credentials.ApiKeyAndSecret;
 import io.confluent.idesidecar.restapi.credentials.ApiSecret;

--- a/src/test/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClientsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/cache/SchemaRegistryClientsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.quarkus.test.junit.QuarkusTest;


### PR DESCRIPTION
Refactoring with an eye to #153 

## Summary of Changes

Moving `AdminClients`, `ClientConfigurator`, `KafkaProducerClients`, `SchemaRegistryClients` into a `restapi/clients` folder and changing some methods to `private` for passing tests.  

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

