### PR TITLE
MINOR(OpenAPI): remove `oneOf` in favor of Credentials reference

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -1126,7 +1126,12 @@
             "type" : "string"
           },
           "credentials" : {
-            "$ref" : "#/components/schemas/Credentials"
+            "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Credentials"
+            } ],
+            "nullable" : true
           },
           "ssl" : {
             "description" : "Whether to communicate with the Kafka cluster over TLS/SSL. Defaults to 'true', but set to 'false' when the Kafka cluster does not support TLS/SSL.",
@@ -1374,7 +1379,12 @@
             "type" : "string"
           },
           "credentials" : {
-            "$ref" : "#/components/schemas/Credentials"
+            "description" : "The credentials for the Schema Registry, or null if no authentication is required",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Credentials"
+            } ],
+            "nullable" : true
           }
         }
       },
@@ -1596,16 +1606,16 @@
       "HealthCheck" : {
         "type" : "object",
         "properties" : {
-          "status" : {
-            "enum" : [ "UP", "DOWN" ],
-            "type" : "string"
-          },
           "name" : {
             "type" : "string"
           },
           "data" : {
             "type" : "object",
             "nullable" : true
+          },
+          "status" : {
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -966,7 +966,14 @@
         }
       },
       "Credentials" : {
-        "type" : "object"
+        "description" : "The credentials for a ConnectionSpec config, or null if no authentication is required",
+        "type" : "object",
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/BasicCredentials"
+        }, {
+          "$ref" : "#/components/schemas/ApiKeyAndSecret"
+        } ],
+        "nullable" : true
       },
       "Error" : {
         "description" : "Describes a particular error encountered while performing an operation.",
@@ -1119,17 +1126,7 @@
             "type" : "string"
           },
           "credentials" : {
-            "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
-            "oneOf" : [ {
-              "$ref" : "#/components/schemas/BasicCredentials"
-            }, {
-              "$ref" : "#/components/schemas/ApiKeyAndSecret"
-            } ],
-            "nullable" : true
+            "$ref" : "#/components/schemas/Credentials"
           },
           "ssl" : {
             "description" : "Whether to communicate with the Kafka cluster over TLS/SSL. Defaults to 'true', but set to 'false' when the Kafka cluster does not support TLS/SSL.",
@@ -1377,17 +1374,7 @@
             "type" : "string"
           },
           "credentials" : {
-            "description" : "The credentials for the Schema Registry, or null if no authentication is required",
-            "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/Credentials"
-            } ],
-            "oneOf" : [ {
-              "$ref" : "#/components/schemas/BasicCredentials"
-            }, {
-              "$ref" : "#/components/schemas/ApiKeyAndSecret"
-            } ],
-            "nullable" : true
+            "$ref" : "#/components/schemas/Credentials"
           }
         }
       },
@@ -1613,12 +1600,12 @@
             "enum" : [ "UP", "DOWN" ],
             "type" : "string"
           },
+          "name" : {
+            "type" : "string"
+          },
           "data" : {
             "type" : "object",
             "nullable" : true
-          },
-          "name" : {
-            "type" : "string"
           }
         }
       }

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -694,7 +694,13 @@ components:
           items:
             $ref: "#/components/schemas/Connection"
     Credentials:
+      description: "The credentials for a ConnectionSpec config, or null if no authentication\
+        \ is required"
       type: object
+      oneOf:
+      - $ref: "#/components/schemas/BasicCredentials"
+      - $ref: "#/components/schemas/ApiKeyAndSecret"
+      nullable: true
     Error:
       description: Describes a particular error encountered while performing an operation.
       type: object
@@ -811,15 +817,7 @@ components:
           minLength: 1
           type: string
         credentials:
-          description: "The credentials for the Kafka cluster, or null if no authentication\
-            \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
-          oneOf:
-          - $ref: "#/components/schemas/BasicCredentials"
-          - $ref: "#/components/schemas/ApiKeyAndSecret"
-          nullable: true
+          $ref: "#/components/schemas/Credentials"
         ssl:
           description: "Whether to communicate with the Kafka cluster over TLS/SSL.\
             \ Defaults to 'true', but set to 'false' when the Kafka cluster does not\
@@ -1005,15 +1003,7 @@ components:
           minLength: 1
           type: string
         credentials:
