### PR TITLE
Refresh status of CCloud connections upon completion of auth flow

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
@@ -73,7 +73,11 @@ public class OAuthCallbackResource {
                     .data("vscode_redirect_uri", CCLOUD_OAUTH_VSCODE_EXTENSION_URI)
                     .render()
             )
-            .recover(this::renderFailure);
+            .recover(this::renderFailure)
+            // Upon completion of the auth flow, refresh the status of the CCloud connection
+            .compose(responseBody ->
+                cCloudConnectionState.refreshStatus().map(ignored -> responseBody)
+            );
         return Uni
             .createFrom()
             .completionStage(

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
@@ -75,9 +75,7 @@ public class OAuthCallbackResource {
             )
             .recover(this::renderFailure)
             // Upon completion of the auth flow, refresh the status of the CCloud connection
-            .compose(responseBody ->
-                cCloudConnectionState.refreshStatus().map(ignored -> responseBody)
-            );
+            .andThen(ignored -> cCloudConnectionState.refreshStatus());
         return Uni
             .createFrom()
             .completionStage(

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
@@ -56,7 +56,7 @@ public class OAuthCallbackResourceTest {
     String authorizationCode = "bar";
     ccloudTestUtil.registerWireMockRoutesForCCloudOAuth(authorizationCode);
 
-    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
+    verifyStatusOfConfluentCloudConnectionEqualsInitialStatus(connectionState.getId());
 
     given()
         .queryParam("code", authorizationCode)
@@ -94,7 +94,7 @@ public class OAuthCallbackResourceTest {
             ).atPriority(50)
     );
 
-    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
+    verifyStatusOfConfluentCloudConnectionEqualsInitialStatus(connectionState.getId());
 
     given()
         .queryParam("state", connectionState.getInternalId())
@@ -135,7 +135,7 @@ public class OAuthCallbackResourceTest {
         new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
     );
 
-    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
+    verifyStatusOfConfluentCloudConnectionEqualsInitialStatus(connectionState.getId());
 
     given()
         .queryParam("state", "INVALID_STATE")
@@ -147,10 +147,10 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Invalid or expired state INVALID_STATE"));
 
     // CCloud connection should remain in initial state and have no errors
-    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
+    verifyStatusOfConfluentCloudConnectionEqualsInitialStatus(connectionState.getId());
   }
 
-  void verifyStateOfConfluentCloudConnectionEqualsInitialState(String connectionId) {
+  void verifyStatusOfConfluentCloudConnectionEqualsInitialStatus(String connectionId) {
     verifyStateAndErrorsOfConfluentCloudConnection(
         connectionId,
         ConnectedState.NONE,

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
@@ -56,7 +56,7 @@ public class OAuthCallbackResourceTest {
     String authorizationCode = "bar";
     ccloudTestUtil.registerWireMockRoutesForCCloudOAuth(authorizationCode);
 
-    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
 
     given()
         .queryParam("code", authorizationCode)
@@ -68,7 +68,7 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Authentication Complete"));
 
     // CCloud connection should hold valid control plane token and have no errors
-    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
+    verifyStateAndErrorsOfConfluentCloudConnection(
         connectionState.getId(),
         ConnectedState.SUCCESS,
         false
@@ -94,7 +94,7 @@ public class OAuthCallbackResourceTest {
             ).atPriority(50)
     );
 
-    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
 
     given()
         .queryParam("state", connectionState.getInternalId())
@@ -105,7 +105,7 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Authentication Failed"));
 
     // CCloud connection should remain in initial state but have errors
-    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
+    verifyStateAndErrorsOfConfluentCloudConnection(
         connectionState.getId(),
         ConnectedState.NONE,
         true
@@ -135,7 +135,7 @@ public class OAuthCallbackResourceTest {
         new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
     );
 
-    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
 
     given()
         .queryParam("state", "INVALID_STATE")
@@ -147,11 +147,11 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Invalid or expired state INVALID_STATE"));
 
     // CCloud connection should remain in initial state and have no errors
-    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+    verifyStateOfConfluentCloudConnectionEqualsInitialState(connectionState.getId());
   }
 
-  void confluentCloudConnectionShouldBeInInitialState(String connectionId) {
-    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
+  void verifyStateOfConfluentCloudConnectionEqualsInitialState(String connectionId) {
+    verifyStateAndErrorsOfConfluentCloudConnection(
         connectionId,
         ConnectedState.NONE,
         false
@@ -166,7 +166,7 @@ public class OAuthCallbackResourceTest {
    * @param expectedState the expected state of the CCloud connection
    * @param expectErrors  whether we expect the CCloud connection to hold errors
    */
-  void confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
+  void verifyStateAndErrorsOfConfluentCloudConnection(
       String connectionId,
       ConnectedState expectedState,
       boolean expectErrors

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
@@ -2,21 +2,28 @@ package io.confluent.idesidecar.restapi.resources;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.exceptions.CreateConnectionException;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.CCloudTestUtil;
 import io.quarkiverse.wiremock.devservice.ConnectWireMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
+@TestProfile(NoAccessFilterProfile.class)
 @ConnectWireMock
 public class OAuthCallbackResourceTest {
 
@@ -43,7 +50,8 @@ public class OAuthCallbackResourceTest {
       throws CreateConnectionException {
 
     var connectionState = connectionStateManager.createConnectionState(
-        new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD));
+        new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
+    );
 
     String authorizationCode = "bar";
     ccloudTestUtil.registerWireMockRoutesForCCloudOAuth(authorizationCode);
@@ -56,6 +64,13 @@ public class OAuthCallbackResourceTest {
         .then()
         .statusCode(200)
         .body(containsString("Authentication Complete"));
+
+    // CCloud connection should hold valid control plane token and have no errors
+    confluentCloudConnectionShouldHaveStateAndErrors(
+        connectionState.getId(),
+        ConnectedState.SUCCESS,
+        false
+    );
   }
 
   @Test
@@ -63,7 +78,8 @@ public class OAuthCallbackResourceTest {
       throws CreateConnectionException {
 
     var connectionState = connectionStateManager.createConnectionState(
-        new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD));
+        new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
+    );
 
     wireMock.register(
         WireMock
@@ -72,7 +88,9 @@ public class OAuthCallbackResourceTest {
                 WireMock
                     .aResponse()
                     .withStatus(201)
-                    .withBody("")).atPriority(50));
+                    .withBody("")
+            ).atPriority(50)
+    );
 
     given()
         .queryParam("state", connectionState.getInternalId())
@@ -81,6 +99,13 @@ public class OAuthCallbackResourceTest {
         .then()
         .statusCode(200)
         .body(containsString("Authentication Failed"));
+
+    // CCloud connection should remain in initial state and have errors
+    confluentCloudConnectionShouldHaveStateAndErrors(
+        connectionState.getId(),
+        ConnectedState.NONE,
+        true
+    );
   }
 
   @Test
@@ -88,7 +113,8 @@ public class OAuthCallbackResourceTest {
       throws CreateConnectionException {
 
     var connectionState = connectionStateManager.createConnectionState(
-        new ConnectionSpec("id-1", "conn-1", ConnectionType.LOCAL));
+        new ConnectionSpec("id-1", "conn-1", ConnectionType.LOCAL)
+    );
 
     given()
         .queryParam("state", connectionState.getInternalId())
@@ -100,11 +126,10 @@ public class OAuthCallbackResourceTest {
   }
 
   @Test
-  void callbackRendersAuthenticationFailedIfStateIsInvalid()
-      throws CreateConnectionException {
-
+  void callbackRendersAuthenticationFailedIfStateIsInvalid() throws CreateConnectionException {
     var connectionState = connectionStateManager.createConnectionState(
-        new ConnectionSpec("id-1", "conn-1", ConnectionType.LOCAL));
+        new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
+    );
 
     given()
         .queryParam("state", "INVALID_STATE")
@@ -114,5 +139,34 @@ public class OAuthCallbackResourceTest {
         .statusCode(200)
         .body(containsString("Authentication Failed"))
         .body(containsString("Invalid or expired state INVALID_STATE"));
+
+    // CCloud connection should remain in initial state and have no errors
+    confluentCloudConnectionShouldHaveStateAndErrors(
+        connectionState.getId(),
+        ConnectedState.NONE,
+        false
+    );
+  }
+
+  /**
+   * Helper method to verify if the fields <code>state</code> and <code>errors</code> of a given
+   * CCloud connection's status match given expectations.
+   *
+   * @param connectionId  the ID of the CCloud connection
+   * @param expectedState the expected state of the CCloud connection
+   * @param expectErrors  whether we expect the CCloud connection to hold errors
+   */
+  void confluentCloudConnectionShouldHaveStateAndErrors(
+      String connectionId,
+      ConnectedState expectedState,
+      boolean expectErrors
+  ) {
+    given()
+        .when()
+        .get("/gateway/v1/connections/%s".formatted(connectionId))
+        .then()
+        .statusCode(200)
+        .body("status.ccloud.state", equalTo(expectedState.toString()))
+        .body("status.ccloud.errors", expectErrors ? notNullValue() : nullValue());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
@@ -56,6 +56,8 @@ public class OAuthCallbackResourceTest {
     String authorizationCode = "bar";
     ccloudTestUtil.registerWireMockRoutesForCCloudOAuth(authorizationCode);
 
+    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+
     given()
         .queryParam("code", authorizationCode)
         .queryParam("state", connectionState.getInternalId())
@@ -92,6 +94,8 @@ public class OAuthCallbackResourceTest {
             ).atPriority(50)
     );
 
+    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+
     given()
         .queryParam("state", connectionState.getInternalId())
         .when()
@@ -100,7 +104,7 @@ public class OAuthCallbackResourceTest {
         .statusCode(200)
         .body(containsString("Authentication Failed"));
 
-    // CCloud connection should remain in initial state and have errors
+    // CCloud connection should remain in initial state but have errors
     confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
         connectionState.getId(),
         ConnectedState.NONE,
@@ -131,6 +135,8 @@ public class OAuthCallbackResourceTest {
         new ConnectionSpec("id-1", "conn-1", ConnectionType.CCLOUD)
     );
 
+    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+
     given()
         .queryParam("state", "INVALID_STATE")
         .when()
@@ -141,8 +147,12 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Invalid or expired state INVALID_STATE"));
 
     // CCloud connection should remain in initial state and have no errors
+    confluentCloudConnectionShouldBeInInitialState(connectionState.getId());
+  }
+
+  void confluentCloudConnectionShouldBeInInitialState(String connectionId) {
     confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
-        connectionState.getId(),
+        connectionId,
         ConnectedState.NONE,
         false
     );

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResourceTest.java
@@ -66,7 +66,7 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Authentication Complete"));
 
     // CCloud connection should hold valid control plane token and have no errors
-    confluentCloudConnectionShouldHaveStateAndErrors(
+    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
         connectionState.getId(),
         ConnectedState.SUCCESS,
         false
@@ -101,7 +101,7 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Authentication Failed"));
 
     // CCloud connection should remain in initial state and have errors
-    confluentCloudConnectionShouldHaveStateAndErrors(
+    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
         connectionState.getId(),
         ConnectedState.NONE,
         true
@@ -141,7 +141,7 @@ public class OAuthCallbackResourceTest {
         .body(containsString("Invalid or expired state INVALID_STATE"));
 
     // CCloud connection should remain in initial state and have no errors
-    confluentCloudConnectionShouldHaveStateAndErrors(
+    confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
         connectionState.getId(),
         ConnectedState.NONE,
         false
@@ -156,7 +156,7 @@ public class OAuthCallbackResourceTest {
    * @param expectedState the expected state of the CCloud connection
    * @param expectErrors  whether we expect the CCloud connection to hold errors
    */
-  void confluentCloudConnectionShouldHaveStateAndErrors(
+  void confluentCloudConnectionShouldBeInStateAndMaybeHoldErrors(
       String connectionId,
       ConnectedState expectedState,
       boolean expectErrors


### PR DESCRIPTION
## Summary of Changes

Upon the completion of the authentication flow and regardless of the outcome, refresh the status of CCloud connections so that the extension can immediately act on it.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

