### PR TITLE
Add mTLS and OAuth 2.0 support for direct connections to Kafka and SR

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -659,7 +659,7 @@
   "components" : {
     "schemas" : {
       "ApiKeyAndSecret" : {
-        "description" : "Basic authentication credentials",
+        "description" : "API key and secret authentication credentials",
         "required" : [ "api_key", "api_secret" ],
         "type" : "object",
         "properties" : {
@@ -1128,6 +1128,10 @@
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
               "$ref" : "#/components/schemas/ApiKeyAndSecret"
+            }, {
+              "$ref" : "#/components/schemas/MutualTLSCredentials"
+            }, {
+              "$ref" : "#/components/schemas/OAuthCredentials"
             } ],
             "nullable" : true
           },
@@ -1180,6 +1184,98 @@
           "schema-registry-uri" : {
             "description" : "The URL of the Schema Registry running locally.",
             "maxLength" : 512,
+            "type" : "string"
+          }
+        }
+      },
+      "MutualTLSCredentials" : {
+        "description" : "Mutual TLS authentication credentials",
+        "required" : [ "truststore_path", "keystore_path" ],
+        "type" : "object",
+        "properties" : {
+          "truststore_path" : {
+            "description" : "The path to the local trust store file.",
+            "maxLength" : 256,
+            "type" : "string"
+          },
+          "truststore_password" : {
+            "description" : "The password for the local trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. A trust store password is not supported for PEM format.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
+          },
+          "truststore_type" : {
+            "description" : "The file format of the local trust store file",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/StoreType"
+            } ]
+          },
+          "keystore_path" : {
+            "description" : "The path to the local key store file.",
+            "maxLength" : 256,
+            "type" : "string"
+          },
+          "keystore_password" : {
+            "description" : "The password for the local key store file. If a password is not set, trust  store file configured will still be used, but integrity checking is disabled. A key store password is not supported for PEM format.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
+          },
+          "keystore_type" : {
+            "description" : "The file format of the local key store file.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/StoreType"
+            } ]
+          },
+          "key_password" : {
+            "description" : "The password of the private key in the local key store file.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
+          }
+        }
+      },
+      "OAuthCredentials" : {
+        "description" : "OAuth 2.0 authentication credentials",
+        "required" : [ "tokens_url", "client_id" ],
+        "type" : "object",
+        "properties" : {
+          "tokens_url" : {
+            "description" : "The URL of the OAuth 2.0 identity provider's token endpoint.",
+            "maxLength" : 256,
+            "type" : "string"
+          },
+          "client_id" : {
+            "description" : "The public identifier for the application as registered with the OAuth 2.0 identity provider.",
+            "maxLength" : 128,
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "client_secret" : {
+            "description" : "The client secret known only to the application and the OAuth 2.0 identity provider.",
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
+          },
+          "scope" : {
+            "description" : "The scope to use. The scope is optional and required only when your identity provider doesn't have a default scope or your groups claim is linked to a scope path to use when connecting to the external service.",
+            "maxLength" : 256,
+            "type" : "string"
+          },
+          "connect_timeout_millis" : {
+            "format" : "int32",
+            "description" : "The timeout in milliseconds when connecting to your identity provider.",
+            "minimum" : 0,
+            "type" : "integer"
+          },
+          "identityPool" : {
+            "description" : "Additional property that can be added in the request header to identify the principal ID for authorization. For example, this may bea Confluent Cloud identity pool.",
             "type" : "string"
           }
         }
@@ -1386,6 +1482,10 @@
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
               "$ref" : "#/components/schemas/ApiKeyAndSecret"
+            }, {
+              "$ref" : "#/components/schemas/MutualTLSCredentials"
+            }, {
+              "$ref" : "#/components/schemas/OAuthCredentials"
             } ],
             "nullable" : true
           }
@@ -1484,6 +1584,10 @@
       },
       "Status" : {
         "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN", "FAILED" ],
