### PR TITLE
feat: Upon auth flow completion, refresh connection status synchronously

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/OAuthCallbackResource.java
@@ -75,7 +75,9 @@ public class OAuthCallbackResource {
             )
             .recover(this::renderFailure)
             // Upon completion of the auth flow, refresh the status of the CCloud connection
-            .andThen(ignored -> cCloudConnectionState.refreshStatus());
+            .compose(renderedTemplate ->
+                cCloudConnectionState.refreshStatus().map(ignored -> renderedTemplate)
+            );
         return Uni
             .createFrom()
             .completionStage(


### PR DESCRIPTION
## Summary of Changes

For Confluent Cloud connections, upon completion of the authentication flow, refresh the status of the connection synchronously before redirecting the user to the extension.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

