### PR TITLE
Wait longer for SidecarClient to establish connection

### DIFF
--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -389,7 +389,7 @@ public class SidecarClient implements SidecarClientApi {
     if (waitUntilConnected
         && (spec.kafkaClusterConfig() != null || spec.schemaRegistryConfig() != null)
     ) {
-      await().atMost(Duration.ofSeconds(10)).until(() -> {
+      await().atMost(Duration.ofSeconds(20)).until(() -> {
         var connection = given()
             .when()
             .get("%s/gateway/v1/connections/%s".formatted(sidecarHost, spec.id()))


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

WarpStream takes a bit longer to get ready even after the "started agent" log. Wait longer to fix failing tests.