+        "type" : "string"
+      },
+      "StoreType" : {
+        "enum" : [ "JKS", "PKCS12", "PEM", "UNKNOWN" ],
         "type" : "string"
       },
       "Template" : {

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -445,7 +445,7 @@ paths:
 components:
   schemas:
     ApiKeyAndSecret:
-      description: Basic authentication credentials
+      description: API key and secret authentication credentials
       required:
       - api_key
       - api_secret
@@ -819,6 +819,8 @@ components:
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
+          - $ref: "#/components/schemas/MutualTLSCredentials"
+          - $ref: "#/components/schemas/OAuthCredentials"
           nullable: true
         ssl:
           description: "Whether to communicate with the Kafka cluster over TLS/SSL.\
@@ -863,6 +865,92 @@ components:
         schema-registry-uri:
           description: The URL of the Schema Registry running locally.
           maxLength: 512
+          type: string
+    MutualTLSCredentials:
+      description: Mutual TLS authentication credentials
+      required:
+      - truststore_path
+      - keystore_path
+      type: object
+      properties:
+        truststore_path:
+          description: The path to the local trust store file.
+          maxLength: 256
+          type: string
+        truststore_password:
+          description: "The password for the local trust store file. If a password\
+            \ is not set, trust store file configured will still be used, but integrity\
+            \ checking is disabled. A trust store password is not supported for PEM\
+            \ format."
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Password"
+        truststore_type:
+          description: The file format of the local trust store file
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/StoreType"
+        keystore_path:
+          description: The path to the local key store file.
+          maxLength: 256
+          type: string
+        keystore_password:
+          description: "The password for the local key store file. If a password is\
+            \ not set, trust  store file configured will still be used, but integrity\
+            \ checking is disabled. A key store password is not supported for PEM\
+            \ format."
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Password"
+        keystore_type:
+          description: The file format of the local key store file.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/StoreType"
+        key_password:
+          description: The password of the private key in the local key store file.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Password"
+    OAuthCredentials:
+      description: OAuth 2.0 authentication credentials
+      required:
+      - tokens_url
+      - client_id
+      type: object
+      properties:
+        tokens_url:
+          description: The URL of the OAuth 2.0 identity provider's token endpoint.
+          maxLength: 256
+          type: string
+        client_id:
+          description: The public identifier for the application as registered with
+            the OAuth 2.0 identity provider.
+          maxLength: 128
+          minLength: 1
+          type: string
+        client_secret:
+          description: The client secret known only to the application and the OAuth
+            2.0 identity provider.
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Password"
+        scope:
+          description: The scope to use. The scope is optional and required only when
+            your identity provider doesn't have a default scope or your groups claim
+            is linked to a scope path to use when connecting to the external service.
+          maxLength: 256
+          type: string
+        connect_timeout_millis:
+          format: int32
+          description: The timeout in milliseconds when connecting to your identity
+            provider.
+          minimum: 0
+          type: integer
+        identityPool:
+          description: "Additional property that can be added in the request header\
+            \ to identify the principal ID for authorization. For example, this may\
+            \ bea Confluent Cloud identity pool."
           type: string
     ObjectMetadata:
       type: object
@@ -1013,6 +1101,8 @@ components:
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
+          - $ref: "#/components/schemas/MutualTLSCredentials"
+          - $ref: "#/components/schemas/OAuthCredentials"
           nullable: true
     SchemaRegistryStatus:
       description: The status related to the specified Schema Registry.
@@ -1083,6 +1173,13 @@ components:
       - VALID_TOKEN
       - INVALID_TOKEN
       - FAILED
+      type: string
+    StoreType:
+      enum:
+      - JKS
+      - PKCS12
+      - PEM
+      - UNKNOWN
       type: string
     Template:
       required:

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(description = "Basic authentication credentials")
+@Schema(description = "API key and secret authentication credentials")
 @RegisterForReflection
 public record ApiKeyAndSecret(
 

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/Credentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/Credentials.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 @JsonSubTypes({
     @Type(value = BasicCredentials.class),
     @Type(value = ApiKeyAndSecret.class),
+    @Type(value = MutualTLSCredentials.class),
+    @Type(value = OAuthCredentials.class)
 })
 @RegisterForReflection
 public interface Credentials {
@@ -41,6 +43,8 @@ public interface Credentials {
 
   enum Type {
     BASIC,
+    MUTUAL_TLS,
+    OAUTH2,
     API_KEY_AND_SECRET,
   }
 
@@ -61,6 +65,26 @@ public interface Credentials {
   @JsonIgnore
   default boolean isBasic() {
     return type() == Type.BASIC;
+  }
+
+  /**
+   * Return true if this is a mutual TLS credentials object.
+   *
+   * @return true if {@link #type()} equals {@link Type#MUTUAL_TLS}
+   */
+  @JsonIgnore
+  default boolean isMutualTls() {
+    return type() == Type.MUTUAL_TLS;
+  }
+
+  /**
+   * Return true if this is an OAuth 2.0 credentials object.
+   *
+   * @return true if {@link #type()} equals {@link Type#OAUTH2}
+   */
+  @JsonIgnore
+  default boolean isOauth2() {
+    return type() == Type.OAUTH2;
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/MutualTLSCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/MutualTLSCredentials.java
@@ -1,0 +1,292 @@
+package io.confluent.idesidecar.restapi.credentials;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.confluent.idesidecar.restapi.exceptions.Failure;
+import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Size;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Mutual TLS authentication credentials")
+public record MutualTLSCredentials(
+    @Schema(description = "The path to the local trust store file.")
+    @JsonProperty(value = "truststore_path")
+    @Size(max = TRUSTSTORE_PATH_MAX_LEN)
+    @NotNull
+    String truststorePath,
+
+    @Schema(
+        description = "The password for the local trust store file. If a password is not set, "
+                      + "trust store file configured will still be used, but integrity checking "
+                      + "is disabled. A trust store password is not supported for PEM format."
+    )
+    @JsonProperty(value = "truststore_password")
+    @Size(max = TRUSTSTORE_PASSWORD_MAX_LEN)
+    @Null
+    Password truststorePassword,
+
+    @Schema(description = "The file format of the local trust store file")
+    @JsonProperty(value = "truststore_type")
+    @Null
+    StoreType truststoreType,
+
+    @Schema(description = "The path to the local key store file.")
+    @JsonProperty(value = "keystore_path")
+    @Size(max = KEYSTORE_PATH_MAX_LEN)
+    @NotNull
+    String keystorePath,
+
+    @Schema(
+        description = "The password for the local key store file. If a password is not set, trust "
+                      + " store file configured will still be used, but integrity checking is "
+                      + "disabled. A key store password is not supported for PEM format."
+    )
+    @JsonProperty(value = "keystore_password")
+    @Size(max = KEYSTORE_PASSWORD_MAX_LEN)
+    @Null
+    Password keystorePassword,
+
+    @Schema(description = "The file format of the local key store file.")
+    @JsonProperty(value = "keystore_type")
+    @Null
+    StoreType keystoreType,
+
+    @Schema(description = "The password of the private key in the local key store file.")
+    @JsonProperty(value = "key_password")
+    @Size(max = KEY_PASSWORD_MAX_LEN)
+    @Null
+    Password keyPassword
+) implements Credentials {
+
+  private static final int TRUSTSTORE_PATH_MAX_LEN = 256;
+  private static final int TRUSTSTORE_PASSWORD_MAX_LEN = 256;
+  private static final int KEYSTORE_PATH_MAX_LEN = 256;
+  private static final int KEYSTORE_PASSWORD_MAX_LEN = 256;
+  private static final int KEY_PASSWORD_MAX_LEN = 256;
+
+  @JsonDeserialize(using = StoreType.Deserializer.class)
+  public enum StoreType {
+    JKS,
+    PKCS12,
+    PEM,
+    @Schema(hidden = true)
+    @JsonEnumDefaultValue
+    UNKNOWN;
+
+    /**
+     * A custom deserializer to handle the store type literals that cannot be parsed.
+     */
+    public static class Deserializer extends JsonDeserializer<StoreType> {
+      @Override
+      public StoreType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        try {
+          return StoreType.valueOf(p.getValueAsString());
+        } catch (IllegalArgumentException e) {
+          return StoreType.UNKNOWN; // Return default on unknown value
+        }
+      }
+    }
+
+    /**
+     * Get the list of allowed values for this enum, without hidden values.
+     * @return the non-hidden allowed values as a comma-separated string
+     */
+    public static String allowedValues() {
+      return Arrays
+          .stream(values())
+          .filter(v -> v != UNKNOWN)
+          .map(Enum::name)
+          .collect(Collectors.joining(", "));
+    }
+  }
+
+  public MutualTLSCredentials(
+      String truststorePath,
+      Password truststorePassword,
+      String keystorePath,
+      Password keystorePassword,
+      Password keyPassword
+  ) {
+    this(
+        truststorePath,
+        truststorePassword,
+        null,
+        keystorePath,
+        keystorePassword,
+        null,
+        keyPassword
+    );
+  }
+
+  @Override
+  public Type type() {
+    return Type.MUTUAL_TLS;
+  }
+
+  @Override
+  public Optional<Map<String, String>> kafkaClientProperties(
+      KafkaConnectionOptions options
+  ) {
+    var config = new LinkedHashMap<String, String>();
+    config.put("security.protocol", "SSL");
+    if (!options.verifyCertificates()) {
+      config.put("ssl.endpoint.identification.algorithm", "");
+    }
+    config.put("ssl.truststore.location", truststorePath);
+    if (truststoreType != null && truststoreType != StoreType.UNKNOWN) {
+      config.put("ssl.truststore.type", truststoreType.name());
+    }
+    if (truststorePassword != null) {
+      config.put("ssl.truststore.password", truststorePassword.asString(options.redact()));
+    }
+    config.put("ssl.keystore.location", keystorePath);
+    if (keystoreType != null && keystoreType != StoreType.UNKNOWN) {
+      config.put("ssl.keystore.type", keystoreType.name());
+    }
+    if (keystorePassword != null) {
+      config.put("ssl.keystore.password", keystorePassword.asString(options.redact()));
+    }
+    if (keyPassword != null) {
+      config.put("ssl.key.password", keyPassword.asString(options.redact()));
+    }
+    return Optional.of(config);
+  }
+
+  /**
+   * Schema Registry appears to support mTLS authentication with
+   * <a href="https://github.com/confluentinc/schema-registry/pull/957">this PR</a>,
+   * which basically uses the same properties and mechanisms as the Kafka clients except with
+   * a {@code schema.registry.} prefix. The documentation is unclear.
+   *
+   * @param options the connection options
+   * @return an empty optional
+   */
+  @Override
+  public Optional<Map<String, String>> schemaRegistryClientProperties(
+      SchemaRegistryConnectionOptions options
+  ) {
+    var config = new LinkedHashMap<String, String>();
+    config.put("ssl.truststore.location", truststorePath);
+    if (truststoreType != null && truststoreType != StoreType.UNKNOWN) {
+      config.put("ssl.truststore.type", truststoreType.name());
+    }
+    if (truststorePassword != null) {
+      config.put("ssl.truststore.password", truststorePassword.asString(options.redact()));
+    }
+    config.put("ssl.keystore.location", keystorePath);
+    if (keystoreType != null && keystoreType != StoreType.UNKNOWN) {
+      config.put("ssl.keystore.type", keystoreType.name());
+    }
+    if (keystorePassword != null) {
+      config.put("ssl.keystore.password", keystorePassword.asString(options.redact()));
+    }
+    if (keyPassword != null) {
+      config.put("ssl.key.password", keyPassword.asString(options.redact()));
+    }
+    return Optional.of(config);
+  }
+
+  @Override
+  public void validate(
+      List<Failure.Error> errors,
+      String path,
+      String what
+  ) {
+    if (truststoreType == StoreType.UNKNOWN) {
+      var values = StoreType.allowedValues();
+      errors.add(
+          Error.create()
+               .withDetail("%s truststore type if provided must be one of: %s", what, values)
+               .withSource("%s.truststore_type", path)
+      );
+    }
+    if (truststorePath == null || truststorePath.isBlank()) {
+      errors.add(
+          Error.create()
+               .withDetail("%s truststore path is required and may not be blank", what)
+               .withSource("%s.truststore_path", path)
+      );
+    } else if (truststorePath.length() > TRUSTSTORE_PATH_MAX_LEN) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s truststore path may not be longer than %d characters",
+                   what,
+                   TRUSTSTORE_PATH_MAX_LEN
+               )
+               .withSource("%s.truststore_path", path)
+      );
+    }
+    if (keystoreType == StoreType.UNKNOWN) {
+      var values = StoreType.allowedValues();
+      errors.add(
+          Error.create()
+               .withDetail("%s keystore type if provided must be one of: %s", what, values)
+               .withSource("%s.keystore_type", path)
+      );
+    }
+    if (keystorePath == null || keystorePath.isBlank()) {
+      errors.add(
+          Error.create()
+               .withDetail("%s keystore path is required and may not be blank", what)
+               .withSource("%s.keystore_path", path)
+      );
+    } else if (keystorePath.length() > KEYSTORE_PATH_MAX_LEN) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s keystore path may not be longer than %d characters",
+                   what,
+                   KEYSTORE_PATH_MAX_LEN
+               )
+               .withSource("%s.keystore_path", path)
+      );
+    }
+    if (truststorePassword != null && truststorePassword.longerThan(TRUSTSTORE_PASSWORD_MAX_LEN)) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s truststore password may not be longer than %d characters",
+                   what,
+                   TRUSTSTORE_PASSWORD_MAX_LEN
+               )
+               .withSource("%s.truststore_password", path)
+      );
+    }
+    if (keystorePassword != null && keystorePassword.longerThan(KEYSTORE_PASSWORD_MAX_LEN)) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s keystore password may not be longer than %d characters",
+                   what,
+                   KEYSTORE_PASSWORD_MAX_LEN
+               )
+               .withSource("%s.keystore_password", path)
+      );
+    }
+    if (keyPassword != null && keyPassword.longerThan(KEY_PASSWORD_MAX_LEN)) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s key password may not be longer than %d characters",
+                   what,
+                   KEY_PASSWORD_MAX_LEN
+               )
+               .withSource("%s.key_password", path)
+      );
+    }
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/OAuthCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/OAuthCredentials.java
@@ -1,0 +1,231 @@
+package io.confluent.idesidecar.restapi.credentials;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.idesidecar.restapi.exceptions.Failure;
+import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Size;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "OAuth 2.0 authentication credentials")
+public record OAuthCredentials(
+
+  @Schema(description = "The URL of the OAuth 2.0 identity provider's token endpoint.")
+  @JsonProperty(value = "tokens_url")
+  @Size(max = TOKENS_URL_MAX_LEN)
+  @NotNull
+  String tokensUrl,
+
+  @Schema(description = "The public identifier for the application as registered with the "
+                        + "OAuth 2.0 identity provider.")
+  @JsonProperty(value = "client_id")
+  @Size(min = 1, max = CLIENT_ID_MAX_LEN)
+  @NotNull
+  String clientId,
+
+  @Schema(description = "The client secret known only to the application and the "
+                        + "OAuth 2.0 identity provider.")
+  @JsonProperty(value = "client_secret")
+  @Size(max = CLIENT_SECRET_MAX_LEN)
+  @Null
+  Password clientSecret,
+
+  @Schema(description = "The scope to use. The scope is optional and required only when your "
+                        + "identity provider doesn't have a default scope or your groups claim is "
+                        + "linked to a scope path to use when connecting to the external service.")
+  @JsonProperty(value = "scope")
+  @Size(max = SCOPE_MAX_LEN)
+  @Null
+  String scope,
+
+  @Schema(description = "The timeout in milliseconds when connecting to your identity provider.")
+  @JsonProperty(value = "connect_timeout_millis")
+  @Min(0)
+  @Null
+  Integer connectTimeoutMillis,
+
+  @Schema(description = "Additional property that can be added in the request header to identify "
+                        + "the principal ID for authorization. For example, this may be"
+                        + "a Confluent Cloud identity pool.")
+  @Null
+  String identityPool
+) implements Credentials {
+
+  private static final int TOKENS_URL_MAX_LEN = 256;
+  private static final int CLIENT_ID_MAX_LEN = 128;
+  private static final int CLIENT_SECRET_MAX_LEN = 256;
+  private static final int SCOPE_MAX_LEN = 256;
+
+  private static final String OAUTHBEARER_LOGIN_MODULE_CLASS =
+      "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule";
+  private static final String OAUTHBEARER_CALLBACK_CLASS =
+      "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler";
+
+  public OAuthCredentials(
+      String tokensUrl,
+      String clientId,
+      Password clientSecret,
+      String scope) {
+    this(tokensUrl, clientId, clientSecret, scope, null, null);
+  }
+
+  public OAuthCredentials(
+      String tokensUrl,
+      String clientId,
+      Password clientSecret
+  ) {
+    this(tokensUrl, clientId, clientSecret, null, null, null);
+  }
+
+  @Override
+  public Type type() {
+    return Type.MUTUAL_TLS;
+  }
+
+  @Override
+  public Optional<Map<String, String>> kafkaClientProperties(
+      KafkaConnectionOptions options
+  ) {
+    var jaasConfig = "%s required clientId=\"%s\"".formatted(
+        OAUTHBEARER_LOGIN_MODULE_CLASS,
+        clientId
+    );
+    if (clientSecret != null) {
+      jaasConfig += " clientSecret=\"%s\"".formatted(clientSecret.asString(options.redact()));
+    }
+    if (scope != null) {
+      jaasConfig += " scope=\"%s\"".formatted(scope);
+    }
+
+    var config = new LinkedHashMap<String, String>();
+    config.put("security.protocol", "SASL_SSL");
+    if (!options.verifyCertificates()) {
+      config.put("ssl.endpoint.identification.algorithm", "");
+    }
+    config.put("sasl.mechanism", "OAUTHBEARER");
+    config.put("sasl.oauthbearer.token.endpoint.url", tokensUrl);
+    config.put("sasl.login.callback.handler.class", OAUTHBEARER_CALLBACK_CLASS);
+    config.put("sasl.jaas.config", jaasConfig);
+    if (connectTimeoutMillis != null) {
+      config.put("sasl.oauthbearer.connect.timeout.ms", connectTimeoutMillis.toString());
+    }
+    return Optional.of(config);
+  }
+
+  @Override
+  public Optional<Map<String, String>> schemaRegistryClientProperties(
+      SchemaRegistryConnectionOptions options
+  ) {
+    var config = new LinkedHashMap<String, String>();
+    config.put("bearer.auth.credentials.source", "OAUTHBEARER");
+    config.put("bearer.auth.issuer.endpoint.url", tokensUrl);
+    config.put("bearer.auth.client.id", clientId);
+    config.put("bearer.auth.client.secret", clientSecret.asString(options.redact()));
+    if (scope != null) {
+      config.put("bearer.auth.scope", scope);
+    }
+    if (options.logicalClusterId() != null) {
+      config.put("bearer.auth.logical.cluster", options.logicalClusterId());
+    }
+    if (identityPool != null) {
+      config.put("bearer.auth.identity.pool.id", identityPool);
+    }
+    return Optional.of(config);
+  }
+
+  @Override
+  public void validate(
+      List<Failure.Error> errors,
+      String path,
+      String what
+  ) {
+    if (tokensUrl == null || tokensUrl.isBlank()) {
+      errors.add(
+          Error.create()
+               .withDetail("%s OAuth tokens URL is required and may not be blank", what)
+               .withSource("%s.tokens_url", path)
+      );
+    } else if (tokensUrl.length() > TOKENS_URL_MAX_LEN) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s OAuth tokens URL must be at most %d characters",
+                   what,
+                   TOKENS_URL_MAX_LEN
+               )
+               .withSource("%s.tokens_url", path)
+      );
+    } else {
+      try {
+        new URI(tokensUrl).toURL();
+      } catch (URISyntaxException | MalformedURLException e) {
+        errors.add(
+            Error.create()
+                 .withDetail("%s OAuth tokens URL is not a valid URL", what)
+                 .withSource("%s.tokens_url", path)
+        );
+      }
+    }
+    if (clientId == null || clientId.isBlank()) {
+      errors.add(
+          Error.create()
+               .withDetail("%s OAuth client ID is required and may not be blank", what)
+               .withSource("%s.client_id", path)
+      );
+    } else if (clientId.length() > CLIENT_ID_MAX_LEN) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s OAuth client ID may not be longer than %d characters",
+                   what,
+                   CLIENT_ID_MAX_LEN
+               )
+               .withSource("%s.client_id", path)
+      );
+    }
+    if (clientSecret == null) {
+      errors.add(
+          Error.create()
+               .withDetail("%s OAuth client secret is required", what)
+               .withSource("%s.client_secret", path)
+      );
+    } else if (clientSecret.longerThan(CLIENT_SECRET_MAX_LEN)) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s OAuth client secret may not be longer than %d characters",
+                   what,
+                   CLIENT_SECRET_MAX_LEN
+               )
+               .withSource("%s.client_secret", path)
+      );
+    }
+    if (scope != null && scope.length() > SCOPE_MAX_LEN) {
+      errors.add(
+          Error.create()
+               .withDetail(
+                   "%s OAuth scope may not be longer than %d characters",
+                   what,
+                   SCOPE_MAX_LEN
+               )
+               .withSource("%s.scope", path)
+      );
+    }
+    if (connectTimeoutMillis != null && connectTimeoutMillis < 0) {
+      errors.add(
+          Error.create()
+               .withDetail("%s connect timeout in milliseconds must be positive", what)
+               .withSource("%s.connect_timeout_millis", path)
+      );
+    }
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.idesidecar.restapi.credentials.ApiKeyAndSecret;
 import io.confluent.idesidecar.restapi.credentials.BasicCredentials;
 import io.confluent.idesidecar.restapi.credentials.Credentials;