-          description: "The credentials for the Schema Registry, or null if no authentication\
-            \ is required"
-          type: object
-          allOf:
-          - $ref: "#/components/schemas/Credentials"
-          oneOf:
-          - $ref: "#/components/schemas/BasicCredentials"
-          - $ref: "#/components/schemas/ApiKeyAndSecret"
-          nullable: true
+          $ref: "#/components/schemas/Credentials"
     SchemaRegistryStatus:
       description: The status related to the specified Schema Registry.
       required:
@@ -1193,8 +1183,8 @@ components:
           - UP
           - DOWN
           type: string
+        name:
+          type: string
         data:
           type: object
           nullable: true
-        name:
-          type: string

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -817,7 +817,12 @@ components:
           minLength: 1
           type: string
         credentials:
-          $ref: "#/components/schemas/Credentials"
+          description: "The credentials for the Kafka cluster, or null if no authentication\
+            \ is required"
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/Credentials"
+          nullable: true
         ssl:
           description: "Whether to communicate with the Kafka cluster over TLS/SSL.\
             \ Defaults to 'true', but set to 'false' when the Kafka cluster does not\
@@ -1003,7 +1008,12 @@ components:
           minLength: 1
           type: string
         credentials:
-          $ref: "#/components/schemas/Credentials"
+          description: "The credentials for the Schema Registry, or null if no authentication\
+            \ is required"
+          type: object
+          allOf:
+          - $ref: "#/components/schemas/Credentials"
+          nullable: true
     SchemaRegistryStatus:
       description: The status related to the specified Schema Registry.
       required:
@@ -1178,13 +1188,13 @@ components:
     HealthCheck:
       type: object
       properties:
-        status:
-          enum:
-          - UP
-          - DOWN
-          type: string
         name:
           type: string
         data:
           type: object
           nullable: true
+        status:
+          enum:
+          - UP
+          - DOWN
+          type: string

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/Credentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/Credentials.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * Base interface for credentials objects used with Kafka and Schema Registry clients.
@@ -22,6 +23,15 @@ import java.util.Optional;
     @Type(value = ApiKeyAndSecret.class),
 })
 @RegisterForReflection
+@Schema(
+    description =
+        "The credentials for a ConnectionSpec config, or null if no authentication is required",
+    oneOf = {
+        BasicCredentials.class,
+        ApiKeyAndSecret.class,
+    },
+    nullable = true
+)
 public interface Credentials {
 
   @RecordBuilder

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -306,10 +306,6 @@ public record ConnectionSpec(
       @Schema(
           description =
               "The credentials for the Kafka cluster, or null if no authentication is required",
-          oneOf = {
-              BasicCredentials.class,
-              ApiKeyAndSecret.class,
-          },
           nullable = true
       )
       @Null
@@ -409,10 +405,6 @@ public record ConnectionSpec(
       @Schema(
           description = "The credentials for the Schema Registry, or null if "
                         + "no authentication is required",
-          oneOf = {
-              BasicCredentials.class,
-              ApiKeyAndSecret.class,
-          },
           nullable = true
       )
       @Null


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Context: We have a type issue in the VS Code extension client code generation where the `allOf` pointing to `Credentials` (of type `object`) is chosen instead of the `oneOf: BasicCredentials | ApiKeyAndSecret`.

This PR aims to tighten up the sections for `credentials` under the `KafkaClusterConfig` and `SchemaRegistryConfig` so we don't mix `allOf` (with a basic `object` type) and `oneOf`. 

#### Current (`main`):
https://github.com/confluentinc/ide-sidecar/blob/9203449cce9f38a236f2c473d314b01ed6017802/src/generated/resources/openapi.yaml#L813-L822

#### New:
https://github.com/confluentinc/ide-sidecar/blob/4cf724ef14e457bb02c41f78ffa969bd576c0c62/src/generated/resources/openapi.yaml#L819-L825

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

