### PR TITLE
MINOR(OpenAPI): remove Credentials reference altogether

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -965,9 +965,6 @@
           }
         }
       },
-      "Credentials" : {
-        "type" : "object"
-      },
       "Error" : {
         "description" : "Describes a particular error encountered while performing an operation.",
         "type" : "object",
@@ -1120,10 +1117,6 @@
           },
           "credentials" : {
             "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -1378,10 +1371,6 @@
           },
           "credentials" : {
             "description" : "The credentials for the Schema Registry, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -1613,12 +1602,12 @@
             "enum" : [ "UP", "DOWN" ],
             "type" : "string"
           },
+          "name" : {
+            "type" : "string"
+          },
           "data" : {
             "type" : "object",
             "nullable" : true
-          },
-          "name" : {
-            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -965,6 +965,9 @@
           }
         }
       },
+      "Credentials" : {
+        "type" : "object"
+      },
       "Error" : {
         "description" : "Describes a particular error encountered while performing an operation.",
         "type" : "object",
@@ -1117,6 +1120,10 @@
           },
           "credentials" : {
             "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Credentials"
+            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -1371,6 +1378,10 @@
           },
           "credentials" : {
             "description" : "The credentials for the Schema Registry, or null if no authentication is required",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Credentials"
+            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -1602,12 +1613,12 @@
             "enum" : [ "UP", "DOWN" ],
             "type" : "string"
           },
-          "name" : {
-            "type" : "string"
-          },
           "data" : {
             "type" : "object",
             "nullable" : true
+          },
+          "name" : {
+            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -965,9 +965,6 @@
           }
         }
       },
-      "Credentials" : {
-        "type" : "object"
-      },
       "Error" : {
         "description" : "Describes a particular error encountered while performing an operation.",
         "type" : "object",
@@ -1120,10 +1117,6 @@
           },
           "credentials" : {
             "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -1378,10 +1371,6 @@
           },
           "credentials" : {
             "description" : "The credentials for the Schema Registry, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -693,8 +693,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Connection"
-    Credentials:
-      type: object
     Error:
       description: Describes a particular error encountered while performing an operation.
       type: object
@@ -813,9 +811,6 @@ components:
         credentials:
           description: "The credentials for the Kafka cluster, or null if no authentication\
             \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
@@ -1007,9 +1002,6 @@ components:
         credentials:
           description: "The credentials for the Schema Registry, or null if no authentication\
             \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -693,6 +693,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Connection"
+    Credentials:
+      type: object
     Error:
       description: Describes a particular error encountered while performing an operation.
       type: object
@@ -811,6 +813,9 @@ components:
         credentials:
           description: "The credentials for the Kafka cluster, or null if no authentication\
             \ is required"
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
@@ -1002,6 +1007,9 @@ components:
         credentials:
           description: "The credentials for the Schema Registry, or null if no authentication\
             \ is required"
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
@@ -1185,8 +1193,8 @@ components:
           - UP
           - DOWN
           type: string
-        name:
-          type: string
         data:
           type: object
           nullable: true
+        name:
+          type: string

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -693,8 +693,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Connection"
-    Credentials:
-      type: object
     Error:
       description: Describes a particular error encountered while performing an operation.
       type: object
@@ -813,9 +811,6 @@ components:
         credentials:
           description: "The credentials for the Kafka cluster, or null if no authentication\
             \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
@@ -1007,9 +1002,6 @@ components:
         credentials:
           description: "The credentials for the Schema Registry, or null if no authentication\
             \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
@@ -1193,8 +1185,8 @@ components:
           - UP
           - DOWN
           type: string
+        name:
+          type: string
         data:
           type: object
           nullable: true
-        name:
-          type: string

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -306,6 +306,7 @@ public record ConnectionSpec(
       @Schema(
           description =
               "The credentials for the Kafka cluster, or null if no authentication is required",
+          // prevent Credentials from showing up in the generated OpenAPI spec here
           implementation = Object.class,
           oneOf = {
               BasicCredentials.class,
@@ -410,6 +411,7 @@ public record ConnectionSpec(
       @Schema(
           description = "The credentials for the Schema Registry, or null if "
                         + "no authentication is required",
+          // prevent Credentials from showing up in the generated OpenAPI spec here
           implementation = Object.class,
           oneOf = {
               BasicCredentials.class,

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -306,6 +306,7 @@ public record ConnectionSpec(
       @Schema(
           description =
               "The credentials for the Kafka cluster, or null if no authentication is required",
+          implementation = Object.class,
           oneOf = {
               BasicCredentials.class,
               ApiKeyAndSecret.class,
@@ -409,6 +410,7 @@ public record ConnectionSpec(
       @Schema(
           description = "The credentials for the Schema Registry, or null if "
                         + "no authentication is required",
+          implementation = Object.class,
           oneOf = {
               BasicCredentials.class,
               ApiKeyAndSecret.class,


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

Context: We have a type issue in the VS Code extension client code generation where the `allOf` pointing to `Credentials` (of type `object`) is chosen instead of the `oneOf: BasicCredentials | ApiKeyAndSecret`.

This PR aims to tighten up the sections for `credentials` under the `KafkaClusterConfig` and `SchemaRegistryConfig` so we don't mix `allOf` (with a basic `object` type) and `oneOf`.

#### Current (`main`):
https://github.com/confluentinc/ide-sidecar/blob/9203449cce9f38a236f2c473d314b01ed6017802/src/generated/resources/openapi.yaml#L813-L822

#### New:
https://github.com/confluentinc/ide-sidecar/blob/b8c02495ef797fcfd22cb1de5fdf2cb5e5e3c90a/src/generated/resources/openapi.yaml#L811-L817

For future use: setting `implementation = Object.class` (for a `Schema` annotation on a property) will prevent another property's interface from being included in that section of the OpenAPI spec. https://download.eclipse.org/microprofile/microprofile-2.0-javadocs-test/apidocs/org/eclipse/microprofile/openapi/annotations/media/Schema.html#implementation--

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