+import io.confluent.idesidecar.restapi.credentials.MutualTLSCredentials;
+import io.confluent.idesidecar.restapi.credentials.OAuthCredentials;
 import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
 import io.confluent.idesidecar.restapi.util.CCloud.KafkaEndpoint;
@@ -309,6 +311,8 @@ public record ConnectionSpec(
           oneOf = {
               BasicCredentials.class,
               ApiKeyAndSecret.class,
+              MutualTLSCredentials.class,
+              OAuthCredentials.class,
           },
           nullable = true
       )
@@ -412,6 +416,8 @@ public record ConnectionSpec(
           oneOf = {
               BasicCredentials.class,
               ApiKeyAndSecret.class,
+              MutualTLSCredentials.class,
+              OAuthCredentials.class,
           },
           nullable = true
       )

--- a/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/cache/ClientConfiguratorStaticTest.java
@@ -13,6 +13,8 @@ import io.confluent.idesidecar.restapi.credentials.ApiSecret;
 import io.confluent.idesidecar.restapi.credentials.BasicCredentials;
 import io.confluent.idesidecar.restapi.credentials.Credentials;
 import io.confluent.idesidecar.restapi.credentials.Credentials.KafkaConnectionOptions;
+import io.confluent.idesidecar.restapi.credentials.MutualTLSCredentials;
+import io.confluent.idesidecar.restapi.credentials.OAuthCredentials;
 import io.confluent.idesidecar.restapi.credentials.Password;
 import io.confluent.idesidecar.restapi.models.graph.KafkaCluster;
 import io.confluent.idesidecar.restapi.models.graph.SchemaRegistry;
