### PR TITLE
Cerchie/resource names

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
@@ -9,6 +9,7 @@ import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forClus
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forConsumerGroups;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forController;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forTopics;
+import static io.confluent.idesidecar.restapi.models.ClusterType.KAFKA;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniItem;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniStage;
 import static io.confluent.idesidecar.restapi.util.RequestHeadersConstants.CONNECTION_ID_HEADER;
@@ -20,6 +21,7 @@ import io.confluent.idesidecar.restapi.kafkarest.model.ClusterData;
 import io.confluent.idesidecar.restapi.kafkarest.model.ClusterDataList;
 import io.confluent.idesidecar.restapi.kafkarest.model.ResourceCollectionMetadata;
 import io.confluent.idesidecar.restapi.kafkarest.model.ResourceMetadata;
+import io.confluent.idesidecar.restapi.models.ClusterType;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.vertx.core.http.HttpServerRequest;
@@ -120,16 +122,24 @@ public class ClusterManagerImpl implements ClusterManager {
             .map(cid::withNodes)
         );
   }
-
+//  ClusterType clusterType = KAFKA;
+//  String resourceName = KafkaRestUtil.constructResourceName(clusterType, clusterId, topicName);
+//    return ResourceMetadata
+//        .builder()
+//        .resourceName(resourceName)
+//        .self(forTopic(clusterId, topicName).getRelated())
+//      .build();
   private ClusterData fromClusterId(ClusterDescribe cluster) {
+    var clusterId = cluster.id();
+    var clusterType = KAFKA;
+    String resourceName = KafkaRestUtil.constructResourceName(clusterType, clusterId);
     var clusterData = ClusterData
         .builder()
         .kind("KafkaCluster")
         .metadata(ResourceMetadata
             .builder()
             .self(forCluster(cluster.id()).getRelated())
-            // TODO: Construct resource name based on the connection/cluster type
-            .resourceName(null)
+            .resourceName(resourceName)
             .build()
         )
         .clusterId(cluster.id())

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImpl.java
@@ -122,13 +122,7 @@ public class ClusterManagerImpl implements ClusterManager {
             .map(cid::withNodes)
         );
   }
