### PR TITLE
Close the admin client with a specified duration

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -268,8 +268,9 @@ public class DirectConnectionState extends ConnectionState {
     if (kafkaClusterConfig == null) {
       return Optional.empty();
     }
-    var adminClient = createAdminClient(kafkaClusterConfig);
+    AdminClient adminClient = null;
     try {
+      adminClient = createAdminClient(kafkaClusterConfig);
       return Optional.ofNullable(
           operation.apply(adminClient)
       );
@@ -284,15 +285,17 @@ public class DirectConnectionState extends ConnectionState {
           errorHandler.apply(e)
       );
     } finally {
-      try {
-        adminClient.close(TIMEOUT);
-      } catch (Throwable e) {
-        Log.errorf(
-            "Error closing the client to the Kafka cluster at %s: %s",
-            kafkaClusterConfig.bootstrapServers(),
-            e.getMessage(),
-            e
-        );
+      if (adminClient != null) {
+        try {
+          adminClient.close(TIMEOUT);
+        } catch (Throwable e) {
+          Log.errorf(
+              "Error closing the client to the Kafka cluster at %s: %s",
+              kafkaClusterConfig.bootstrapServers(),
+              e.getMessage(),
+              e
+          );
+        }
       }
     }
   }
@@ -331,8 +334,9 @@ public class DirectConnectionState extends ConnectionState {
     if (srConfig == null) {
       return Optional.empty();
     }
-    var srClient = createSchemaRegistryClient(srConfig);
+    SchemaRegistryClient srClient = null;
     try {
+      srClient = createSchemaRegistryClient(srConfig);
       return Optional.ofNullable(
           operation.apply(srClient)
       );
@@ -347,15 +351,17 @@ public class DirectConnectionState extends ConnectionState {
           errorHandler.apply(e)
       );
     } finally {
-      try {
-        srClient.close();
-      } catch (Throwable e) {
-        Log.errorf(
-            "Error closing the client to the Schema Registry at %s: %s",
-            srConfig.uri(),
-            e.getMessage(),
-            e
-        );
+      if (srClient != null) {
+        try {
+          srClient.close();
+        } catch (Throwable e) {
+          Log.errorf(
+              "Error closing the client to the Schema Registry at %s: %s",
+              srConfig.uri(),
+              e.getMessage(),
+              e
+          );
+        }
       }
     }
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -268,7 +268,8 @@ public class DirectConnectionState extends ConnectionState {
     if (kafkaClusterConfig == null) {
       return Optional.empty();
     }
-    try (var adminClient = createAdminClient(kafkaClusterConfig)) {
+    var adminClient = createAdminClient(kafkaClusterConfig);
+    try {
       return Optional.ofNullable(
           operation.apply(adminClient)
       );
@@ -282,6 +283,17 @@ public class DirectConnectionState extends ConnectionState {
       return Optional.ofNullable(
           errorHandler.apply(e)
       );
+    } finally {
+      try {
+        adminClient.close(TIMEOUT);
+      } catch (Throwable e) {
+        Log.errorf(
+            "Error closing the client to the Kafka cluster at %s: %s",
+            kafkaClusterConfig.bootstrapServers(),
+            e.getMessage(),
+            e
+        );
+      }
     }
   }
 
@@ -319,7 +331,8 @@ public class DirectConnectionState extends ConnectionState {
     if (srConfig == null) {
       return Optional.empty();
     }
-    try (var srClient = createSchemaRegistryClient(srConfig)) {
+    var srClient = createSchemaRegistryClient(srConfig);
+    try {
       return Optional.ofNullable(
           operation.apply(srClient)
       );
@@ -333,6 +346,17 @@ public class DirectConnectionState extends ConnectionState {
       return Optional.ofNullable(
           errorHandler.apply(e)
       );
+    } finally {
+      try {
+        srClient.close();
+      } catch (Throwable e) {
+        Log.errorf(
+            "Error closing the client to the Schema Registry at %s: %s",
+            srConfig.uri(),
+            e.getMessage(),
+            e
+        );
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #206

## Summary of Changes

The default timeout for KafkaAdminClient.close() is a year (!), so we want to close the DirectConnectionState’s admin client with far shorter timeout (5 sec), since there is a good chance the connection will not be configured correctly.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