@@ -44,14 +46,50 @@ class ClientConfiguratorStaticTest {
   static final String PASSWORD = "my-secret";
   static final String API_KEY = "api-key-123";
   static final String API_SECRET = "api-secret-123";
+  static final String OAUTH_TOKEN_URL = "http://localhost:8081/oauth/token";
+  static final String OAUTH_CLIENT_ID = "client-123";
+  static final String OAUTH_SCOPE = "oauth-scope";
+  static final String OAUTH_SECRET = "oauth-secret";
+  static final String MTLS_TRUSTSTORE_PATH = "/path/to/truststore";
+  static final String MTLS_KEYSTORE_PATH = "/path/to/keystore";
+  static final String MTLS_TRUSTSTORE_PASSWORD = "my-ts-secret";
+  static final String MTLS_KEYSTORE_PASSWORD = "my-ks-secret";
+  static final String MTLS_KEY_PASSWORD = "my-key-secret";
 
   static final BasicCredentials BASIC_CREDENTIALS = new BasicCredentials(
       USERNAME,
       new Password(PASSWORD.toCharArray())
   );
+  static final OAuthCredentials OAUTH_CREDENTIALS = new OAuthCredentials(
+      OAUTH_TOKEN_URL,
+      OAUTH_CLIENT_ID,
+      new Password(OAUTH_SECRET.toCharArray())
+  );
+  static final OAuthCredentials OAUTH_CREDENTIALS_WITH_SCOPE = new OAuthCredentials(
+      OAUTH_TOKEN_URL,
+      OAUTH_CLIENT_ID,
+      new Password(OAUTH_SECRET.toCharArray()),
+      OAUTH_SCOPE
+  );
   static final ApiKeyAndSecret API_KEY_AND_SECRET = new ApiKeyAndSecret(
       API_KEY,
       new ApiSecret(API_SECRET.toCharArray())
+  );
+  static final MutualTLSCredentials MUTAL_TLS_CREDENTIALS = new MutualTLSCredentials(
+      MTLS_TRUSTSTORE_PATH,
+      new Password(MTLS_TRUSTSTORE_PASSWORD.toCharArray()),
+      MTLS_KEYSTORE_PATH,
+      new Password(MTLS_KEYSTORE_PASSWORD.toCharArray()),
+      new Password(MTLS_KEY_PASSWORD.toCharArray())
+  );
+  static final MutualTLSCredentials MUTAL_TLS_CREDENTIALS_WITH_TYPES = new MutualTLSCredentials(
+      MTLS_TRUSTSTORE_PATH,
+      new Password(MTLS_TRUSTSTORE_PASSWORD.toCharArray()),
+      MutualTLSCredentials.StoreType.JKS,
+      MTLS_KEYSTORE_PATH,
+      new Password(MTLS_KEYSTORE_PASSWORD.toCharArray()),
+      MutualTLSCredentials.StoreType.PEM,
+      new Password(MTLS_KEY_PASSWORD.toCharArray())
   );
 
   @Mock ConnectionState connection;
@@ -262,6 +300,114 @@ class ClientConfiguratorStaticTest {
                 basic.auth.credentials.source=USER_INFO
                 basic.auth.user.info=%s:%s
                 """.formatted(API_KEY, API_SECRET)
+        ),
+        new TestInput(
+            "With mTLS for Kafka and SR",
+            kafka,
+            MUTAL_TLS_CREDENTIALS,
+            schemaRegistry,
+            MUTAL_TLS_CREDENTIALS,
+            true,
+            true,
+            false,
+            null,
+            """
+                bootstrap.servers=localhost:9092
+                security.protocol=SSL
+                ssl.truststore.location=/path/to/truststore
+                ssl.truststore.password=%s
+                ssl.keystore.location=/path/to/keystore
+                ssl.keystore.password=%s
+                ssl.key.password=%s
+                """.formatted(MTLS_TRUSTSTORE_PASSWORD, MTLS_KEYSTORE_PASSWORD, MTLS_KEY_PASSWORD),
+            """
+                schema.registry.url=http://localhost:8081
+                ssl.truststore.location=/path/to/truststore
+                ssl.truststore.password=%s
+                ssl.keystore.location=/path/to/keystore
+                ssl.keystore.password=%s
+                ssl.key.password=%s
+                """.formatted(MTLS_TRUSTSTORE_PASSWORD, MTLS_KEYSTORE_PASSWORD, MTLS_KEY_PASSWORD)
+        ),
+        new TestInput(
+            "With OAuth for Kafka and SR",
+            kafka,
+            OAUTH_CREDENTIALS,
+            schemaRegistry,
+            OAUTH_CREDENTIALS,
+            true,
+            true,
+            false,
+            null,
+            """
+                bootstrap.servers=localhost:9092
+                security.protocol=SASL_SSL
+                sasl.mechanism=OAUTHBEARER
+                sasl.oauthbearer.token.endpoint.url=http://localhost:8081/oauth/token
+                sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+                sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s"
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET),
+            """
+                schema.registry.url=http://localhost:8081
+                bearer.auth.credentials.source=OAUTHBEARER
+                bearer.auth.issuer.endpoint.url=http://localhost:8081/oauth/token
+                bearer.auth.client.id=%s
+                bearer.auth.client.secret=%s
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET)
+        ),
+        new TestInput(
+            "With OAuth with scopes for Kafka and SR",
+            kafka,
+            OAUTH_CREDENTIALS_WITH_SCOPE,
+            schemaRegistry,
+            OAUTH_CREDENTIALS_WITH_SCOPE,
+            true,
+            true,
+            false,
+            null,
+            """
+                bootstrap.servers=localhost:9092
+                security.protocol=SASL_SSL
+                sasl.mechanism=OAUTHBEARER
+                sasl.oauthbearer.token.endpoint.url=http://localhost:8081/oauth/token
+                sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+                sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s" scope="%s"
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET, OAUTH_SCOPE),
+            """
+                schema.registry.url=http://localhost:8081
+                bearer.auth.credentials.source=OAUTHBEARER
+                bearer.auth.issuer.endpoint.url=http://localhost:8081/oauth/token
+                bearer.auth.client.id=%s
+                bearer.auth.client.secret=%s
+                bearer.auth.scope=%s
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET, OAUTH_SCOPE)
+        ),
+        new TestInput(
+            "With OAuth for Kafka and SR and unsigned certificates",
+            kafka,
+            OAUTH_CREDENTIALS,
+            schemaRegistry,
+            OAUTH_CREDENTIALS,
+            true,
+            false,
+            false,
+            null,
+            """
+                bootstrap.servers=localhost:9092
+                security.protocol=SASL_SSL
+                ssl.endpoint.identification.algorithm=
+                sasl.mechanism=OAUTHBEARER
+                sasl.oauthbearer.token.endpoint.url=http://localhost:8081/oauth/token
+                sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+                sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="%s" clientSecret="%s"
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET),
+            """
+                schema.registry.url=http://localhost:8081
+                bearer.auth.credentials.source=OAUTHBEARER
+                bearer.auth.issuer.endpoint.url=http://localhost:8081/oauth/token
+                bearer.auth.client.id=%s
+                bearer.auth.client.secret=%s
+                """.formatted(OAUTH_CLIENT_ID, OAUTH_SECRET)
         )
     );
     return inputs

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -22,6 +22,8 @@ import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.credentials.ApiKeyAndSecret;
 import io.confluent.idesidecar.restapi.credentials.ApiSecret;
 import io.confluent.idesidecar.restapi.credentials.BasicCredentials;
