### PR TITLE
Minor improvements to the WebsocketEndpoint

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpoint.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpoint.java
@@ -12,7 +12,6 @@ import io.confluent.idesidecar.websocket.messages.ProtocolErrorBody;
 import io.confluent.idesidecar.websocket.messages.WorkspacesChangedBody;
 import io.quarkus.logging.Log;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -23,7 +22,6 @@ import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
-import javax.validation.constraints.NotNull;
 
 /**
  * Websocket endpoint for "control plane" variety async messaging between sidecar and workspaces,
@@ -44,7 +42,6 @@ public class WebsocketEndpoint {
   @Inject
   KnownWorkspacesBean knownWorkspacesBean;
 
-  // Miscellany
   private final ObjectMapper mapper = JsonMapper
       .builder()
       .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
@@ -53,10 +50,11 @@ public class WebsocketEndpoint {
   /**
    * Broadcast a message originating from sidecar to all authorized connected workspaces.
    *
+   * @param message the message to broadcast
    * @throws IOException              if there is an error serializing the message to JSON.
    * @throws IllegalArgumentException if the headers of the message are not valid for broadcasting.
    * */
-  public void broadcast(Message message) throws IOException {
+  public void broadcast(Message message) throws IOException, IllegalArgumentException {
     final MessageHeaders headers = validateHeadersForSidecarBroadcast(message);
 
     if (sessions.isEmpty()) {
@@ -64,6 +62,7 @@ public class WebsocketEndpoint {
       return;
     }
 
+    // Serialize the message to JSON
     String jsonMessage = mapper.writeValueAsString(message);
     Log.debugf(
         "Broadcasting %d char message, id %s to all workspaces",
@@ -71,6 +70,7 @@ public class WebsocketEndpoint {
         headers.id()
     );
 
+    // And broadcast the message
     sessions.entrySet().stream()
         .filter(pair -> pair.getKey().isOpen())
         .forEach(pair -> {
@@ -91,6 +91,7 @@ public class WebsocketEndpoint {
    * the sidecar {@link KnownWorkspacesBean}, the session is closed. Otherwise, a new
    * {@link WorkspaceSession} object is created and stored in the sessions map, and the updated
    * current connection count is broadcast to all workspace connections (inclusive).
+   *
    * @param session      the session that was opened
    * @throws IOException if there is an error opening the session, or closing the session if the
    *                     workspace id is invalid or not provided.
@@ -99,56 +100,69 @@ public class WebsocketEndpoint {
   public void onOpen(Session session) throws IOException {
     Log.info("New websocket session opened: " + session.getId());
 
-    // Request must have had a valid access token to pass through AccessTokenFilter, so we can assume that the session is authorized.
+    // Request must have had a valid access token to pass through AccessTokenFilter,
+    // so we can assume that the session is authorized.
     // The workspace process id should have been passed as a request parameter, though.
-    Map <String, java.util.List<String>> requestParams = session.getRequestParameterMap();
+    var requestParams = session.getRequestParameterMap();
     if (requestParams.size() == 0) {
-      String error = "No request parameters provided. Closing new session %s.".format(session.getId());
-      Log.error(error);
-
-      sendErrorAndCloseSession(session, error, null);
-
+      sendErrorAndCloseSession(
+          session,
+          null,
+          "No request parameters provided. Closing new session %s.",
+          session.getId()
+      );
       return;
     }
 
-    List<String> workspaceIdList = requestParams.get("workspace_id");
+    var workspaceIdList = requestParams.get("workspace_id");
     if (workspaceIdList == null || workspaceIdList.isEmpty()) {
-      String error = "No workspace_id parameter provided. Closing new session %s.".format(session.getId());
-      Log.error(error);
-
-      sendErrorAndCloseSession(session, error, null);
-
+      sendErrorAndCloseSession(
+          session,
+          null,
+          "No workspace_id parameter provided. Closing new session %s.",
+          session.getId()
+      );
       return;
     }
 
-    String workspaceIdString = workspaceIdList.get(0);
+    var workspaceIdString = workspaceIdList.get(0);
     long workspaceId;
     try {
       workspaceId = Long.parseLong(workspaceIdString);
     } catch (NumberFormatException e) {
-      String error = "Invalid workspace_id parameter value: %s. Closing new session %s.".format(workspaceIdString, session.getId());
-      Log.error(error);
-      sendErrorAndCloseSession(session, error, null);
+      sendErrorAndCloseSession(
+          session,
+          null,
+          "Invalid workspace_id parameter value: %s. Closing new session %s.",
+          workspaceIdString,
+          session.getId()
+      );
       return;
     }
 
     // As of time of writing, the workspace should have REST handshook or hit the health check
     // route with the workspace id header, so we should know about it already.
     if (!knownWorkspacesBean.isKnownWorkspacePID(workspaceId)) {
-      String error = "Unknown workspace id: %d. Closing new session %s.".format(
-          String.valueOf(workspaceId), session.getId());
-
-      Log.error(error);
-      sendErrorAndCloseSession(session, error, null);
+      sendErrorAndCloseSession(
+          session,
+          null,
+          "Unknown workspace id: %d. Closing new session %s.",
+          workspaceId,
+          session.getId()
+      );
       return;
     }
 
-    Log.infof("New websocket session %s opened for workspace pid: %d", session.getId(), workspaceId);
+    Log.infof(
+        "New websocket session %s opened for workspace pid: %d",
+        session.getId(),
+        workspaceId
+    );
     // create new WorkspaceSession object and store in sessions map.
-    WorkspaceSession newWorkspaceSession = new WorkspaceSession(workspaceId);
+    var newWorkspaceSession = new WorkspaceSession(workspaceId);
     sessions.put(session, newWorkspaceSession);
 
-    // Broadcast a message to all workspaces (inclusive) that the authorized workspaces count has changed.
+    // Broadcast message to all workspaces (inclusive) a change in the authorized workspaces count.
     broadcastWorkspacesChanged();
   }
 
@@ -158,72 +172,64 @@ public class WebsocketEndpoint {
    * @param messageString The message as a JSON string, which will be parsed as a
    *                      {@link io.confluent.idesidecar.websocket.messages.Message} object
    * @param senderSession The websocket session that sent the message.
-   * @throws IOException if there is an error parsing the message or if the message is invalid
    */
   @OnMessage
-  public void onMessage(String messageString, Session senderSession) throws IOException {
-    WorkspaceSession workspaceSession = sessions.get(senderSession);
+  public void onMessage(String messageString, Session senderSession) {
+    var workspaceSession = sessions.get(senderSession);
     if (workspaceSession == null) {
-      String error = "Odd! Received message from unregistered session %s. Closing session.".format(senderSession.getId());
-      Log.error(error);
-      sendErrorAndCloseSession(senderSession, error, null);
+      sendErrorAndCloseSession(
+          senderSession,
+          null,
+          "Odd! Received message from unregistered session %s. Closing session.",
+          senderSession.getId()
+      );
       return;
     }
 
     Message m;
-
     try {
       m = mapper.readValue(messageString, Message.class);
-    } catch (java.io.IOException e) {
-      String error =
-          "Invalid message from session %s, workspace %d. Discarding and closing.".format(
-              senderSession.getId(), workspaceSession.processId());
-
-      Log.error(error);
-
-      sendErrorAndCloseSession(senderSession, error, null);
-      sessions.remove(senderSession);
+    } catch (IOException e) {
+      sendErrorAndCloseSession(
+          senderSession,
+          null,
+          "Invalid message from session %s, workspace %d. Discarding and closing.",
+          senderSession.getId(),
+          workspaceSession.processId()
+      );
       return;
     }
 
-    MessageHeaders headers = m.headers();
+    var headers = m.headers();
 
     // Validate message.header.originator corresponds to the authorized workspace process id.
-    // (messages sent from workspaces to sidecar should have the workspace's process id as the originator)
-    int claimedWorkspaceId = 0;
+    // (messages sent from workspaces to sidecar should have the workspace's process id as
+    // the originator)
+    var claimedWorkspaceId = 0;
     try {
       claimedWorkspaceId = Integer.parseInt(headers.originator());
     } catch (NumberFormatException e) {
-      String error = (
+      sendErrorAndCloseSession(
+          senderSession,
+          m.headers().id(),
           "Invalid websocket message header originator value -- not an integer: %s. "
-          + "Removing and closing session %s.".format(
-          headers.originator(),
+          + "Removing and closing session %s.",
+          headers.messageType(),
           senderSession.getId()
-      ));
-
-      Log.error(error);
-
-      sendErrorAndCloseSession(senderSession, error, m.headers().id());
-      sessions.remove(senderSession);
-
+      );
       return;
     }
 
     if (claimedWorkspaceId != workspaceSession.processId()) {
-      String error = (
+      sendErrorAndCloseSession(
+          senderSession,
+          m.headers().id(),
           "Workspace %s sent message with incorrect originator value: %d."
-          + " Removing and closing session %s.".format(
-              String.valueOf(workspaceSession.processId()),
-              claimedWorkspaceId,
-              senderSession.getId()
-          )
+          + " Removing and closing session %s.",
+          workspaceSession.processId(),
+          claimedWorkspaceId,
+          senderSession.getId()
       );
-
-      Log.error(error);
-
-      sendErrorAndCloseSession(senderSession, error, m.headers().id());
-      sessions.remove(senderSession);
-
       return;
     }
 
@@ -234,15 +240,12 @@ public class WebsocketEndpoint {
         workspaceSession.processId()
     );
 
-    /*
-      At this time, all websocket messages received from workspaces are intended to
-      be proxied to all of the other workspaces. Do so here.
-     */
+    // At this time, all websocket messages received from workspaces are intended to
+    // be proxied to all the other workspaces. Do so here.
 
-    int otherCount = sessions.size() - 1;
+    var otherCount = sessions.size() - 1;
     if (otherCount <= 0) {
       Log.debug("No other workspaces to broadcast message to.");
-      return;
     } else {
       Log.debugf(
           "Proxying message %s from workspace %d to %d other workspace(s)",
@@ -250,11 +253,15 @@ public class WebsocketEndpoint {
           workspaceSession.processId(),
           otherCount
       );
-      sessions.entrySet().stream()
-          .filter(pair -> pair.getValue().processId() != workspaceSession.processId() && pair.getKey().isOpen())
-          .forEach(pair -> {
-            pair.getKey().getAsyncRemote().sendText(messageString);
-          });
+      sessions
+          .entrySet()
+          .stream()
+          .filter(pair ->
+              pair.getValue().processId() != workspaceSession.processId() && pair.getKey().isOpen()
+          )
+          .forEach(pair ->
+              pair.getKey().getAsyncRemote().sendText(messageString)
+          );
     }
   }
 
@@ -262,27 +269,32 @@ public class WebsocketEndpoint {
   public void onError(Session session, Throwable throwable) throws IOException {
     // May or may not actually remove -- if had not yet been authorized, it won't be in the map.
     // (but will definitely not be in the map after this statement.)
-    WorkspaceSession existingSession = sessions.remove(session);
+    var existingSession = sessions.remove(session);
     session.close();
 
     var id = existingSession != null ? existingSession.processId() : "unknown";
-    Log.errorf("Websocket error for workspace pid %s, session id %s. Closed and removed session.", id, session.getId(), throwable.getMessage());
+    Log.errorf(
+        "Websocket error for workspace pid %s, session id %s. Closed and removed session.",
+        id,
+        session.getId(),
+        throwable.getMessage()
+    );
   }
 
   @OnClose
   public void onClose(Session session) {
-    WorkspaceSession existing = sessions.remove(session);
+    var existing = sessions.remove(session);
     Log.info("Websocket session closed: " + session.getId());
 
     if (existing != null) {
-      // was a registered workspace session. Announce to all other workspaces that the list has changed.
+      // was a registered workspace session. Announce to all other workspaces the list has changed
       Log.infof(
           "Closed session was workspace %d, broadcasting workspace count change.",
           existing.processId()
       );
       try {
         broadcastWorkspacesChanged();
-      } catch (java.io.IOException e) {
+      } catch (IOException e) {
         Log.errorf("Failed to broadcast workspace removed message: %s", e.getMessage());
       }
     }
@@ -292,10 +304,11 @@ public class WebsocketEndpoint {
    * Send a message to all workspaces that the count of authorized workspaces has changed.
    * Used whenever a workspace is added or removed.
    */
-  private void broadcastWorkspacesChanged() throws java.io.IOException {
-    // changedWorkspace was either just added or removed. Informall  workspaces about the new connected/authorized workspace count.
+  private void broadcastWorkspacesChanged() throws IOException {
+    // changedWorkspace was either just added or removed. Inform all workspaces about the
+    // new connected/authorized workspace count.
 
-    Message message = new Message(
+    var message = new Message(
         new MessageHeaders(MessageType.WORKSPACE_COUNT_CHANGED, "sidecar"),
         new WorkspacesChangedBody(this.sessions.size())
     );
@@ -309,20 +322,50 @@ public class WebsocketEndpoint {
    * Send an PROTOCOL_ERROR message to a websocket session, then close the session.
    * @param session the session to send the error message to.
    * @param message the error message to send.
-   * @throws IOException if there is an error sending the message.
    */
-  private void sendErrorAndCloseSession(Session session, String message, String originalMessageId) throws IOException {
-    Message errorMessage = new Message(
-        new MessageHeaders(MessageType.PROTOCOL_ERROR, "sidecar"),
-        new ProtocolErrorBody(message, originalMessageId)
-    );
-    session.getAsyncRemote().sendText(mapper.writeValueAsString(errorMessage));
+  private void sendErrorAndCloseSession(
+      Session session,
+      String originalMessageId,
+      String message,
+      Object...messageParams
+  ) {
+    // Remove the session if it exists
+    sessions.remove(session);
 
-    session.close();
+    // Send the error message to the session
+    var msg = message.formatted(messageParams);
+    Log.info(msg);
+    try {
+      var errorMessage = new Message(
+          new MessageHeaders(MessageType.PROTOCOL_ERROR, "sidecar"),
+          new ProtocolErrorBody(msg, originalMessageId)
+      );
+      session.getAsyncRemote()
+             .sendText(mapper.writeValueAsString(errorMessage));
+    } catch (IOException e) {
+      Log.errorf(
+          "Unable to send error message to session %s: %s",
+          session.getId(),
+          e.getMessage(),
+          e
+      );
+    } finally {
+      try {
+        // And always close the session
+        session.close();
+      } catch (IOException e) {
+        Log.errorf(
+            "Unable to close session %s: %s",
+            session.getId(),
+            e.getMessage(),
+            e
+        );
+      }
+    }
   }
 
   /**
-   * Validate that the headers are suitable for a broadcasted sidecar -> all workspaces message.
+   * Validate that the headers are suitable for a broadcast sidecar -> all workspaces message.
    * @param outboundMessage the message intended to be sent.
    * @return the validated headers of the message.
    * @throws IllegalArgumentException if the headers are not suitable for broadcasting.
@@ -331,13 +374,15 @@ public class WebsocketEndpoint {
   static MessageHeaders validateHeadersForSidecarBroadcast(Message outboundMessage) {
     MessageHeaders headers = outboundMessage.headers();
 
-    if (! headers.originator().equals("sidecar")) {
-      Log.errorf("Message id %s is not originator=sidecar message, cannot broadcast.", headers.id());
+    if (!headers.originator().equals("sidecar")) {
+      Log.errorf(
+          "Message id %s is not originator=sidecar message, cannot broadcast.",
+          headers.id()
+      );
       throw new IllegalArgumentException(
           "Attempted to broadcast a non-sidecar message to workspaces."
       );
     }
-
     return headers;
   }
 }


### PR DESCRIPTION
Suggested fixes for #215 

Mostly formatting and line lengths, but also refactored the `sendErrorAndCloseSession(…)` method to format and log the message, and better handle errors while ensuring the session is closed.