### PR TITLE
GraphQL queries should not block for direct connections that are not connected

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -75,7 +75,7 @@ public class CCloudConnectionState extends ConnectionState {
    * @return status of connection
    */
   @Override
-  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
+  protected Future<ConnectionStatus> doRefreshStatus() {
     var missingTokens = new HashSet<String>();
     if (oauthContext.getRefreshToken() == null) {
       missingTokens.add("Refresh token");

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -46,7 +46,7 @@ public class CCloudConnectionState extends ConnectionState {
   }
 
   @Override
-  public ConnectionStatus getInitialStatus() {
+  protected ConnectionStatus getInitialStatus() {
     return INITIAL_STATUS;
   }
 
@@ -75,7 +75,7 @@ public class CCloudConnectionState extends ConnectionState {
    * @return status of connection
    */
   @Override
-  public Future<ConnectionStatus> getConnectionStatus() {
+  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
     var missingTokens = new HashSet<String>();
     if (oauthContext.getRefreshToken() == null) {
       missingTokens.add("Refresh token");

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -89,10 +89,10 @@ public abstract class ConnectionState {
   }
 
   /**
-   * Attempt to {@link #doRefreshConnectionStatus() refresh the connection status and
+   * Attempt to {@link #doRefreshStatus() refresh the connection status and
    * update the {@link #getStatus() cached results}.
    *
-   * <p>This method always calls {@link #doRefreshConnectionStatus()} and then on success updates
+   * <p>This method always calls {@link #doRefreshStatus()} and then on success updates
    * the {@link #getStatus() cached connection status}.
    *
    * @return the future that will complete with the updated connection status
@@ -101,7 +101,7 @@ public abstract class ConnectionState {
    */
   public final Future<ConnectionStatus> refreshStatus() {
     // Always set the cached status when the future completes successfully
-    return doRefreshConnectionStatus().onSuccess(this.cachedStatus::set);
+    return doRefreshStatus().onSuccess(this.cachedStatus::set);
   }
 
   /**
@@ -113,7 +113,7 @@ public abstract class ConnectionState {
    * @see #refreshStatus()
    * @see #getStatus()
    */
-  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
+  protected Future<ConnectionStatus> doRefreshStatus() {
     return Future.succeededFuture(getInitialStatus());
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -74,7 +74,7 @@ public abstract class ConnectionState {
    *
    * @return the connection status; never null
    */
-  public ConnectionStatus getConnectionStatus() {
+  public ConnectionStatus getStatus() {
     return this.cachedStatus.get();
   }
 
@@ -90,16 +90,16 @@ public abstract class ConnectionState {
 
   /**
    * Attempt to {@link #doRefreshConnectionStatus() refresh the connection status and
-   * update the {@link #getConnectionStatus() cached results}.
+   * update the {@link #getStatus() cached results}.
    *
    * <p>This method always calls {@link #doRefreshConnectionStatus()} and then on success updates
-   * the {@link #getConnectionStatus() cached connection status}.
+   * the {@link #getStatus() cached connection status}.
    *
    * @return the future that will complete with the updated connection status
    * @see #getConnectionStatus()
    * @see #doRefreshConnectionStatus()
    */
-  public final Future<ConnectionStatus> refreshConnectionStatus() {
+  public final Future<ConnectionStatus> refreshStatus() {
     // Always set the cached status when the future completes successfully
     return doRefreshConnectionStatus().onSuccess(this.cachedStatus::set);
   }
@@ -110,8 +110,8 @@ public abstract class ConnectionState {
    * implement the actual connection status refresh logic.
    *
    * @return the future that will complete with the updated connection status
-   * @see #refreshConnectionStatus()
-   * @see #getConnectionStatus()
+   * @see #refreshStatus()
+   * @see #getStatus()
    */
   protected Future<ConnectionStatus> doRefreshConnectionStatus() {
     return Future.succeededFuture(getInitialStatus());

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -9,6 +9,7 @@ import io.confluent.idesidecar.restapi.models.ConnectionStatus;
 import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
 import io.vertx.core.Future;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base class holding default implementations for interacting with connection states.
@@ -46,11 +47,14 @@ public abstract class ConnectionState {
 
   protected ConnectionSpec spec;
 
+  private final AtomicReference<ConnectionStatus> cachedStatus = new AtomicReference<>();
+
   protected final StateChangedListener listener;
 
   protected ConnectionState(ConnectionSpec spec, StateChangedListener listener) {
     this.spec = spec;
     this.listener = listener != null ? listener : StateChangedListener.NO_OP;
+    this.cachedStatus.set(getInitialStatus());
   }
 
   public ConnectionSpec getSpec() {
@@ -65,12 +69,52 @@ public abstract class ConnectionState {
     this.spec = in;
   }
 
-  public Future<ConnectionStatus> getConnectionStatus() {
-    return Future.succeededFuture(ConnectionStatus.INITIAL_STATUS);
+  /**
+   * Obtain the most recently-obtained status of the connection.
+   *
+   * @return the connection status; never null
+   */
+  public ConnectionStatus getConnectionStatus() {
+    return this.cachedStatus.get();
   }
 
-  public ConnectionStatus getInitialStatus() {
+  /**
+   * Return the status for a newly-created connection. This method can be overridden by subclasses
+   * to provide a different initial status.
+   *
+   * @return the initial status; never null
+   */
+  protected ConnectionStatus getInitialStatus() {
     return ConnectionStatus.INITIAL_STATUS;
+  }
+
+  /**
+   * Attempt to {@link #doRefreshConnectionStatus() refresh the connection status and
+   * update the {@link #getConnectionStatus() cached results}.
+   *
+   * <p>This method always calls {@link #doRefreshConnectionStatus()} and then on success updates
+   * the {@link #getConnectionStatus() cached connection status}.
+   *
+   * @return the future that will complete with the updated connection status
+   * @see #getConnectionStatus()
+   * @see #doRefreshConnectionStatus()
+   */
+  public final Future<ConnectionStatus> refreshConnectionStatus() {
+    // Always set the cached status when the future completes successfully
+    return doRefreshConnectionStatus().onSuccess(this.cachedStatus::set);
+  }
+
+  /**
+   * Refresh the connection status. By default, this simply returns a completed future with the
+   * {@link #getInitialStatus() initial status}. Subclasses should override this method to
+   * implement the actual connection status refresh logic.
+   *
+   * @return the future that will complete with the updated connection status
+   * @see #refreshConnectionStatus()
+   * @see #getConnectionStatus()
+   */
+  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
+    return Future.succeededFuture(getInitialStatus());
   }
 
   public ConnectionMetadata getConnectionMetadata() {

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
@@ -133,7 +133,7 @@ public class ConnectionStateManager {
   /**
    * Test whether the given connection spec is valid and can be used to create a connection state.
    * This does not store the resulting connection state, and does not
-   * {@link ConnectionState#refreshConnectionStatus()} of the resulting connection state.
+   * {@link ConnectionState#refreshStatus()} of the resulting connection state.
    *
    * @param spec the specification for the connection
    * @return the connection state that would have been created

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * The {@link ConnectionStateManager} allows to manage a set of {@link ConnectionState}s. It
@@ -134,7 +133,7 @@ public class ConnectionStateManager {
   /**
    * Test whether the given connection spec is valid and can be used to create a connection state.
    * This does not store the resulting connection state, and does not
-   * {@link ConnectionState#getConnectionStatus()} of the resulting connection state.
+   * {@link ConnectionState#refreshConnectionStatus()} of the resulting connection state.
    *
    * @param spec the specification for the connection
    * @return the connection state that would have been created

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -72,12 +72,32 @@ public class DirectConnectionState extends ConnectionState {
   }
 
   @Override
-  public ConnectionStatus getInitialStatus() {
+  protected ConnectionStatus getInitialStatus() {
     return new ConnectionStatus(
         null,
         spec.kafkaClusterConfig() != null ? KAFKA_INITIAL_STATUS : null,
         spec.schemaRegistryConfig() != null ? SR_INITIAL_STATUS : null
     );
+  }
+
+  /**
+   * Check if the connection to the Kafka cluster is currently connected.
+   *
+   * @return true if the Kafka component is connected
+   */
+  public boolean isKafkaConnected() {
+    var status = getConnectionStatus();
+    return status.kafkaCluster() != null && status.kafkaCluster().isConnected();
+  }
+
+  /**
+   * Check if the connection to the Schema Registry is currently connected.
+   *
+   * @return true if the Kafka component is connected
+   */
+  public boolean isSchemaRegistryConnected() {
+    var status = getConnectionStatus();
+    return status.schemaRegistry() != null && status.schemaRegistry().isConnected();
   }
 
   public MultiMap getAuthenticationHeaders(ClusterType clusterType) {
@@ -116,7 +136,7 @@ public class DirectConnectionState extends ConnectionState {
   }
 
   @Override
-  public Future<ConnectionStatus> getConnectionStatus() {
+  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
     return Future.join(
         getKafkaConnectionStatus(),
         getSchemaRegistryConnectionStatus()
@@ -263,7 +283,7 @@ public class DirectConnectionState extends ConnectionState {
     }
   }
 
-  AdminClient createAdminClient(
+  protected AdminClient createAdminClient(
       ConnectionSpec.KafkaClusterConfig config
   ) {
     // Create the configuration for an AdminClient
@@ -314,7 +334,7 @@ public class DirectConnectionState extends ConnectionState {
     }
   }
 
-  SchemaRegistryClient createSchemaRegistryClient(
+  protected SchemaRegistryClient createSchemaRegistryClient(
       ConnectionSpec.SchemaRegistryConfig config
   ) {
     var srClientConfig = ClientConfigurator.getSchemaRegistryClientConfig(

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -136,7 +136,7 @@ public class DirectConnectionState extends ConnectionState {
   }
 
   @Override
-  protected Future<ConnectionStatus> doRefreshConnectionStatus() {
+  protected Future<ConnectionStatus> doRefreshStatus() {
     return Future.join(
         getKafkaConnectionStatus(),
         getSchemaRegistryConnectionStatus()

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -86,7 +86,7 @@ public class DirectConnectionState extends ConnectionState {
    * @return true if the Kafka component is connected
    */
   public boolean isKafkaConnected() {
-    var status = getConnectionStatus();
+    var status = getStatus();
     return status.kafkaCluster() != null && status.kafkaCluster().isConnected();
   }
 
@@ -96,7 +96,7 @@ public class DirectConnectionState extends ConnectionState {
    * @return true if the Kafka component is connected
    */
   public boolean isSchemaRegistryConnected() {
-    var status = getConnectionStatus();
+    var status = getStatus();
     return status.schemaRegistry() != null && status.schemaRegistry().isConnected();
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -30,7 +30,7 @@ public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
     return new Connection(
         connectionState.getConnectionMetadata(),
         connectionState.getSpec(),
-        connectionState.getConnectionStatus()
+        connectionState.getStatus()
     );
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Connection.java
@@ -21,7 +21,21 @@ import java.util.Objects;
 public class Connection extends BaseModel<ConnectionSpec, ConnectionMetadata> {
 
   /**
-   * Create a connection from the given connection state, resource path and status.
+   * Create a connection from the given connection state.
+   *
+   * @param connectionState the state of the connection
+   * @return the connection
+   */
+  public static Connection from(ConnectionState connectionState) {
+    return new Connection(
+        connectionState.getConnectionMetadata(),
+        connectionState.getSpec(),
+        connectionState.getConnectionStatus()
+    );
+  }
+
+  /**
+   * Create a connection from the given connection state and given status.
    *
    * @param connectionState the state of the connection
    * @param status          the status of the connection

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
@@ -112,6 +112,11 @@ public class RealDirectFetcher extends ConfluentRestClient implements DirectFetc
   public Uni<DirectKafkaCluster> getKafkaCluster(String connectionId) {
     var state = connections.getConnectionState(connectionId);
     if (state instanceof DirectConnectionState directState) {
+      if (!directState.isKafkaConnected()) {
+        // Either there is no Kafka cluster configured or it is not connected, so return no info
+        Log.debugf("Skipping connection '%s' since Kafka is not connected.", connectionId);
+        return Uni.createFrom().nullItem();
+      }
       // If there is a Kafka cluster configured, get the details
       return directState.withAdminClient(
           adminClient -> getKafkaCluster(directState, adminClient),
@@ -164,6 +169,11 @@ public class RealDirectFetcher extends ConfluentRestClient implements DirectFetc
   public Uni<DirectSchemaRegistry> getSchemaRegistry(String connectionId) {
     var state = connections.getConnectionState(connectionId);
     if (state instanceof DirectConnectionState directState) {
+      if (!directState.isSchemaRegistryConnected()) {
+        // Either there is no Kafka cluster configured or it is not connected, so return no info
+        Log.debugf("Skipping connection '%s' since Schema Registry is not connected.", connectionId);
+        return Uni.createFrom().nullItem();
+      }
       // Use the SR client to obtain the cluster ID
       return directState.withSchemaRegistryClient(
           srClient -> getSchemaRegistry(directState, srClient),

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
@@ -170,7 +170,7 @@ public class RealDirectFetcher extends ConfluentRestClient implements DirectFetc
     var state = connections.getConnectionState(connectionId);
     if (state instanceof DirectConnectionState directState) {
       if (!directState.isSchemaRegistryConnected()) {
-        // Either there is no Kafka cluster configured or it is not connected, so return no info
+        // Either there is no Schema Registry configured or it is not connected, so return no info
         Log.debugf("Skipping connection '%s' since Schema Registry is not connected.", connectionId);
         return Uni.createFrom().nullItem();
       }

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -99,7 +99,7 @@ public class ConnectionsResource {
       // Just test the connection and return the status
       var testedState = connectionStateManager.testConnectionState(connectionSpec);
       // Get the status of the connection
-      var futureStatus = testedState.refreshConnectionStatus();
+      var futureStatus = testedState.refreshStatus();
       // And create a uni that will complete when the status is available
       return Uni
           .createFrom()
@@ -113,7 +113,7 @@ public class ConnectionsResource {
     return Uni
         .createFrom()
         .item(
-            Connection.from(newState, newState.getConnectionStatus())
+            Connection.from(newState, newState.getStatus())
         );
   }
 
@@ -174,7 +174,7 @@ public class ConnectionsResource {
     try {
       ConnectionState connectionState = connectionStateManager.getConnectionState(id);
       return connectionState
-          .refreshConnectionStatus()
+          .refreshStatus()
           .map(connectionStatus -> Connection.from(connectionState, connectionStatus))
           .toCompletionStage();
     } catch (ConnectionNotFoundException e) {

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -99,7 +99,7 @@ public class ConnectionsResource {
       // Just test the connection and return the status
       var testedState = connectionStateManager.testConnectionState(connectionSpec);
       // Get the status of the connection
-      var futureStatus = testedState.getConnectionStatus();
+      var futureStatus = testedState.refreshConnectionStatus();
       // And create a uni that will complete when the status is available
       return Uni
           .createFrom()
@@ -108,12 +108,12 @@ public class ConnectionsResource {
               Connection.from(testedState, connectionStatus)
           );
     }
-    // Create a real connection state and return the connection using the initial status
+    // Create a real connection state and return the connection using the latest status
     var newState = connectionStateManager.createConnectionState(connectionSpec);
     return Uni
         .createFrom()
         .item(
-            Connection.from(newState, newState.getInitialStatus())
+            Connection.from(newState, newState.getConnectionStatus())
         );
   }
 
@@ -174,7 +174,7 @@ public class ConnectionsResource {
     try {
       ConnectionState connectionState = connectionStateManager.getConnectionState(id);
       return connectionState
-          .getConnectionStatus()
+          .refreshConnectionStatus()
           .map(connectionStatus -> Connection.from(connectionState, connectionStatus))
           .toCompletionStage();
     } catch (ConnectionNotFoundException e) {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
@@ -35,7 +35,7 @@ public class CCloudConnectionTest {
         mockListener
     );
 
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -62,7 +62,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -89,7 +89,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -116,7 +116,7 @@ public class CCloudConnectionTest {
         false,
         false
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -143,7 +143,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -170,7 +170,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -197,7 +197,7 @@ public class CCloudConnectionTest {
         true,
         true
     );
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
@@ -35,7 +35,7 @@ public class CCloudConnectionTest {
         mockListener
     );
 
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -62,7 +62,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -89,7 +89,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -116,7 +116,7 @@ public class CCloudConnectionTest {
         false,
         false
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -143,7 +143,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -170,7 +170,7 @@ public class CCloudConnectionTest {
         true,
         false
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {
@@ -197,7 +197,7 @@ public class CCloudConnectionTest {
         true,
         true
     );
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/LocalConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/LocalConnectionTest.java
@@ -26,7 +26,7 @@ public class LocalConnectionTest {
         mockListener
     );
 
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/LocalConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/LocalConnectionTest.java
@@ -26,7 +26,7 @@ public class LocalConnectionTest {
         mockListener
     );
 
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/PlatformConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/PlatformConnectionTest.java
@@ -28,7 +28,7 @@ public class PlatformConnectionTest {
         mockListener
     );
 
-    connectionState.refreshConnectionStatus()
+    connectionState.refreshStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/PlatformConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/PlatformConnectionTest.java
@@ -28,7 +28,7 @@ public class PlatformConnectionTest {
         mockListener
     );
 
-    connectionState.getConnectionStatus()
+    connectionState.refreshConnectionStatus()
         .onComplete(
             testContext.succeeding(connectionStatus ->
                 testContext.verify(() -> {

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcherTest.java
@@ -1,0 +1,349 @@
+package io.confluent.idesidecar.restapi.models.graph;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
+import io.confluent.idesidecar.restapi.connections.DirectConnectionState;
+import io.confluent.idesidecar.restapi.models.ConnectionSpec;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.time.Duration;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class RealDirectFetcherTest {
+
+  private static final String CONNECTION_ID = "connection-id";
+  private static final String KAFKA_CLUSTER_ID = "cluster-1";
+  private static final String KAFKA_BOOTSTRAP_SERVERS = "kafka_host:100";
+  private static final String SR_CLUSTER_ID = "schema-registry-1";
+  private static final String SR_URL = "http://localhost:123456";
+  private static final Duration ONE_SECOND = Duration.ofSeconds(1);
+  private static final ConnectionSpec KAFKA_AND_SR_SPEC = new ConnectionSpec(
+      CONNECTION_ID,
+      "my connection",
+      ConnectionSpec.ConnectionType.DIRECT,
+      null,
+      null,
+      new ConnectionSpec.KafkaClusterConfig(
+          KAFKA_BOOTSTRAP_SERVERS,
+          null,
+          false,
+          false
+      ),
+      new ConnectionSpec.SchemaRegistryConfig(
+          SR_CLUSTER_ID,
+          SR_URL,
+          null
+      )
+  );
+
+  private static final ConnectionSpec NO_KAFKA_SPEC = new ConnectionSpec(
+      CONNECTION_ID,
+      "my connection",
+      ConnectionSpec.ConnectionType.DIRECT,
+      null,
+      null,
+      null,
+      new ConnectionSpec.SchemaRegistryConfig(
+          SR_CLUSTER_ID,
+          SR_URL,
+          null
+      )
+  );
+
+  private static final ConnectionSpec NO_SR_SPEC = new ConnectionSpec(
+      CONNECTION_ID,
+      "my connection",
+      ConnectionSpec.ConnectionType.DIRECT,
+      null,
+      null,
+      new ConnectionSpec.KafkaClusterConfig(
+          KAFKA_BOOTSTRAP_SERVERS,
+          null,
+          false,
+          false
+      ),
+      null
+  );
+
+  @InjectMock
+  ConnectionStateManager connections;
+
+  @Inject
+  RealDirectFetcher directFetcher;
+
+  @Nested
+  class FetchesKafkaCluster {
+
+    @Test
+    void shouldSkipFetchingKafkaClusterIfNotConnected() {
+      // When there is a direct connection
+      var connection = mock(DirectConnectionState.class);
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // That is not connected to Kafka
+      when(connection.isKafkaConnected()).thenReturn(false);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectKafkaCluster> kafkaCluster = directFetcher.getKafkaCluster(CONNECTION_ID);
+
+      // Then the Kafka cluster will be null
+      assertNull(kafkaCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFailToFetchKafkaClusterIfAdminClientFails() {
+      // When there is a direct connection that thinks it has connected to Kafka but fails to create an admin client
+      var connection = new DirectConnectionState(KAFKA_AND_SR_SPEC, null) {
+        @Override
+        protected AdminClient createAdminClient(ConnectionSpec.KafkaClusterConfig config) {
+          throw new RuntimeException("Failed to create Admin client");
+        }
+
+        @Override
+        public boolean isKafkaConnected() {
+          return true;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectKafkaCluster> kafkaCluster = directFetcher.getKafkaCluster(CONNECTION_ID);
+
+      // Then the Kafka cluster will be null
+      assertNull(kafkaCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFailToFetchKafkaClusterWhenAdminClientFailsToReturnsClusterId() {
+      // When we have a mock admin client that returns the Kafka cluster ID
+      var mockAdminClient = mock(AdminClient.class);
+      var describeCluster = mock(DescribeClusterResult.class);
+      when(mockAdminClient.describeCluster()).thenReturn(describeCluster);
+      when(describeCluster.clusterId()).thenThrow(
+          new RuntimeException("Failed to get the cluster ID")
+      );
+
+      // And a direct connection that is connected to Kafka and uses that mock admin client
+      var connection = new DirectConnectionState(KAFKA_AND_SR_SPEC, null) {
+        @Override
+        protected AdminClient createAdminClient(ConnectionSpec.KafkaClusterConfig config) {
+          return mockAdminClient;
+        }
+
+        @Override
+        public boolean isKafkaConnected() {
+          return true;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectKafkaCluster> kafkaCluster = directFetcher.getKafkaCluster(CONNECTION_ID);
+
+      // Then the Kafka cluster will be null
+      assertNull(kafkaCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFetchKafkaClusterWhenConnectedAndAdminClientReturnsClusterId() {
+      // When we have a mock admin client that returns the Kafka cluster ID
+      var mockAdminClient = mock(AdminClient.class);
+      var describeCluster = mock(DescribeClusterResult.class);
+      when(mockAdminClient.describeCluster()).thenReturn(describeCluster);
+      when(describeCluster.clusterId()).thenReturn(KafkaFuture.completedFuture(KAFKA_CLUSTER_ID));
+
+      // And a direct connection that is connected to Kafka and uses that mock admin client
+      var connection = new DirectConnectionState(KAFKA_AND_SR_SPEC, null) {
+        @Override
+        protected AdminClient createAdminClient(ConnectionSpec.KafkaClusterConfig config) {
+          return mockAdminClient;
+        }
+
+        @Override
+        public boolean isKafkaConnected() {
+          return true;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectKafkaCluster> kafkaCluster = directFetcher.getKafkaCluster(CONNECTION_ID);
+
+      // Then the Kafka cluster will be returned
+      assertEquals(
+          new DirectKafkaCluster(KAFKA_CLUSTER_ID, null, KAFKA_BOOTSTRAP_SERVERS, CONNECTION_ID),
+          kafkaCluster.await().atMost(ONE_SECOND)
+      );
+    }
+
+    @Test
+    void shouldFetchNoKafkaClusterIfNoKafkaClusterIsConfigured() {
+      // When there is a direct connection that thinks it has connected to Kafka but has no Kafka cluster configured
+      var connection = new DirectConnectionState(NO_KAFKA_SPEC, null) {
+        @Override
+        public boolean isKafkaConnected() {
+          return true;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectKafkaCluster> kafkaCluster = directFetcher.getKafkaCluster(CONNECTION_ID);
+
+      // Then the Kafka cluster will be null
+      assertNull(kafkaCluster.await().atMost(ONE_SECOND));
+    }
+  }
+
+  @Nested
+  class FetchesSchemaRegistry {
+
+    @Test
+    void shouldSkipFetchingSchemaRegistryIfNotConnected() {
+      // When there is a direct connection
+      var connection = mock(DirectConnectionState.class);
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // That is not connected to Kafka
+      when(connection.isSchemaRegistryConnected()).thenReturn(false);
+
+      // And we try to fetch the Kafka cluster
+      Uni<DirectSchemaRegistry> srCluster = directFetcher.getSchemaRegistry(CONNECTION_ID);
+
+      // Then the Kafka cluster will be null
+      assertNull(srCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFailToFetchSchemaRegistryIfSrClientFails() {
+      // When there is a direct connection that thinks it has connected to SR but fails to create an SR client
+      var connection = new DirectConnectionState(NO_KAFKA_SPEC, null) {
+        @Override
+        public boolean isSchemaRegistryConnected() {
+          return true;
+        }
+
+        @Override
+        protected SchemaRegistryClient createSchemaRegistryClient(ConnectionSpec.SchemaRegistryConfig config) {
+          throw new RuntimeException("Failed to create Schema Registry client");
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the SR cluster
+      Uni<DirectSchemaRegistry> srCluster = directFetcher.getSchemaRegistry(CONNECTION_ID);
+
+      // Then the cluster will be null
+      assertNull(srCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFailToFetchSchemaRegistryWhenSrClientFailsToReturnsMode() throws IOException, RestClientException {
+      // When we have an SR client that returns the SR cluster's mode
+      var mockSrClient = mock(SchemaRegistryClient.class);
+      when(mockSrClient.getMode()).thenThrow(
+          new RuntimeException("Failed to get mode with Schema Registry client")
+      );
+
+      // And a direct connection that thinks it has connected to SR and returns that SR client
+      var connection = new DirectConnectionState(NO_KAFKA_SPEC, null) {
+        @Override
+        public boolean isSchemaRegistryConnected() {
+          return true;
+        }
+
+        @Override
+        protected SchemaRegistryClient createSchemaRegistryClient(ConnectionSpec.SchemaRegistryConfig config) {
+          return mockSrClient;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the SR cluster
+      Uni<DirectSchemaRegistry> srCluster = directFetcher.getSchemaRegistry(CONNECTION_ID);
+
+      // Then the cluster will be null
+      assertNull(srCluster.await().atMost(ONE_SECOND));
+    }
+
+    @Test
+    void shouldFetchSchemaRegistryWhenConnectedAndSrClientReturnsMode() throws IOException, RestClientException {
+      // When we have an SR client that returns the SR cluster's mode
+      var mockSrClient = new MockSchemaRegistryClient();
+      mockSrClient.setMode("READWRITE");
+
+      // And a direct connection that thinks it has connected to SR and returns that SR client
+      var connection = new DirectConnectionState(NO_KAFKA_SPEC, null) {
+        @Override
+        public boolean isSchemaRegistryConnected() {
+          return true;
+        }
+
+        @Override
+        protected SchemaRegistryClient createSchemaRegistryClient(ConnectionSpec.SchemaRegistryConfig config) {
+          return mockSrClient;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the SR cluster
+      Uni<DirectSchemaRegistry> srCluster = directFetcher.getSchemaRegistry(CONNECTION_ID);
+
+      // Then the cluster will be returned
+      assertEquals(
+          new DirectSchemaRegistry(SR_CLUSTER_ID, SR_URL, CONNECTION_ID),
+          srCluster.await().atMost(ONE_SECOND)
+      );
+    }
+
+    @Test
+    void shouldFetchNoSchemaRegistryIfNoSchemaRegistryIsConfigured() {
+      // When there is a direct connection that thinks it has connected to SR but has no SR configured
+      var connection = new DirectConnectionState(NO_SR_SPEC, null) {
+        @Override
+        public boolean isSchemaRegistryConnected() {
+          return true;
+        }
+      };
+
+      // And that connection is in the manager
+      when(connections.getConnectionState(eq(CONNECTION_ID))).thenReturn(connection);
+
+      // And we try to fetch the SR cluster
+      Uni<DirectSchemaRegistry> srCluster = directFetcher.getSchemaRegistry(CONNECTION_ID);
+
+      // Then the cluster will be null
+      assertNull(srCluster.await().atMost(ONE_SECOND));
+    }
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -316,6 +316,15 @@ public class SidecarClient implements SidecarClientApi {
     } else {
       assertNotNull(connection.id());
     }
+
+    // Get the connection to make sure the status is updated
+    // TODO: This can be removed once we fix issue #181 https://github.com/confluentinc/ide-sidecar/issues/181
+    given()
+        .when()
+        .get("%s/gateway/v1/connections/%s".formatted(sidecarHost, connection.id()))
+        .then()
+        .statusCode(200);
+
     // Use this connection for subsequent operations
     currentConnectionId = connection.id();
     return connection;
@@ -575,7 +584,7 @@ public class SidecarClient implements SidecarClientApi {
       await()
            .pollDelay(Duration.ofMillis(20))
            .pollInterval(Duration.ofMillis(10))
-           .atMost(Duration.ofMillis(100))
+           .atMost(Duration.ofMillis(250))
            .until(()->getLatestSchemaVersion(subject, currentSchemaClusterId) != null);
 
         return getLatestSchemaVersion(subject, currentSchemaClusterId);


### PR DESCRIPTION
Resolves #197. Also relates to #181

## Summary of Changes

Modifies `ConnectionState` as follows:
* add a new `cachedStatus` field to store the most recent status
* renames the asynchronous `getConnectionStatus(): Future<ConnectionStatus>` method to `refreshStatus(): Future<ConnectionStatus>`, changed the implementation to:
  * delegate to a new protected method called `doRefreshStatus()` that subclasses override
  * update the `cachedStatus` field
* add a new *synchronous* `getStatus(): ConnectionStatus` method that returns the `cachedStatus` value

All the uses of the old async `getConnectionStatus(): Future<ConnectionStatus>` have been changed to use the newer async `refreshConnectionStatus(): Future<ConnectionStatus>` method.

The `DirectConnectionState` class was changed to have two convenience methods:
* `isKafkaConnected()` returns true when `status.kafkaCluster().isConnected()` is true; and
* `isSchemaRegistryConnected()` returns true when `status.kafkaCluster().isConnected()` is true

When we want to implement the async status update mechanism (#181), that mechanism only has to call the async `refreshConnectionStatus()`, which will then automatically cache the status in the `ConnectionState` instance.

This commit also changes `RealDirectFetcher` to use the two convenience methods to check the status of the connection’s Kafka cluster and SR *before* using the AdminClient or SR client, respectively, to construct the corresponding cluster information. Only when the status is “SUCCESS” will the clients be used; in all other cases, the `RealDirectFetcher` quickly returning no cluster information.

Added new unit tests for `RealDirectFetcher` to verify the behavior for various statuses and error conditions.

## Any additional details or context that should be provided?

This reduces the risk of blocked threads when the connection's status is up-to-date and known to be good or bad. Right now any `GET /gateway/v1/connections` request will cause all connections' status to be updated, and `GET /gateway/v1/connections/{id}` request will cause that connection's status to be updated.

It still is relatively easy to get out of sync. For example, blocked queries are still a risk if the extension issues GraphQL queries some time after either of the two `GET` requests are issued, or when the connectivity to the external Kafka and/or SR clusters are affected (e.g., by stopping the external Kafka and/or SR clusters) without refreshing the statuses.

We really need #181 to help the sidecar maintain an up-to-date status for all connections.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

