### PR TITLE
Harden websocket serde

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpoint.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpoint.java
@@ -79,8 +79,6 @@ public class WebsocketEndpoint {
     private final Session session;
     private final Instant createdAt;
 
-
-
     /** Will be null if session has not sent HELLO_WORKSPACE message carrying its process id. */
     @Nullable
     private final WorkspacePid workspacePid;

--- a/src/test/java/io/confluent/idesidecar/restapi/util/ResourceIOUtil.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/ResourceIOUtil.java
@@ -18,7 +18,16 @@ import wiremock.com.github.jknack.handlebars.internal.Files;
 
 public class ResourceIOUtil {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static ObjectMapper MAPPER = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    // Automatically registers JavaTimeModule and others as would be done for the ObjectMapper
+    // used within Quarkus will be. Alas that ResourceIOUtil is used as collection
+    // of static methods, @Inject is not possible here.
+    mapper.findAndRegisterModules();
+    return mapper;
+  }
 
   /**
    * Load a resource file at the given path relative to the current thread's context class loader.

--- a/src/test/java/io/confluent/idesidecar/websocket/messages/MessageSerializationTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/messages/MessageSerializationTest.java
@@ -54,6 +54,13 @@ public class MessageSerializationTest {
             "websocket-messages/connection-valid.json",
             MessageType.CONNECTION_EVENT,
             ConnectionEventBody.class
+        ),
+        new TestInput(
+            // Has some java.time.Instant fields, not serializable by default
+            // ObjectMapper instances.
+            "websocket-messages/ccloud-connection-connected.json",
+            MessageType.CONNECTION_EVENT,
+            ConnectionEventBody.class
         )
     );
 

--- a/src/test/java/io/confluent/idesidecar/websocket/resources/AbstractWebsocketTestBase.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/resources/AbstractWebsocketTestBase.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.websocket.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.idesidecar.restapi.application.KnownWorkspacesBean;
 import io.confluent.idesidecar.restapi.application.KnownWorkspacesBean.WorkspacePid;
 import io.confluent.idesidecar.restapi.application.SidecarAccessTokenBean;
@@ -23,6 +24,9 @@ abstract class AbstractWebsocketTestBase implements WebsocketClients {
 
   @Inject
   WebsocketEndpoint websocketEndpoint;
+
+  @Inject
+  ObjectMapper mapper;
 
   @TestHTTPResource("/ws")
   URI uri;
@@ -113,6 +117,7 @@ abstract class AbstractWebsocketTestBase implements WebsocketClients {
     TestWebsocketClientConfigurator.setAccessToken(expectedTokenValue);
 
     return connectWorkspace(
+        mapper,
         uri,
         "valid-token",
         workspacePid,

--- a/src/test/java/io/confluent/idesidecar/websocket/resources/WorkspaceWebsocketSessionTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/resources/WorkspaceWebsocketSessionTest.java
@@ -4,14 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.idesidecar.restapi.application.KnownWorkspacesBean.WorkspacePid;
 import io.confluent.idesidecar.websocket.resources.WebsocketEndpoint.WorkspaceWebsocketSession;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import jakarta.websocket.Session;
 import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+@QuarkusTest
 public class WorkspaceWebsocketSessionTest {
+
+  @Inject
+  ObjectMapper mapper;
 
   /**
    * Test that by default, a WorkspaceWebsocketSession is inactive and has an unknown pid, and that
@@ -22,7 +29,7 @@ public class WorkspaceWebsocketSessionTest {
     // inactive / not yet pid known session
     Instant now = Instant.now();
     var mockSession = getMockSession();
-    WorkspaceWebsocketSession session = new WorkspaceWebsocketSession(mockSession, null, now);
+    WorkspaceWebsocketSession session = new WorkspaceWebsocketSession(this.mapper, mockSession, null, now);
     Assertions.assertFalse(session.isActive());
     // inactive session should report "unknown" for its pid string
     assertEquals("unknown", session.workspacePidString());

--- a/src/test/resources/websocket-messages/ccloud-connection-connected.json
+++ b/src/test/resources/websocket-messages/ccloud-connection-connected.json
@@ -1,0 +1,51 @@
+{
+  "headers": {
+    "message_type": "CONNECTION_EVENT",
+    "originator": "sidecar",
+    "message_id": "4597525f-ac86-4aeb-b656-25658987ff0c"
+  },
+  "body": {
+    "action": "CONNECTED",
+    "connection": {
+      "api_version": "gateway/v1",
+      "kind": "Connection",
+      "id": "vscode-confluent-cloud-connection",
+      "metadata": {
+        "self": "http://localhost:26636/gateway/v1/connections/vscode-confluent-cloud-connection",
+        "resource_name": null,
+        "sign_in_uri": "https://login.confluent.io/oauth/authorize?..."
+      },
+      "spec": {
+        "id": "vscode-confluent-cloud-connection",
+        "name": "Confluent Cloud",
+        "type": "CCLOUD"
+      },
+      "status": {
+        "authentication": {
+          "status": "VALID_TOKEN",
+          "user": {
+            "id": "u-foo",
+            "username": "foo@bar.com",
+            "first_name": "Foo",
+            "last_name": "Bar",
+            "social_connection": "",
+            "auth_type": "AUTH_TYPE_LOCAL"
+          },
+          "requires_authentication_at": "2025-01-09T02:16:28.903418Z"
+        },
+        "ccloud": {
+          "state": "SUCCESS",
+          "user": {
+            "id": "u-foo",
+            "username": "foo@bar.com",
+            "first_name": "Foo",
+            "last_name": "Bar",
+            "social_connection": "",
+            "auth_type": "AUTH_TYPE_LOCAL"
+          },
+          "requires_authentication_at": "2025-01-09T02:16:28.903418Z"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Close #277 through ensuring that websocket related code uses the properly configured and `@Inject`-ed Quarkus application `ObjectMapper`, able to serde `java.time.Instant` instances. Previously, `WebsocketEndpoint` was using a separate, default configuration `ObjectMapper` unable to serialize `java.time.Instant` instances.
- The REST endpoints were able to serde those `Instant`-bearing `Connection` objects just fine though, so the fix is to get websocket-land using the same `ObjectMapper` as the REST endpoints are implicitly using.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This rippled out to needing to get the `@Inject`-ed `ObjectMapper`through to static inner class `WorkspaceWebsocketSession` of `WebsocketEndpoint`, as well as through to a few testsuite-side classes, and finally promoting a few test suites to become @QuarkusTest so as to be able receive the `@Inject`ion.
- Static function class `ResourceIOUtil` is used as a namespace for a collection of static test suite helper functions, some of which do serde using an `ObjectMapper`. Getting the `@Injected` `ObjectMapper` into this static class prior to any using test utilizing it proved quite invasive, so I ended up punting and having it create what should be an equivalent one in its new static method `createObjectMapper` (whose improvement is definitely exercised by the new `ccloud-connection-connected.json` test case of `testSerdeResourceMessageFiles`.
- That said, the truly authoritative test that all of websocket-land is using the better `ObjectMapper` instance is new test [`WebsocketEndpointTest.testSendingCCloudConnectionStatusMessage()`](https://github.com/confluentinc/ide-sidecar/pull/286/files#diff-d45c9c263b56c3a6c59dd30d1756f343b48c112820ae62d595d54b4e79945d2bR266), which was born failing.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

