### PR TITLE
feat(CCloud OAuth. redirect): add support for custom URI schemes

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlags.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlags.java
@@ -758,7 +758,8 @@ public class FeatureFlags {
           .set("os.type", sidecar.osType().name());
       sidecar.vsCode().ifPresent(vscode -> context
           .set("vscode.extension.version", vscode.extensionVersion())
-          .set("vscode.version", vscode.version()));
+          .set("vscode.version", vscode.version())
+          .set("vscode.uri.scheme", vscode.uriScheme()));
     }
     this.deviceContext.set(context.build());
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,8 +92,10 @@ ide-sidecar:
         client-id: Q93zdbI3FnltpEa9G1gg6tiMuoDDBkwS
         login-realm-uri: https://confluent.cloud/api/login/realm
         redirect-uri: http://127.0.0.1:26636/gateway/v1/callback-vscode-docs
-        # URI redirect to tell the VS Code extension if the auth flow completed successfully or not
-        vscode-extension-uri: vscode://confluentinc.vscode-confluent/authCallback
+        # URI redirect path to tell the VS Code extension if the auth flow completed successfully or
+        # not. URI scheme is provided in SidecarInfo.VsCode as vscode.extension.uri and defaults to
+        # "vscode" if not provided.
+        vscode-extension-uri-path: confluentinc.vscode-confluent/authCallback
         scope: email openid offline_access
       refresh-status-interval-seconds: 5
       refresh-token:

--- a/src/test/java/io/confluent/idesidecar/restapi/application/SidecarInfoTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/application/SidecarInfoTest.java
@@ -6,6 +6,7 @@ import static io.confluent.idesidecar.restapi.application.SidecarInfo.OS_VERSION
 import static io.confluent.idesidecar.restapi.application.SidecarInfo.SIDECAR_VERSION;
 import static io.confluent.idesidecar.restapi.application.SidecarInfo.VSCODE_EXTENSION_VERSION_KEY;
 import static io.confluent.idesidecar.restapi.application.SidecarInfo.VSCODE_VERSION_KEY;
+import static io.confluent.idesidecar.restapi.application.SidecarInfo.VSCODE_URI_SCHEME_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -75,7 +76,7 @@ public class SidecarInfoTest {
             "22.0413",
             "aarch64",
             OperatingSystemType.Linux,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             null,
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (linux/aarch64)"
         ),
