### PR TITLE
Expect controller to be null in DescribeCluster call

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -241,8 +241,8 @@ public class DirectConnectionState extends ConnectionState {
   protected Future<SchemaRegistryStatus> getSchemaRegistryConnectionStatus() {
     return withSchemaRegistryClient(srClient -> {
       // There is a configuration, so validate the connection by creating a SchemaRegistryClient
-      // and getting the global mode.
-      srClient.getMode();
+      // and getting all subjects.
+      srClient.getAllSubjects();
       return Future.succeededFuture(
           ConnectionStatusSchemaRegistryStatusBuilder
               .builder()

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
@@ -143,7 +143,7 @@ public class ClusterManagerImpl implements ClusterManager {
 
     // Controller may be null
     if (cluster.controllerId() != null) {
-      clusterData.controller(forController(cluster.id(), cluster.controllerId()));
+      clusterData = clusterData.controller(forController(cluster.id(), cluster.controllerId()));
     }
 
     return clusterData;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
@@ -109,15 +109,20 @@ public class ClusterManagerImpl implements ClusterManager {
         .chain(describeClusterResult ->
             uniStage(describeClusterResult.clusterId().toCompletionStage())
                 .map(id -> new ClusterDescribe(describeClusterResult).withId(id)))
-        .chain(cid -> uniStage(cid.result.controller().toCompletionStage()).map(Node::id)
-            .map(cid::withControllerId)
+        .chain(cid -> uniStage(cid.result.controller().toCompletionStage())
+            .map(controller -> {
+              if (controller == null || controller.isEmpty()) {
+                return cid;
+              }
+              return cid.withControllerId(controller.id());
+            })
         ).chain(cid -> uniStage(cid.result.nodes().toCompletionStage())
             .map(cid::withNodes)
         );
   }
 
   private ClusterData fromClusterId(ClusterDescribe cluster) {
-    return ClusterData
+    var clusterData = ClusterData
         .builder()
         .kind("KafkaCluster")
         .metadata(ResourceMetadata
@@ -131,11 +136,17 @@ public class ClusterManagerImpl implements ClusterManager {
         .acls(forAcls(cluster.id()))
         .brokerConfigs(forBrokerConfigs(cluster.id()))
         .brokers(forBrokers(cluster.id()))
-        .controller(forController(cluster.id(), cluster.controllerId()))
         .consumerGroups(forConsumerGroups(cluster.id()))
         .topics(forTopics(cluster.id()))
         .partitionReassignments(forAllPartitionReassignments(cluster.id()))
         .build();
+
+    // Controller may be null
+    if (cluster.controllerId() != null) {
+      clusterData.controller(forController(cluster.id(), cluster.controllerId()));
+    }
+
+    return clusterData;
   }
 
   /**

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcher.java
@@ -201,7 +201,7 @@ public class RealDirectFetcher extends ConfluentRestClient implements DirectFetc
       SchemaRegistryClient srClient
   ) throws RestClientException, IOException {
     // Use the client to get *some* information, to verify that we can connect
-    var mode = srClient.getMode(); // unused
+    var mode = srClient.getAllSubjects();
 
     // Construct the cluster object
     var srConfig = state.getSpec().schemaRegistryConfig();

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
@@ -1,0 +1,47 @@
+package io.confluent.idesidecar.restapi.integration;
+
+import io.confluent.idesidecar.restapi.kafkarest.api.ClusterV3Suite;
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.confluent.idesidecar.restapi.util.SHA256Digest;
+import io.confluent.idesidecar.restapi.util.TestEnvironment;
+import io.confluent.idesidecar.restapi.util.WarpStreamTestEnvironment;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Regression tests to be run against a local WarpStream container.
+ */
+public class WarpStreamRegressionIT {
+  private static final WarpStreamTestEnvironment TEST_ENVIRONMENT = new WarpStreamTestEnvironment(
+      // This is a WarpStream version that is known to return `null` as part of the
+      // `DescribeCluster.controller()` response. The sidecar's Internal Kafka REST
+      // previously failed to handle this case correctly. This test class ensures that
+      // the ClusterV3Suite passes since the sidecar now correctly handles this case.
+      new SHA256Digest("dc694b4ecb415b61264707a87da1b440b3178ee55283c5a38b9c59c1d856b819")
+  );
+
+  static {
+    TEST_ENVIRONMENT.start();
+  }
+
+  @QuarkusIntegrationTest
+  @Tag("io.confluent.common.utils.IntegrationTest")
+  @TestProfile(NoAccessFilterProfile.class)
+  @Nested
+  class ClustersTests extends AbstractIT implements ClusterV3Suite {
+
+    @Override
+    public TestEnvironment environment() {
+      return TEST_ENVIRONMENT;
+    }
+
+    @BeforeEach
+    @Override
+    public void setupConnection() {
+      setupConnection(this, TestEnvironment::directConnectionSpec);
+    }
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3Suite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/ClusterV3Suite.java
@@ -1,34 +1,40 @@
 package io.confluent.idesidecar.restapi.kafkarest.api;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.confluent.idesidecar.restapi.integration.ITSuite;
-import io.confluent.idesidecar.restapi.util.ConfluentLocalKafkaWithRestProxyContainer;
 import org.junit.jupiter.api.Test;
 
 public interface ClusterV3Suite extends ITSuite {
-
   @Test
   default void shouldListKafkaClusters() {
-    givenConnectionId()
+    assertNotNull(getClusterId());
+  }
+
+  /**
+   * Get the cluster ID of the first cluster in the list of clusters.
+   */
+  private String getClusterId() {
+    return givenConnectionId()
         .when()
         .get("/internal/kafka/v3/clusters")
         .then()
         .statusCode(200)
         .body("data.size()", equalTo(1))
-        .body("data[0].cluster_id",
-            equalTo(ConfluentLocalKafkaWithRestProxyContainer.CLUSTER_ID));
+        .extract()
+        .path("data[0].cluster_id");
   }
 
   @Test
   default void shouldGetKafkaCluster() {
+    var clusterId = getClusterId();
     givenConnectionId()
         .when()
-        .get("/internal/kafka/v3/clusters/{cluster_id}",
-            ConfluentLocalKafkaWithRestProxyContainer.CLUSTER_ID)
+        .get("/internal/kafka/v3/clusters/{cluster_id}", clusterId)
         .then()
         .statusCode(200)
-        .body("cluster_id", equalTo(ConfluentLocalKafkaWithRestProxyContainer.CLUSTER_ID));
+        .body("cluster_id", equalTo(clusterId));
   }
 
   @Test

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3Suite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/api/TopicV3Suite.java
@@ -15,19 +15,23 @@ public interface TopicV3Suite extends ITSuite {
     createTopic("test-topic-1");
 
     // Get topic should contain the topic name
-    givenDefault()
-        .get("/internal/kafka/v3/clusters/{cluster_id}/topics/test-topic-1")
-        .then()
-        .statusCode(200)
-        .body("topic_name", equalTo("test-topic-1"));
+    await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        givenDefault()
+          .get("/internal/kafka/v3/clusters/{cluster_id}/topics/test-topic-1")
+          .then()
+          .statusCode(200)
+          .body("topic_name", equalTo("test-topic-1"))
+    );
 
     // List topics should contain the topic name
-    givenDefault()
-        .get("/internal/kafka/v3/clusters/{cluster_id}/topics")
-        .then()
-        .statusCode(200)
-        // Could be at any index
-        .body("data.find { it.topic_name == 'test-topic-1' }.topic_name", equalTo("test-topic-1"));
+    await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+        givenDefault()
+          .get("/internal/kafka/v3/clusters/{cluster_id}/topics")
+          .then()
+          .statusCode(200)
+          // Could be at any index
+          .body("data.find { it.topic_name == 'test-topic-1' }.topic_name", equalTo("test-topic-1"))
+    );
   }
 
   @Test

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealDirectFetcherTest.java
@@ -265,11 +265,11 @@ public class RealDirectFetcherTest {
     }
 
     @Test
-    void shouldFailToFetchSchemaRegistryWhenSrClientFailsToReturnsMode() throws IOException, RestClientException {
+    void shouldFailToFetchSchemaRegistryWhenSrClientFailsToReturnsAllSubjects() throws IOException, RestClientException {
       // When we have an SR client that returns the SR cluster's mode
       var mockSrClient = mock(SchemaRegistryClient.class);
-      when(mockSrClient.getMode()).thenThrow(
-          new RuntimeException("Failed to get mode with Schema Registry client")
+      when(mockSrClient.getAllSubjects()).thenThrow(
+          new RuntimeException("Failed to get all subjects with Schema Registry client")
       );
 
       // And a direct connection that thinks it has connected to SR and returns that SR client

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SHA256Digest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SHA256Digest.java
@@ -1,0 +1,13 @@
+package io.confluent.idesidecar.restapi.util;
+
+/**
+ * Typed-String representation of a SHA-256 digest.
+ * @param digest the SHA-256 digest
+ */
+public record SHA256Digest(
+    String digest
+) {
+  public String toString() {
+    return digest;
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/util/WarpStreamContainer.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/WarpStreamContainer.java
@@ -1,0 +1,42 @@
+package io.confluent.idesidecar.restapi.util;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+
+public class WarpStreamContainer extends GenericContainer<WarpStreamContainer> {
+
+  // https://gallery.ecr.aws/warpstream-labs/warpstream_agent
+  private static final String WARPSTREAM_IMAGE = "public.ecr.aws/warpstream-labs/warpstream_agent";
+  private static final Integer KAFKA_PORT = 9092;
+  private static final Integer SCHEMA_REGISTRY_PORT = 9094;
+
+  void initialize() {
+    super
+        .withCreateContainerCmdModifier(
+            cmd -> cmd.withCmd("playground")
+        );
+    super.addFixedExposedPort(KAFKA_PORT, KAFKA_PORT);
+    super.addFixedExposedPort(SCHEMA_REGISTRY_PORT, SCHEMA_REGISTRY_PORT);
+
+    super.waitingFor(
+        new WaitAllStrategy()
+            .withStrategy(
+                Wait.forLogMessage(".*started agent.*\\n", 1)
+            )
+            .withStrategy(
+                Wait.forLogMessage(".*started schema registry agent.*\\n", 1)
+            )
+    );
+  }
+
+  public WarpStreamContainer(String tag) {
+    super(WARPSTREAM_IMAGE + ":" + tag);
+    initialize();
+  }
+
+  public WarpStreamContainer(SHA256Digest digest) {
+    super(WARPSTREAM_IMAGE + "@sha256:" + digest);
+    initialize();
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/util/WarpStreamTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/WarpStreamTestEnvironment.java
@@ -1,0 +1,65 @@
+package io.confluent.idesidecar.restapi.util;
+
+import io.confluent.idesidecar.restapi.credentials.TLSConfigBuilder;
+import io.confluent.idesidecar.restapi.models.ConnectionSpec;
+import io.confluent.idesidecar.restapi.models.ConnectionSpecKafkaClusterConfigBuilder;
+import io.confluent.idesidecar.restapi.models.ConnectionSpecSchemaRegistryConfigBuilder;
+import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import java.util.Optional;
+
+/**
+ * A {@link TestEnvironment} that starts a local WarpStream container with a Kafka-compatible broker
+ * and Confluent Schema Registry API compatible server.
+ */
+@TestProfile(NoAccessFilterProfile.class)
+public class WarpStreamTestEnvironment implements TestEnvironment {
+
+  private final WarpStreamContainer warpStream;
+
+  public WarpStreamTestEnvironment(String tag) {
+    warpStream = new WarpStreamContainer(tag);
+  }
+
+  public WarpStreamTestEnvironment(SHA256Digest digest) {
+    warpStream = new WarpStreamContainer(digest);
+  }
+
+  @Override
+  public void start() {
+    warpStream.start();
+  }
+
+  @Override
+  public void shutdown() {
+    close();
+  }
+
+  @Override
+  public Optional<ConnectionSpec> localConnectionSpec() {
+    return Optional.empty();
+  }
+
+  public void close() {
+    warpStream.close();
+  }
+
+  public Optional<ConnectionSpec> directConnectionSpec() {
+    return Optional.of(
+        ConnectionSpec.createDirect(
+            "warpstream-direct",
+            "WarpStream Direct Connection",
+            ConnectionSpecKafkaClusterConfigBuilder
+                .builder()
+                .bootstrapServers("localhost:9092")
+                // Disable TLS
+                .tlsConfig(TLSConfigBuilder.builder().enabled(false).build())
+                .build(),
+            ConnectionSpecSchemaRegistryConfigBuilder
+                .builder()
+                .uri("http://localhost:9094")
+                .build()
+        ));
+  }
+}


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Expect `DescribeClusterResult.controller()` to return a null value on future completion. See [docs](https://kafka.apache.org/33/javadoc/org/apache/kafka/clients/admin/DescribeClusterResult.html):

> Returns a future which yields the current controller id. Note that this may yield null, if the controller ID is not yet known.

See similar treatment by kafka-rest: https://github.com/confluentinc/kafka-rest/blob/30258f22eb714001bfe3663494c34876c52c0bdf/kafka-rest/src/main/java/io/confluent/kafkarest/controllers/ClusterManagerImpl.java#L78

- Also replace usages of `getMode()` with `getAllSubjects()` since WarpStream SR doesn't support the `GET /mode` endpoint. This resolves #278.
- Added a WarpStream test environment. Wrote a regression test that uses a pinned WarpStream image version that is known to return `null` as part of `DescribeCluster.controller()`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Resolves #274 
More context: WarpStream returns a particular hardcoded value for the Controller ID (as part of Describe Cluster call) that makes the `AdminClient` interpret it as `null`. This was then breaking the sidecar when trying to extract the controller ID from the describe cluster response. This PR fixes it so that we gracefully handle `null` values.

FYI @rmb938 also has a fix for the controller ID value returned from WarpStream.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

