### PR TITLE
chore: Skip running unit tests in `native` maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,7 @@
         </property>
       </activation>
       <properties>
+        <skipUTs>true</skipUTs>
         <skipITs>false</skipITs>
         <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
@@ -828,6 +829,7 @@
             <quarkus.jacoco.reuse-data-file>true</quarkus.jacoco.reuse-data-file>
             <quarkus.jacoco.report>false</quarkus.jacoco.report>
           </systemPropertyVariables>
+          <skip>${skipUTs}</skip>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Resolves part of #247:
> Don't [run unit tests when building the native executables](https://github.com/confluentinc/ide-sidecar/blob/main/.semaphore/multi-arch-builds-and-upload.yml#L43), as they are already ran by the [Build JARs and Unit Test](https://github.com/confluentinc/ide-sidecar/blob/main/.semaphore/multi-arch-builds-and-upload.yml) block.