+import io.confluent.idesidecar.restapi.credentials.MutualTLSCredentials;
+import io.confluent.idesidecar.restapi.credentials.OAuthCredentials;
 import io.confluent.idesidecar.restapi.credentials.Password;
 import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
@@ -890,6 +892,77 @@ public class ConnectionsResourceTest {
             """
         ),
         new TestInput(
+            "Local spec is valid with new Schema Registry config including minimal OAuth credentials",
+            """
+            {
+              "name": "Connection 1",
+              "type": "LOCAL",
+              "schema_registry": {
+                "uri": "http://localhost:8081",
+                "credentials": {
+                  "tokens_url": "http://localhost/oauth2/token",
+                  "client_id": "my-client-id",
+                  "client_secret": "my-client-secret"
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
+            "Local spec is valid with new Schema Registry config including complete OAuth credentials",
+            """
+            {
+              "name": "Connection 1",
+              "type": "LOCAL",
+              "schema_registry": {
+                "uri": "http://localhost:8081",
+                "credentials": {
+                  "tokens_url": "http://localhost/oauth2/token",
+                  "client_id": "my-client-id",
+                  "client_secret": "my-client-secret",
+                  "scope": "my-scope",
+                  "connect_timeout_millis": 1000
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
+            "Local spec is valid with new Schema Registry config including minimal mTLS credentials",
+            """
+            {
+              "name": "Connection 1",
+              "type": "LOCAL",
+              "schema_registry": {
+                "uri": "http://localhost:8081",
+                "credentials": {
+                  "truststore_path": "/path/to/truststore",
+                  "keystore_path": "/path/to/keystore"
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
+            "Local spec is valid with new Schema Registry config including complete mTLS credentials",
+            """
+            {
+              "name": "Connection 1",
+              "type": "LOCAL",
+              "schema_registry": {
+                "uri": "http://localhost:8081",
+                "credentials": {
+                  "truststore_path": "/path/to/truststore",
+                  "truststore_password": "truststore-password",
+                  "keystore_path": "/path/to/keystore",
+                  "keystore_password": "keystore-password",
+                  "key_password": "key-password"
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
             "Local spec is invalid without name",
             """
             {
@@ -1259,6 +1332,44 @@ public class ConnectionsResourceTest {
             """
         ),
         new TestInput(
+            "Direct spec is valid with name and Kafka w/ mTLS credentials and no Schema Registry",
+            """
+            {
+              "name": "Some connection name",
+              "type": "DIRECT",
+              "kafka_cluster": {
+                "bootstrap_servers": "localhost:9092",
+                "credentials": {
+                  "truststore_path": "/path/to/truststore",
+                  "truststore_password": "truststore-password",
+                  "keystore_path": "/path/to/keystore",
+                  "keystore_password": "keystore-password",
+                  "key_password": "key-password"
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
+            "Direct spec is valid with name and Kafka w/ OAuth credentials and no Schema Registry",
+            """
+            {
+              "name": "Some connection name",
+              "type": "DIRECT",
+              "kafka_cluster": {
+                "bootstrap_servers": "localhost:9092",
+                "credentials": {
+                  "tokens_url": "http://localhost/oauth2/token",
+                  "client_id": "my-client-id",
+                  "client_secret": "my-client-secret",
+                  "scope": "my-scope",
+                  "connect_timeout_millis": 1000
+                }
+              }
+            }
+            """
+        ),
+        new TestInput(
             "Direct spec is valid with name and Schema Registry and no Kafka",
             """
             {
@@ -1478,6 +1589,42 @@ public class ConnectionsResourceTest {
                         new ApiKeyAndSecret(
                             "api-key-123",
                             new ApiSecret("api-secret-123456".toCharArray())
+                        )
+                    )
+                )
+        ),
+        new TestInput(
+            "Updated of local config is valid with (new) Schema Registry URI and OAuth credentials",
+            validLocalSpec,
+            validLocalSpec
+                .withoutLocalConfig()
+                .withSchemaRegistry(
+                    new SchemaRegistryConfig(
+                        null,
+                        "http://localhost:8081",
+                        new OAuthCredentials(
+                            "http://localhost/oauth/token",
+                            "client-id",
+                            new Password("client-secret".toCharArray())
+                        )
+                    )
+                )
+        ),
+        new TestInput(
+            "Updated of local config is valid with (new) Schema Registry URI and mTLS credentials",
+            validLocalSpec,
+            validLocalSpec
+                .withoutLocalConfig()
+                .withSchemaRegistry(
+                    new SchemaRegistryConfig(
+                        null,
+                        "http://localhost:8081",
+                        new MutualTLSCredentials(
+                            "/path/to/truststore",
+                            new Password("truststore-secret".toCharArray()),
+                            "/path/to/keystore",
+                            new Password("keystore-secret".toCharArray()),
+                            new Password("key-secret".toCharArray())
                         )
                     )
                 )


### PR DESCRIPTION
Resolves #125 #126

## Summary of Changes

Adds preliminary support to allow Kafka and SR clients to use mTLS and OAuth 2.0 to authenticate for direct connections.

These changes have been unit tested to verify the expected client configurations are generated.

**NOTE: However, those expected configurations have NOT yet been tested against CCloud or CP via integration tests.**


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