@@ -85,7 +86,7 @@ public class SidecarInfoTest {
             "22.0413",
             "aarch64",
             OperatingSystemType.Linux,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (linux/aarch64)"),
         new TestInputs(
@@ -104,7 +105,7 @@ public class SidecarInfoTest {
             "13.1",
             "amd64",
             OperatingSystemType.MacOS,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (macos/amd64)"),
         new TestInputs(
@@ -113,7 +114,7 @@ public class SidecarInfoTest {
             "13.1",
             "amd64",
             OperatingSystemType.MacOS,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (macos/amd64)"),
         new TestInputs(
@@ -132,7 +133,7 @@ public class SidecarInfoTest {
             "10.0.1904562",
             "x86_64",
             OperatingSystemType.Windows,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (windows/x86_64)"),
         new TestInputs(
@@ -141,7 +142,7 @@ public class SidecarInfoTest {
             "10.0.1904562",
             "x86_64",
             OperatingSystemType.Windows,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (windows/x86_64)")
 ,
@@ -162,7 +163,7 @@ public class SidecarInfoTest {
             "10.0.1904562",
             "x86_64",
             OperatingSystemType.Windows,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (windows/x86_64)"
         ),
@@ -172,7 +173,7 @@ public class SidecarInfoTest {
             "10.0.1904562",
             "x86_64",
             OperatingSystemType.Windows,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (windows/x86_64)"),
         new TestInputs(
@@ -192,7 +193,7 @@ public class SidecarInfoTest {
             "4.1.X.Y",
             "sparc",
             OperatingSystemType.Unix,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (unix/sparc)"
         ),
@@ -202,7 +203,7 @@ public class SidecarInfoTest {
             "4.1.X.Y",
             "sparc",
             OperatingSystemType.Unix,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (unix/sparc)")
 ,
@@ -212,7 +213,7 @@ public class SidecarInfoTest {
             "4.1.X.Y",
             "sparc",
             OperatingSystemType.Unix,
-            new SidecarInfo.VsCode("20.1.2", "1.2.3"),
+            new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode"),
             "v",
             "Confluent-for-VSCode/v1.2.3 (https://confluent.io; support@confluent.io) sidecar/v%s (unix/sparc)"
         )
@@ -246,11 +247,14 @@ public class SidecarInfoTest {
     // Don't use the constants, so that we check that the constants are correct
     final String vscodeVersionKey = "vscode.version";
     final String vscodeExtensionVersionKey = "vscode.extension.version";
+    final String vscodeUriSchemeKey = "vscode.uri.scheme";
     final String existingVscodeVersion = System.getProperty(vscodeVersionKey);
     final String existingVscodeExtensionVersion = System.getProperty(vscodeExtensionVersionKey);
+    final String existingVscodeUriScheme = System.getProperty(vscodeUriSchemeKey);
     try {
       System.clearProperty(vscodeVersionKey);
       System.clearProperty(vscodeExtensionVersionKey);
+      System.clearProperty(vscodeUriSchemeKey);
       SidecarInfo sidecar = new SidecarInfo();
       assertNotNull(sidecar.osType());
       assertEquals(System.getProperty("os.name"), sidecar.osName());
@@ -267,6 +271,9 @@ public class SidecarInfoTest {
       if (existingVscodeExtensionVersion != null) {
         System.setProperty(vscodeExtensionVersionKey, existingVscodeExtensionVersion);
       }
+      if (existingVscodeUriScheme != null) {
+        System.setProperty(vscodeUriSchemeKey, existingVscodeUriScheme);
+      }
     }
   }
 
@@ -274,9 +281,11 @@ public class SidecarInfoTest {
   void shouldEvaluateCurrentOsWithVSCode() {
     final String existingVscodeVersion = System.getProperty(VSCODE_VERSION_KEY);
     final String existingVscodeExtensionVersion = System.getProperty(VSCODE_EXTENSION_VERSION_KEY);
+    final String existingVscodeUriScheme = System.getProperty(VSCODE_URI_SCHEME_KEY);
     try {
       System.setProperty(VSCODE_VERSION_KEY, "v20.1.2");
       System.setProperty(VSCODE_EXTENSION_VERSION_KEY, "v1.2.3");
+      System.setProperty(VSCODE_URI_SCHEME_KEY, "vscode-insiders");
       SidecarInfo sidecar = new SidecarInfo();
       assertNotNull(sidecar.osType());
       assertEquals(System.getProperty("os.name"), sidecar.osName());
@@ -284,6 +293,7 @@ public class SidecarInfoTest {
       assertTrue(sidecar.vsCode().isPresent());
       assertEquals("20.1.2", sidecar.vsCode().get().version());
       assertEquals("1.2.3", sidecar.vsCode().get().extensionVersion());
+      assertEquals("vscode-insiders", sidecar.vsCode().get().uriScheme());
       // And there is a non-other type
       assertNotNull(sidecar.osType());
       assertNotEquals(OperatingSystemType.Other, sidecar.osType());
@@ -299,6 +309,11 @@ public class SidecarInfoTest {
         System.clearProperty(VSCODE_EXTENSION_VERSION_KEY);
       } else {
         System.setProperty(VSCODE_EXTENSION_VERSION_KEY, existingVscodeExtensionVersion);
+      }
+      if (existingVscodeUriScheme == null) {
+        System.clearProperty(VSCODE_URI_SCHEME_KEY);
+      } else {
+        System.setProperty(VSCODE_URI_SCHEME_KEY, existingVscodeUriScheme);
       }
     }
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlagTestConstants.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlagTestConstants.java
@@ -9,7 +9,7 @@ public interface FeatureFlagTestConstants {
   String OS_NAME = "Mac OS X";
   String OS_VERSION = "13.1";
   OperatingSystemType OS_TYPE = OperatingSystemType.MacOS;
-  SidecarInfo.VsCode VS_CODE = new SidecarInfo.VsCode("20.1.2", "1.2.3");
+  SidecarInfo.VsCode VS_CODE = new SidecarInfo.VsCode("20.1.2", "1.2.3", "vscode");
   String USER_ID = "u-1234";
   String USER_EMAIL = "zeus@acme.com";
   String ORG_ID = "b0362fb6-772a-44bb-9f5d-ce576f649e48";

--- a/src/test/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlagsContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/featureflags/FeatureFlagsContextTest.java
@@ -152,6 +152,7 @@ class FeatureFlagsContextTest extends BaseFeatureFlagsTest implements FeatureFla
     assertEquals(OS_TYPE.name(), deviceContext.getValue("os.type").stringValue());
     assertEquals(VS_CODE.extensionVersion(), deviceContext.getValue("vscode.extension.version").stringValue());
     assertEquals(VS_CODE.version(), deviceContext.getValue("vscode.version").stringValue());
+    assertEquals(VS_CODE.uriScheme(), deviceContext.getValue("vscode.uri.scheme").stringValue());
     assertEquals(SIDECAR_VERSION, deviceContext.getValue("sidecar.version").stringValue());
     assertAttributeNames(
         deviceContext,
@@ -161,7 +162,8 @@ class FeatureFlagsContextTest extends BaseFeatureFlagsTest implements FeatureFla
         "os.type",
         "sidecar.version",
         "vscode.extension.version",
-        "vscode.version"
+        "vscode.version",
+        "vscode.uri.scheme"
     );
   }
 


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR extends the `VsCode` record to include a `uriScheme` property, which should normally be passed as the `VSCODE_URI_SCHEME` environment variable. Previously, we hard-coded it to be `vscode`, but that limits support for other "products" which may include VS Code Insiders, Code OSS, Cursor, and more.

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/647c8f86-3bf6-4ad4-bffc-147757fdb8b6" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

