### PR TITLE
chore: Configure Sonarqube main branch for ide-sidecar [ci skip]

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -28,3 +28,4 @@ sonarqube:
     - "**/*.pb.*"
     - "**/mk-files/**/*"
     - "**/test/**/*"
+  main_branch: main


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Configure Sonarqube main branch to `main`, overrides default `master`.