-//  ClusterType clusterType = KAFKA;
-//  String resourceName = KafkaRestUtil.constructResourceName(clusterType, clusterId, topicName);
-//    return ResourceMetadata
-//        .builder()
-//        .resourceName(resourceName)
-//        .self(forTopic(clusterId, topicName).getRelated())
-//      .build();
+
   private ClusterData fromClusterId(ClusterDescribe cluster) {
     var clusterId = cluster.id();
     var clusterType = KAFKA;

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/KafkaRestUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/KafkaRestUtil.java
@@ -1,0 +1,25 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import io.confluent.idesidecar.restapi.models.ClusterType;
+
+public class KafkaRestUtil {
+
+  public static String constructResourceName(ClusterType clusterType, String clusterId, String topicName) {
+    String authority = switch (clusterType) {
+      case KAFKA -> "kafka";
+      case SCHEMA_REGISTRY -> "schema-registry";
+      default -> "unknown";
+    };
+    return "crn://" + authority + "/resource=" + clusterId + "/sub-resource=" + topicName;
+  }
+
+  public static String constructResourceName(ClusterType clusterType, String clusterId) {
+    String authority = switch (clusterType) {
+      case KAFKA -> "kafka";
+      case SCHEMA_REGISTRY -> "schema-registry";
+      default -> "unknown";
+    };
+    return "crn://" + authority + "/resource=" + clusterId;
+  }
+
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/PartitionV3ApiImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/PartitionV3ApiImpl.java
@@ -5,6 +5,7 @@ import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forPart
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forReassignment;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forReplicas;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forTopicPartitions;
+import static io.confluent.idesidecar.restapi.models.ClusterType.KAFKA;
 
 import io.confluent.idesidecar.restapi.kafkarest.api.PartitionV3Api;
 import io.confluent.idesidecar.restapi.kafkarest.model.PartitionData;
@@ -13,6 +14,7 @@ import io.confluent.idesidecar.restapi.kafkarest.model.ReassignmentData;
 import io.confluent.idesidecar.restapi.kafkarest.model.ReassignmentDataList;
 import io.confluent.idesidecar.restapi.kafkarest.model.ResourceCollectionMetadata;
 import io.confluent.idesidecar.restapi.kafkarest.model.ResourceMetadata;
+import io.confluent.idesidecar.restapi.models.ClusterType;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -60,13 +62,14 @@ public class PartitionV3ApiImpl implements PartitionV3Api {
   private static PartitionData getPartitionData(
       String clusterId, String topicName, TopicPartitionInfo partitionInfo
   ) {
+    ClusterType clusterType = KAFKA;
+    String resourceName = KafkaRestUtil.constructResourceName(clusterType, clusterId, topicName);
     return PartitionData.builder()
         .kind("KafkaPartition")
         .metadata(
             ResourceMetadata.builder()
                 .self(forPartition(clusterId, topicName, partitionInfo.partition()).getRelated())
-                // TODO: Construct resource name based on the connection/cluster type
-                .resourceName(null)
+                .resourceName(resourceName)
                 .build()
         )
         .clusterId(clusterId)

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicV3ApiImpl.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/TopicV3ApiImpl.java
@@ -5,6 +5,7 @@ import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forPart
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forTopic;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forTopicConfigs;
 import static io.confluent.idesidecar.restapi.kafkarest.RelationshipUtil.forTopics;
+import static io.confluent.idesidecar.restapi.models.ClusterType.KAFKA;
 import static io.confluent.idesidecar.restapi.util.MutinyUtil.uniItem;
 
 import io.confluent.idesidecar.restapi.kafkarest.api.TopicV3Api;
@@ -14,6 +15,8 @@ import io.confluent.idesidecar.restapi.kafkarest.model.ResourceMetadata;
 import io.confluent.idesidecar.restapi.kafkarest.model.TopicData;
 import io.confluent.idesidecar.restapi.kafkarest.model.TopicDataList;
 import io.confluent.idesidecar.restapi.kafkarest.model.UpdatePartitionCountRequestData;
+import io.confluent.idesidecar.restapi.models.ClusterType;
+import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
@@ -112,10 +115,11 @@ public class TopicV3ApiImpl implements TopicV3Api {
   }
 
   private static ResourceMetadata getTopicMetadata(String clusterId, String topicName) {
+    ClusterType clusterType = KAFKA;
+    String resourceName = KafkaRestUtil.constructResourceName(clusterType, clusterId, topicName);
     return ResourceMetadata
         .builder()
-        // TODO: Construct resource name based on the connection/cluster type
-        .resourceName(null)
+        .resourceName(resourceName)
         .self(forTopic(clusterId, topicName).getRelated())
         .build();
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/KafkaRestUtilTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/KafkaRestUtilTest.java
@@ -1,0 +1,27 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import io.confluent.idesidecar.restapi.models.ClusterType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KafkaRestUtilTest {
+
+
+  @Test
+  void testConstructResourceNameWithTopic() {
+    String result = KafkaRestUtil.constructResourceName(ClusterType.KAFKA, "cluster1", "topic1");
+    assertEquals("crn://kafka/resource=cluster1/sub-resource=topic1", result);
+
+    result = KafkaRestUtil.constructResourceName(ClusterType.SCHEMA_REGISTRY, "cluster2", "topic2");
+    assertEquals("crn://schema-registry/resource=cluster2/sub-resource=topic2", result);
+  }
+
+  @Test
+  void testConstructResourceNameWithoutTopic() {
+    String result = KafkaRestUtil.constructResourceName(ClusterType.KAFKA, "cluster1");
+    assertEquals("crn://kafka/resource=cluster1", result);
+
+    result = KafkaRestUtil.constructResourceName(ClusterType.SCHEMA_REGISTRY, "cluster2");
+    assertEquals("crn://schema-registry/resource=cluster2", result);
+  }
+}


### PR DESCRIPTION
## Summary of Changes

This PR partially addresses #80, as it adds a crn utility function [along the lines of kafkares](https://github.com/search?q=repo%3Aconfluentinc%2Fkafka-rest+crn%3A%2F%2F&type=code&p=2
)t but does not determine what the names should default to for non-Confluent flavored clusters. The cluster types I saw were KAFKA and SCHEMA_REGISTRY, but I'm happy to adjust and make it more granular to include CCloud, CP, Confluent Local. 

It also adds a new utility class, `KafkaRestUtil`, as I didn't think the other util class was appropriate. Maybe we could combine?

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

