### PR TITLE
chore: Reduce noise in sidecar logs

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionState.java
@@ -136,14 +136,6 @@ public abstract class ConnectionState {
       } else {
         // Update the status if it has not been updated since the refresh was started
         updateStatus(originalState, updated);
-        Log.infof(
-            "Updated connection status for %s: %s, " +
-                "last updated: %s, before starting refresh time: %s",
-            spec.id(),
-            updated,
-            lastUpdatedInstant,
-            beforeStartingRefresh
-        );
       }
     });
   }
@@ -152,15 +144,16 @@ public abstract class ConnectionState {
     // update the cached status
     this.cachedStatus.set(updated);
     this.lastUpdated.set(Instant.now());
-    Log.infof(
-        "Updated connection status for %s: %s, last updated: %s",
-        spec.id(),
-        updated,
-        lastUpdated.get()
-    );
 
     // If the status has changed, notify the listener
     if (!updated.equals(original)) {
+      Log.infof(
+          "Updated status for connection ID=%s. Original spec: %s, Updated spec: %s, Last updated: %s",
+          spec.id(),
+          original,
+          updated,
+          lastUpdated.get()
+      );
       if (updated.isConnected()) {
         listener.connected(this);
       } else {


### PR DESCRIPTION
When checking the status of a connection, write a log message only if the status has changed. Before this change, the sidecar wrote two log messages for every check of the connection status, i.e., every 5 seconds, regardless of whether the status has changed.

Fixes #282

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

