### PR TITLE
Remove the `kafka_cluster.id` from the connection specs, and update RealDirectFetcher to populate the cluster ID

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -1103,11 +1103,6 @@
         "required" : [ "bootstrap_servers" ],
         "type" : "object",
         "properties" : {
-          "id" : {
-            "description" : "The identifier of the Kafka cluster, if known.",
-            "maxLength" : 64,
-            "type" : "string"
-          },
           "bootstrap_servers" : {
             "description" : "A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.",
             "maxLength" : 256,

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -796,10 +796,6 @@ components:
       - bootstrap_servers
       type: object
       properties:
-        id:
-          description: "The identifier of the Kafka cluster, if known."
-          maxLength: 64
-          type: string
         bootstrap_servers:
           description: A list of host/port pairs to use for establishing the initial
             connection to the Kafka cluster.

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -21,6 +21,17 @@ import java.util.HashSet;
  */
 public class CCloudConnectionState extends ConnectionState {
 
+  static final ConnectionStatus INITIAL_STATUS = new ConnectionStatus(
+      new CCloudStatus(
+          ConnectedState.NONE,
+          null,
+          null,
+          null
+      ),
+      null,
+      null
+  );
+
   private final CCloudOAuthContext oauthContext = new CCloudOAuthContext();
 
   CCloudConnectionState() {
@@ -32,6 +43,11 @@ public class CCloudConnectionState extends ConnectionState {
       @Nullable StateChangedListener listener
   ) {
     super(spec, listener);
+  }
+
+  @Override
+  public ConnectionStatus getInitialStatus() {
+    return INITIAL_STATUS;
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -69,6 +69,10 @@ public abstract class ConnectionState {
     return Future.succeededFuture(ConnectionStatus.INITIAL_STATUS);
   }
 
+  public ConnectionStatus getInitialStatus() {
+    return ConnectionStatus.INITIAL_STATUS;
+  }
+
   public ConnectionMetadata getConnectionMetadata() {
     return ConnectionMetadata.from(
         null,

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -30,8 +30,7 @@ public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
   public static Connection from(
       ConnectionState connectionState
   ) {
-    // By default, a connection does not hold any tokens
-    return from(connectionState, ConnectionStatus.INITIAL_STATUS);
+    return from(connectionState, connectionState.getInitialStatus());
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -278,11 +278,6 @@ public record ConnectionSpec(
   @RegisterForReflection
   @RecordBuilder
   public record KafkaClusterConfig(
-      @Schema(description = "The identifier of the Kafka cluster, if known.")
-      @Null
-      @Size(max = ID_MAX_LEN)
-      String id,
-
       @Schema(description = "A list of host/port pairs to use for establishing the "
                             + "initial connection to the Kafka cluster.")
       @JsonProperty(value = "bootstrap_servers")
@@ -356,13 +351,6 @@ public record ConnectionSpec(
         String path,
         String what
     ) {
-      if (id != null && id.length() > ID_MAX_LEN) {
-        errors.add(
-            Error.create()
-                 .withDetail("%s cluster ID may not be longer than %d characters", what, ID_MAX_LEN)
-                 .withSource("%s.id", path)
-        );
-      }
       if (bootstrapServers == null || bootstrapServers.isBlank()) {
         errors.add(
             Error.create()

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
@@ -345,4 +345,10 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
     });
     current.useBy(this);
   }
+
+  @Override
+  public void deleteAllConnections() {
+    super.deleteAllConnections();
+    REUSABLE_CONNECTIONS_BY_TEST_SCOPE.clear();
+  }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/LocalITs.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/LocalITs.java
@@ -1,5 +1,7 @@
 package io.confluent.idesidecar.restapi.integration;
 
+import io.confluent.idesidecar.restapi.integration.connection.DirectConnectionSuite;
+import io.confluent.idesidecar.restapi.integration.connection.LocalConnectionSuite;
 import io.confluent.idesidecar.restapi.kafkarest.RecordsV3ErrorsSuite;
 import io.confluent.idesidecar.restapi.kafkarest.RecordsV3Suite;
 import io.confluent.idesidecar.restapi.kafkarest.RecordsV3DryRunSuite;
@@ -38,6 +40,23 @@ public class LocalITs {
 
   @Nested
   class LocalConnectionTests {
+
+    @QuarkusIntegrationTest
+    @Tag("io.confluent.common.utils.IntegrationTest")
+    @TestProfile(NoAccessFilterProfile.class)
+    @Nested
+    class ConnectionAndGraphQL extends AbstractIT implements LocalConnectionSuite {
+
+      @Override
+      public TestEnvironment environment() {
+        return TEST_ENVIRONMENT;
+      }
+
+      @Override
+      public void setupConnection() {
+        deleteAllConnections();
+      }
+    }
 
     @QuarkusIntegrationTest
     @Tag("io.confluent.common.utils.IntegrationTest")
@@ -150,6 +169,23 @@ public class LocalITs {
 
   @Nested
   class DirectConnectionWithoutCredentialsTests {
+
+    @QuarkusIntegrationTest
+    @Tag("io.confluent.common.utils.IntegrationTest")
+    @TestProfile(NoAccessFilterProfile.class)
+    @Nested
+    class ConnectionAndGraphQL extends AbstractIT implements DirectConnectionSuite {
+
+      @Override
+      public TestEnvironment environment() {
+        return TEST_ENVIRONMENT;
+      }
+
+      @Override
+      public void setupConnection() {
+        deleteAllConnections();
+      }
+    }
 
     /**
      * All tests that create connections with this scope will reuse the same connection.

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/connection/DirectConnectionSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/connection/DirectConnectionSuite.java
@@ -1,0 +1,173 @@
+package io.confluent.idesidecar.restapi.integration.connection;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.idesidecar.restapi.integration.ITSuite;
+import io.confluent.idesidecar.restapi.models.Connection;
+import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+public interface DirectConnectionSuite extends ITSuite {
+
+  @Test
+  default void shouldCreateAndListAndGetAndDeleteDirectConnection() {
+    // Not all environments support direct connections
+    var spec = environment().directConnectionSpec().orElse(null);
+    assertNotNull(spec, "Expected environment %s has direct connection spec".formatted(environment().name()));
+
+    // Create the connection and mark it as the one we'll use
+    var connection = createConnection(spec);
+    useConnection(connection.id());
+
+    final boolean startedWithKafka = spec.kafkaClusterConfig() != null;
+    final boolean startedWithSr = spec.schemaRegistryConfig() != null;
+
+    // Verify the response has the necessary objects
+    assertEquals(connection.id(), connection.spec().id());
+    assertNotNull(connection.spec());
+    assertEquals(spec.name(), connection.spec().name());
+    assertEquals(spec.kafkaClusterConfig(), connection.spec().kafkaClusterConfig());
+    assertEquals(spec.schemaRegistryConfig(), connection.spec().schemaRegistryConfig());
+    assertNotNull(connection.status());
+    var expectedKafkaState = ConnectedState.NONE;
+    var expectedSrState = ConnectedState.NONE;
+    if (startedWithKafka) {
+      assertNotNull(connection.spec().kafkaClusterConfig().bootstrapServers());
+      assertNotNull(connection.status().kafkaCluster());
+      assertNotNull(connection.status().kafkaCluster().state());
+      expectedKafkaState = ConnectedState.SUCCESS;
+    } else {
+      assertNull(connection.status().kafkaCluster());
+    }
+    if (startedWithSr) {
+      assertNotNull(connection.status().schemaRegistry());
+      assertNotNull(connection.status().schemaRegistry().state());
+      expectedSrState = ConnectedState.SUCCESS;
+    } else {
+      assertNull(connection.status().schemaRegistry());
+    }
+
+    // Update the spec to include the generated ID
+    spec = spec.withId(connection.id());
+
+    // Get the connection again
+    var connection2 = given()
+        .when()
+        .get("/gateway/v1/connections/{id}", connection.id())
+        .then()
+        .statusCode(200)
+        .body("id", equalTo(connection.id()))
+        .body("metadata.self", notNullValue())
+        .body("spec.id", equalTo(connection.id()))
+        .body("spec.name", equalTo(spec.name()))
+        .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
+        .body("spec.local_config", nullValue())
+        .body("spec.ccloud_config", nullValue())
+        .body("spec.kafka_cluster.bootstrap_servers", equalTo(spec.kafkaClusterConfig().bootstrapServers()))
+        .body("status.kafka_cluster.state", equalTo(expectedKafkaState.name()))
+        .body("status.schema_registry.state", equalTo(expectedSrState.name()))
+        .extract().body().as(Connection.class);
+
+    if (startedWithKafka) {
+      assertEquals(spec.kafkaClusterConfig(), connection2.spec().kafkaClusterConfig());
+    }
+    if (startedWithSr) {
+      assertEquals(spec.schemaRegistryConfig(), connection2.spec().schemaRegistryConfig());
+    }
+    assertNotNull(connection2.status().kafkaCluster());
+    assertEquals(expectedKafkaState, connection2.status().kafkaCluster().state());
+    assertNotNull(connection2.status().schemaRegistry());
+    assertEquals(expectedSrState, connection2.status().schemaRegistry().state());
+
+    // Query for resources
+    if (startedWithKafka) {
+      submitDirectConnectionsGraphQL()
+          .body("data.directConnections[0].id", equalTo(spec.id()))
+          .body("data.directConnections[0].name", equalTo(spec.name()))
+          .body("data.directConnections[0].type", equalTo("DIRECT"))
+          .body("data.directConnections[0].kafkaCluster.id", notNullValue())
+          .body("data.directConnections[0].kafkaCluster.bootstrapServers", equalTo(spec.kafkaClusterConfig().bootstrapServers()));
+    }
+    if (startedWithSr) {
+      submitDirectConnectionsGraphQL()
+          .body("data.directConnections[0].id", equalTo(spec.id()))
+          .body("data.directConnections[0].name", equalTo(spec.name()))
+          .body("data.directConnections[0].type", equalTo("DIRECT"))
+          .body("data.directConnections[0].schemaRegistry.id", notNullValue())
+          .body("data.directConnections[0].schemaRegistry.uri", equalTo(spec.schemaRegistryConfig().uri()));
+    }
+
+    if (startedWithSr && startedWithKafka) {
+      // Update the connection to remove the schema registry
+      var specNoSr = spec.withSchemaRegistry(null);
+
+      given()
+          .when()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(specNoSr)
+          .put("/gateway/v1/connections/{id}", connection.id())
+          .then()
+          .statusCode(200)
+          .body("id", equalTo(connection.id()))
+          .body("metadata.self", notNullValue())
+          .body("spec.id", equalTo(connection.id()))
+          .body("spec.name", equalTo(spec.name()))
+          .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
+          .body("spec.local_config", nullValue())
+          .body("spec.ccloud_config", nullValue())
+          .body("spec.kafka_cluster.bootstrap_servers", equalTo(specNoSr.kafkaClusterConfig().bootstrapServers()))
+          .body("spec.schema_registry", nullValue())
+          .body("status.kafka_cluster.state", equalTo(ConnectedState.SUCCESS.name()))
+          .body("status.schema_registry.state", equalTo(ConnectedState.NONE.name()));
+
+      // Query for resources
+      submitDirectConnectionsGraphQL()
+          .body("data.directConnections[0].id", equalTo(spec.id()))
+          .body("data.directConnections[0].name", equalTo(spec.name()))
+          .body("data.directConnections[0].type", equalTo("DIRECT"))
+          .body("data.directConnections[0].kafkaCluster.id", notNullValue())
+          .body("data.directConnections[0].kafkaCluster.bootstrapServers", notNullValue())
+          .body("data.directConnections[0].schemaRegistry", nullValue());
+    }
+
+    // Query for resources finds our connection
+    assertTrue(
+        directConnectionsGraphQLResponseContains(connection.id())
+    );
+
+    // Delete the connection
+    deleteConnection(connection.id());
+
+    // Get the connection again
+    given()
+        .when()
+        .get("/gateway/v1/connections/{id}", connection.id())
+        .then()
+        .statusCode(404)
+        .body("status", equalTo("404"))
+        .body("code", equalTo("None"))
+        .body("title", equalTo("Not Found"))
+        .body("id", notNullValue())
+        .body("errors", hasSize(1))
+        .body("errors[0].code", equalTo("None"))
+        .body("errors[0].title", equalTo("Not Found"))
+        .body("errors[0].detail", equalTo("Connection %s is not found.".formatted(connection.id())));
+
+    // Query for resources does not find our connection
+    assertFalse(
+        directConnectionsGraphQLResponseContains(connection.id())
+    );
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
@@ -1,0 +1,137 @@
+package io.confluent.idesidecar.restapi.integration.connection;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.idesidecar.restapi.integration.ITSuite;
+import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+public interface LocalConnectionSuite extends ITSuite {
+
+  @Test
+  default void shouldCreateAndListAndGetAndDeleteLocalConnection() {
+    // Not all environments support local connections
+    var spec = environment().localConnectionSpec().orElse(null);
+    assertNotNull(spec, "Expected environment %s has local connection spec".formatted(environment().name()));
+
+    // Create the connection and mark it as the one we'll use
+    var connection = createConnection(spec);
+    useConnection(connection.id());
+
+    // Verify the response has the necessary objects
+    assertEquals(connection.id(), connection.spec().id());
+    assertNotNull(connection.spec());
+    assertEquals(spec.name(), connection.spec().name());
+    assertNotNull(connection.spec().localConfig());
+    assertEquals(spec.localConfig().schemaRegistryUri(), connection.spec().localConfig().schemaRegistryUri());
+    assertNotNull(connection.status());
+    assertNotNull(connection.status().authentication());
+    assertEquals(Status.NO_TOKEN, connection.status().authentication().status());
+
+    // Update the spec to include the generated ID
+    spec = spec.withId(connection.id());
+
+    // Get the connection again
+    given()
+        .when()
+        .get("/gateway/v1/connections/{id}", connection.id())
+        .then()
+        .statusCode(200)
+        .body("id", equalTo(connection.id()))
+        .body("metadata.self", notNullValue())
+        .body("spec.id", equalTo(connection.id()))
+        .body("spec.name", equalTo(spec.name()))
+        .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
+        .body("spec.local_config", notNullValue())
+        .body("spec.local_config.schema-registry-uri", equalTo(spec.localConfig().schemaRegistryUri()))
+        .body("spec.ccloud_config", nullValue())
+        .body("spec.kafka_cluster", nullValue())
+        .body("spec.schema_registry", nullValue())
+        .body(
+            "status.authentication.status",
+            equalTo(Status.NO_TOKEN.name())
+        );
+
+    // Query for resources
+    submitLocalConnectionsGraphQL()
+        .body("data.localConnections[0].id", equalTo(spec.id()))
+        .body("data.localConnections[0].name", equalTo("local")) // hard-coded in LocalConnection
+        .body("data.localConnections[0].type", equalTo("LOCAL"))
+        .body("data.localConnections[0].kafkaCluster.id", notNullValue())
+        .body("data.localConnections[0].kafkaCluster.bootstrapServers", notNullValue())
+        .body("data.localConnections[0].schemaRegistry.uri", notNullValue());
+
+    // Update the connection to remove the schema registry
+    var specNoSr = spec.withLocalConfig("");
+
+    given()
+        .when()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(specNoSr)
+        .put("/gateway/v1/connections/{id}", connection.id())
+        .then()
+        .statusCode(200)
+        .body("id", equalTo(connection.id()))
+        .body("metadata.self", notNullValue())
+        .body("spec.id", equalTo(connection.id()))
+        .body("spec.name", equalTo(spec.name()))
+        .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
+        .body("spec.local_config", notNullValue())
+        .body("spec.local_config.schema-registry-uri", equalTo(""))
+        .body("spec.ccloud_config", nullValue())
+        .body("spec.kafka_cluster", nullValue())
+        .body("spec.schema_registry", nullValue())
+        .body(
+            "status.authentication.status",
+            equalTo(Status.NO_TOKEN.name())
+        );
+
+    // Query for resources
+    submitLocalConnectionsGraphQL()
+        .body("data.localConnections[0].id", equalTo(spec.id()))
+        .body("data.localConnections[0].name", equalTo("local")) // hard-coded in LocalConnection
+        .body("data.localConnections[0].type", equalTo("LOCAL"))
+        .body("data.localConnections[0].kafkaCluster.id", notNullValue())
+        .body("data.localConnections[0].kafkaCluster.bootstrapServers", notNullValue())
+        .body("data.localConnections[0].schemaRegistry", nullValue());
+
+    // Query for resources finds our connection
+    assertTrue(
+        localConnectionsGraphQLResponseContains(connection.id())
+    );
+
+    // Delete the connection
+    deleteConnection(connection.id());
+
+    // Get the connection again
+    given()
+        .when()
+        .get("/gateway/v1/connections/{id}", connection.id())
+        .then()
+        .statusCode(404)
+        .body("status", equalTo("404"))
+        .body("code", equalTo("None"))
+        .body("title", equalTo("Not Found"))
+        .body("id", notNullValue())
+        .body("errors", hasSize(1))
+        .body("errors[0].code", equalTo("None"))
+        .body("errors[0].title", equalTo("Not Found"))
+        .body("errors[0].detail", equalTo("Connection local-connection is not found."));
+
+    // Query for resources does not find our connection
+    assertFalse(
+        localConnectionsGraphQLResponseContains(connection.id())
+    );
+  }
+
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/DirectQueryResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/DirectQueryResourceTest.java
@@ -21,7 +21,6 @@ public class DirectQueryResourceTest extends ConfluentQueryResourceTestBase {
 
   static final String CONNECTION_ID = "direct-1";
   static final String CONNECTION_NAME = "Direct 1";
-  static final String KAFKA_CLUSTER_ID = "kafka-cluster-1";
   static final String KAFKA_BOOTSTRAP_SERVERS = "localhost:9092";
   static final String SCHEMA_REGISTRY_ID = "schema-registry-1";
   static final String SCHEMA_REGISTRY_URL = "http://localhost:8081";
@@ -104,7 +103,6 @@ public class DirectQueryResourceTest extends ConfluentQueryResourceTestBase {
     KafkaClusterConfig kafkaConfig = null;
     if (withKafka) {
       kafkaConfig = new KafkaClusterConfig(
-          KAFKA_CLUSTER_ID,
           KAFKA_BOOTSTRAP_SERVERS,
           null,
           null,

--- a/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
@@ -3,10 +3,7 @@ package io.confluent.idesidecar.restapi.util;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.quarkus.test.junit.TestProfile;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -93,7 +90,6 @@ public class LocalTestEnvironment implements TestEnvironment {
             "direct-to-local-connection",
             "Direct to Local",
             new ConnectionSpec.KafkaClusterConfig(
-                kafkaWithRestProxy.getClusterId(),
                 kafkaWithRestProxy.getKafkaBootstrapServers(),
                 null,
                 null,

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -691,13 +691,34 @@ public class SidecarClient implements SidecarClientApi {
 
   public ValidatableResponse submitDirectConnectionsGraphQL() {
     return submitGraphQL(
-        loadLocalConnectionsGraphQL()
+        loadDirectConnectionsGraphQL()
     );
   }
 
   public ValidatableResponse submitCCloudConnectionsGraphQL() {
     return submitGraphQL(
-        loadLocalConnectionsGraphQL()
+        loadCCloudConnectionsGraphQL()
     );
   }
+
+  public boolean localConnectionsGraphQLResponseContains(String connectionId) {
+    return submitLocalConnectionsGraphQL()
+        .extract()
+        .response()
+        .jsonPath()
+        .getList("data.localConnections", Map.class)
+        .stream()
+        .anyMatch(m -> m.get("id").equals(connectionId));
+  }
+
+  public boolean directConnectionsGraphQLResponseContains(String connectionId) {
+    return submitDirectConnectionsGraphQL()
+        .extract()
+        .response()
+        .jsonPath()
+        .getList("data.directConnections", Map.class)
+        .stream()
+        .anyMatch(m -> m.get("id").equals(connectionId));
+  }
+
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClientApi.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClientApi.java
@@ -215,4 +215,8 @@ public interface SidecarClientApi {
   ValidatableResponse submitDirectConnectionsGraphQL() ;
 
   ValidatableResponse submitCCloudConnectionsGraphQL();
+
+  boolean localConnectionsGraphQLResponseContains(String connectionId);
+
+  boolean directConnectionsGraphQLResponseContains(String connectionId);
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/util/TestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/TestEnvironment.java
@@ -46,4 +46,8 @@ public interface TestEnvironment {
     }
     return spec;
   }
+
+  default String name() {
+    return getClass().getSimpleName();
+  }
 }


### PR DESCRIPTION
Resolves #173 

## Summary of Changes

We should not allow users to specify the ID of the Kafka cluster in direct connection specs — getting the ID is not always straightforward, and even if they provide an ID it might be wrong.

Instead, the `RealDirectFetcher` should be able to use the AdminClient to get the cluster’s ID from the cluster, and then include the ID in the cached `KafkaCluster` objects.

Added integration tests for the Connection API and GraphQL API to test local and direct connections and the Kafka cluster and Schema Registry cluster representations (including the Kafka cluster does have an ID). (Unfortunately, we can’t easily mock Kafka protocol, so adding unit tests for all the `RealDirectFetcher` logic is not as straightforward.)

Found and fixed a bug where the `status` response in a newly-created direct connection had no `kafka_cluster` or `schema_registry` object.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

