### PR TITLE
Fix connection status update by ignoring stale refreshes

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -110,7 +110,8 @@ public abstract class ConnectionState {
    * update the {@link #getStatus() cached results}.
    *
    * <p>This method always calls {@link #doRefreshStatus()} and then on success updates
-   * the {@link #getStatus() cached connection status}.
+   * the {@link #getStatus() cached connection status}. If we see that the status has been updated
+   * since the refresh was started, we ignore the update and refresh the status again.
    *
    * @return the future that will complete with the updated connection status
    * @see #getConnectionStatus()
@@ -121,30 +122,35 @@ public abstract class ConnectionState {
     var beforeStartingRefresh = Instant.now();
 
     // Always set the cached status when the future completes successfully
-    return doRefreshStatus().onSuccess(updated -> {
-      var lastUpdatedInstant = lastUpdated.get();
-      if (lastUpdatedInstant.isAfter(beforeStartingRefresh)) {
-        Log.infof(
-            "Ignoring stale connection status update for %s: %s. " +
-                "last updated: %s, before starting refresh time: %s",
-            spec.id(),
-            updated,
-            lastUpdatedInstant,
-            beforeStartingRefresh
-        );
-      } else {
-        // Update the status if it has not been updated since the refresh was started
-        updateStatus(originalState, updated);
-        Log.infof(
-            "Updated connection status for %s: %s, " +
-                "last updated: %s, before starting refresh time: %s",
-            spec.id(),
-            updated,
-            lastUpdatedInstant,
-            beforeStartingRefresh
-        );
-      }
-    });
+    return doRefreshStatus()
+        .compose(updated -> {
+          var lastUpdatedInstant = lastUpdated.get();
+          if (lastUpdatedInstant.isAfter(beforeStartingRefresh)) {
+            Log.infof(
+                "Found stale connection status update for %s: %s. Refreshing again. " +
+                    "last updated: %s, before starting refresh time: %s",
+                spec.id(),
+                updated,
+                lastUpdatedInstant,
+                beforeStartingRefresh
+            );
+
+            // Refresh the status again if it has been updated since the refresh was started
+            return refreshStatus();
+          } else {
+            // Update the status if it has not been updated since the refresh was started
+            updateStatus(originalState, updated);
+            Log.infof(
+                "Updated connection status for %s: %s, " +
+                    "last updated: %s, before starting refresh time: %s",
+                spec.id(),
+                updated,
+                lastUpdatedInstant,
+                beforeStartingRefresh
+            );
+            return Future.succeededFuture(updated);
+          }
+        });
   }
 
   private void updateStatus(ConnectionStatus original, ConnectionStatus updated) {

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -10,7 +10,9 @@ import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus;
 import io.confluent.idesidecar.restapi.resources.ConnectionsResource;
+import io.quarkus.logging.Log;
 import io.vertx.core.Future;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -51,6 +53,9 @@ public abstract class ConnectionState {
   protected ConnectionSpec spec;
 
   private final AtomicReference<ConnectionStatus> cachedStatus = new AtomicReference<>();
+  private final AtomicReference<Instant> lastUpdated = new AtomicReference<>(
+      Instant.now()
+  );
 
   private final StateChangedListener listener;
 
@@ -107,17 +112,43 @@ public abstract class ConnectionState {
    */
   public final Future<ConnectionStatus> refreshStatus() {
     var originalState = this.cachedStatus.get();
+    var beforeStartingRefresh = Instant.now();
 
     // Always set the cached status when the future completes successfully
-    return doRefreshStatus().onSuccess(updated ->
-        updateStatus(originalState, updated)
-    );
+    return doRefreshStatus().onSuccess(updated -> {
+      var lastUpdatedInstant = lastUpdated.get();
+      if (beforeStartingRefresh.equals(lastUpdatedInstant) ||
+          beforeStartingRefresh.isAfter(lastUpdatedInstant)) {
+        Log.infof(
+            "Updated connection status for %s: %s, last updated: %s, before starting refresh time: %s",
+            spec.id(),
+            updated,
+            lastUpdatedInstant,
+            beforeStartingRefresh
+        );
+        updateStatus(originalState, updated);
+      } else {
+        Log.infof(
+            "Ignoring stale connection status update for %s: %s. last updated: %s, before starting refresh time: %s",
+            spec.id(),
+            updated,
+            lastUpdatedInstant,
+            beforeStartingRefresh
+        );
+      }
+    });
   }
 
   private void updateStatus(ConnectionStatus original, ConnectionStatus updated) {
     // update the cached status
     this.cachedStatus.set(updated);
-
+    this.lastUpdated.set(Instant.now());
+    Log.infof(
+        "Updated connection status for %s: %s, last updated: %s",
+        spec.id(),
+        updated,
+        lastUpdated.get()
+    );
     // If the status has changed, notify the listener
     if (!updated.equals(original)) {
       if (updated.isConnected()) {

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -136,7 +136,17 @@ public abstract class ConnectionState {
             );
 
             // Refresh the status again if it has been updated since the refresh was started
-            return refreshStatus();
+            return doRefreshStatus().onSuccess(updated2 -> {
+              updateStatus(originalState, updated2);
+              Log.infof(
+                  "Updated connection status for %s: %s, " +
+                      "last updated: %s, before starting refresh time: %s",
+                  spec.id(),
+                  updated2,
+                  lastUpdatedInstant,
+                  beforeStartingRefresh
+              );
+            });
           } else {
             // Update the status if it has not been updated since the refresh was started
             updateStatus(originalState, updated);


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes #267 

- Store the `lastUpdated` time for the connection status as an atomic reference. This is used to prevent stale connection status refreshes from going through.

**Before:**

1. [Sidecar] Refresh connection status task 1 kicks off using ConnectionSpec A (say, with valid credentials)
2. [VS Code] User updates connection with invalid Kafka credentials
3. [Sidecar] Update connection spec (now A') processed and Connection status set to `ATTEMPTING` by sidecar. 
4. [VS Code] Sees `ATTEMPTING` status and starts polling the connection status until `SUCCESS` or `FAILED`.
5. [Sidecar] Refresh connection status task 1 completes and updates connection status to `SUCCESS`.
6. [VS Code] Sees `SUCCESS` in subsequent poll and reports to user. -- **This is the wrong state!** ❌ 
7. [Sidecar] Refresh connection status task 2 kicks off using Connection Spec A' and sets connection status to `FAILED`. -- This is the correct state, but VS Code will not pick it up automatically.

**After:**

1. [Sidecar] Refresh connection status task 1 kicks off using ConnectionSpec A (say, with valid credentials). **Store current time here**
2. [VS Code] User updates connection with invalid Kafka credentials
3. [Sidecar] Update connection spec (now A') processed and Connection status set to `ATTEMPTING` by sidecar. **Set last modified time to now**
4. [VS Code] Sees `ATTEMPTING` status and starts polling the connection status until `SUCCESS` or `FAILED`.
5. [Sidecar] Refresh connection status task 1 completes. Sees that last modified time is _later_ than when we started this refresh, so skip the connection status update.
4. [VS Code] Still sees `ATTEMPTING` status on continuous polling.
7. [Sidecar] Refresh connection status task 2 kicks off using Connection Spec A' and sets connection status to `FAILED`.
9. [VS Code] Sees `FAILED` status and reports to user. -- **This is correct** ✅ 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Click tested with @shouples 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

