### PR TITLE
Return status code 400 when updating unauthed CCloud connection

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
@@ -265,21 +265,47 @@ public class ConnectionStateManager {
     var connectionState = (CCloudConnectionState) connectionStates.get(id);
     CCloudOAuthContext authContext = connectionState.getOauthContext();
 
-    return Uni.createFrom()
-        .completionStage(authContext
-            .refreshIgnoreFailures(organizationId).toCompletionStage())
-        .onFailure(CCloudAuthenticationFailedException.class).recoverWithUni(
+    return Uni
+        .createFrom()
+        .completionStage(
+            authContext.refreshIgnoreFailures(organizationId).toCompletionStage()
+        )
+        .onFailure(CCloudAuthenticationFailedException.class)
+        .recoverWithUni(
             error -> {
               // If Confluent Cloud tells us that the organization ID is invalid, return a 400
               if (error.getMessage().contains("invalid resource id")) {
-                return Uni.createFrom().failure(new InvalidInputException(List.of(Error.create()
-                  .withSource("ccloud_config.organization_id")
-                  .withTitle("Invalid organization ID")
-                  .withDetail("Could not authenticate with the provided organization ID: %s"
-                      .formatted(organizationId))
-                )));
+                return Uni
+                    .createFrom()
+                    .failure(
+                        new InvalidInputException(
+                            List.of(
+                                Error
+                                    .create()
+                                    .withSource("ccloud_config.organization_id")
+                                    .withTitle("Invalid organization ID")
+                                    .withDetail(
+                                        "Could not authenticate with the provided organization ID: %s".formatted(organizationId)
+                                    )
+                            )
+                        )
+                    );
               } else {
-                return Uni.createFrom().failure(error);
+                return Uni
+                    .createFrom()
+                    .failure(
+                        new InvalidInputException(
+                            List.of(
+                                Error
+                                    .create()
+                                    .withSource("ccloud_config")
+                                    .withTitle("Could not authenticate")
+                                    .withDetail(
+                                        "Could not authenticate with Confluent Cloud using the provided config"
+                                    )
+                            )
+                        )
+                    );
               }
             }
         )

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/ConnectionStateManager.java
@@ -279,15 +279,14 @@ public class ConnectionStateManager {
                     .createFrom()
                     .failure(
                         new InvalidInputException(
-                            List.of(
-                                Error
-                                    .create()
-                                    .withSource("ccloud_config.organization_id")
-                                    .withTitle("Invalid organization ID")
-                                    .withDetail(
-                                        "Could not authenticate with the provided organization ID: %s".formatted(organizationId)
-                                    )
-                            )
+                            Error
+                                .create()
+                                .withSource("ccloud_config.organization_id")
+                                .withTitle("Invalid organization ID")
+                                .withDetail(
+                                    "Could not authenticate with the provided organization ID: %s".formatted(
+                                        organizationId)
+                                )
                         )
                     );
               } else {
@@ -295,15 +294,13 @@ public class ConnectionStateManager {
                     .createFrom()
                     .failure(
                         new InvalidInputException(
-                            List.of(
-                                Error
-                                    .create()
-                                    .withSource("ccloud_config")
-                                    .withTitle("Could not authenticate")
-                                    .withDetail(
-                                        "Could not authenticate with Confluent Cloud using the provided config"
-                                    )
-                            )
+                            Error
+                                .create()
+                                .withSource("ccloud_config")
+                                .withTitle("Could not authenticate")
+                                .withDetail(
+                                    "Could not authenticate with Confluent Cloud using the provided config"
+                                )
                         )
                     );
               }

--- a/src/main/java/io/confluent/idesidecar/restapi/exceptions/InvalidInputException.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/exceptions/InvalidInputException.java
@@ -15,6 +15,11 @@ public class InvalidInputException extends RuntimeException {
     this.errors = errors;
   }
 
+  public InvalidInputException(Error error) {
+    super("Invalid input");
+    this.errors = List.of(error);
+  }
+
   public List<Error> errors() {
     return errors;
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConnectionsResourceTest.java
@@ -784,9 +784,9 @@ public class ConnectionsResourceTest {
           .body(connectionSpec.withCCloudOrganizationId("d6fc52f8-ae8a-405c-9692-e997965b730dc"))
           .when().put("/gateway/v1/connections/{id}", connectionSpec.id())
           .then()
-          .statusCode(401)
+          .statusCode(400)
           .body("errors.size()", is(1))
-          .body("errors[0].title", is("Unauthorized"));
+          .body("errors[0].title", is("Could not authenticate"));
 
       // The above update should have triggered a failed auth refresh, which is fine
       assertAuthStatus(connectionId, "NO_TOKEN")


### PR DESCRIPTION
Return the HTTP response status code 400 not 401 when attempting to update an unauthenticated CCloud connection.

Fixes #287

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

