### PR TITLE
Remove fragile timestamp from connection error states which causes sidecar to emit websocket messages every 5s.

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -227,7 +227,7 @@
             }
           },
           "401" : {
-            "description" : "Could not authenticate with updated connection configuration",
+            "description" : "Could not authenticate",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -261,6 +261,68 @@
         "responses" : {
           "204" : {
             "description" : "No Content"
+          }
+        }
+      },
+      "patch" : {
+        "tags" : [ "Connections Resource" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/JsonMergePatch"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Connection updated with PATCH",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Connection not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Failure"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Could not authenticate",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Failure"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid input",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Failure"
+                }
+              }
+            }
           }
         }
       }
@@ -607,9 +669,6 @@
       "AuthError" : {
         "type" : "object",
         "properties" : {
-          "created_at" : {
-            "$ref" : "#/components/schemas/Instant"
-          },
           "message" : {
             "type" : "string"
           },
@@ -936,6 +995,9 @@
         "format" : "date-time",
         "type" : "string",
         "example" : "2022-03-10T16:15:50Z"
+      },
+      "JsonMergePatch" : {
+        "type" : "object"
       },
       "JsonNode" : {
         "type" : "object",
@@ -1536,12 +1598,12 @@
       "HealthCheck" : {
         "type" : "object",
         "properties" : {
-          "name" : {
-            "type" : "string"
-          },
           "data" : {
             "type" : "object",
             "nullable" : true
+          },
+          "name" : {
+            "type" : "string"
           },
           "status" : {
             "enum" : [ "UP", "DOWN" ],

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -157,7 +157,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Failure"
         "401":
-          description: Could not authenticate with updated connection configuration
+          description: Could not authenticate
           content:
             application/json:
               schema:
@@ -180,6 +180,45 @@ paths:
       responses:
         "204":
           description: No Content
+    patch:
+      tags:
+      - Connections Resource
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JsonMergePatch"
+      responses:
+        "200":
+          description: Connection updated with PATCH
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Connection"
+        "404":
+          description: Connection not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Failure"
+        "401":
+          description: Could not authenticate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Failure"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Failure"
   /gateway/v1/feature-flags/{id}/value:
     get:
       tags:
@@ -415,8 +454,6 @@ components:
     AuthError:
       type: object
       properties:
-        created_at:
-          $ref: "#/components/schemas/Instant"
         message:
           type: string
         is_transient:
@@ -673,6 +710,8 @@ components:
       format: date-time
       type: string
       example: 2022-03-10T16:15:50Z
+    JsonMergePatch:
+      type: object
     JsonNode:
       type: object
       properties:
@@ -1160,11 +1199,11 @@ components:
     HealthCheck:
       type: object
       properties:
-        name:
-          type: string
         data:
           type: object
           nullable: true
+        name:
+          type: string
         status:
           enum:
           - UP

--- a/src/main/java/io/confluent/idesidecar/restapi/auth/AuthErrors.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/AuthErrors.java
@@ -43,7 +43,7 @@ public record AuthErrors(
   public AuthErrors withAuthStatusCheck(String message) {
     return new AuthErrors(
         // Always consider errors that occurred when checking the auth status as transient
-        new AuthError(Instant.now(), message, true),
+        new AuthError(message, true),
         signIn,
         tokenRefresh
     );
@@ -57,7 +57,7 @@ public record AuthErrors(
     return new AuthErrors(
         authStatusCheck,
         // Always consider errors that occurred when signing in as non-transient
-        new AuthError(Instant.now(), message, false),
+        new AuthError(message, false),
         tokenRefresh
     );
   }
@@ -70,7 +70,7 @@ public record AuthErrors(
     return new AuthErrors(
         authStatusCheck,
         signIn,
-        new AuthError(Instant.now(), message, isTransient)
+        new AuthError(message, isTransient)
     );
   }
 
@@ -79,7 +79,6 @@ public record AuthErrors(
   }
 
   public record AuthError(
-      @JsonProperty(value = "created_at") Instant createdAt,
       String message,
       @JsonProperty(value = "is_transient") Boolean isTransient
   ) {

--- a/src/test/java/io/confluent/idesidecar/restapi/auth/AuthErrorsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/auth/AuthErrorsTest.java
@@ -26,7 +26,7 @@ public class AuthErrorsTest {
   @Test
   void hasErrorsShouldReturnTrueIfAuthStatusCheckIsNotNull() {
     var authErrorsWithAuthStatusCheck = new AuthErrors(
-        new AuthError(Instant.now(), "error", true),
+        new AuthError("error", true),
         null,
         null);
     assertTrue(authErrorsWithAuthStatusCheck.hasErrors());
@@ -36,7 +36,7 @@ public class AuthErrorsTest {
   void hasErrorsShouldReturnTrueIfSignInIsNotNull() {
     var authErrorsWithSignIn = new AuthErrors(
         null,
-        new AuthError(Instant.now(), "error", false),
+        new AuthError("error", false),
         null);
     assertTrue(authErrorsWithSignIn.hasErrors());
   }
@@ -46,7 +46,7 @@ public class AuthErrorsTest {
     var authErrorsWithTokenRefresh = new AuthErrors(
         null,
         null,
-        new AuthError(Instant.now(), "error", false));
+        new AuthError("error", false));
     assertTrue(authErrorsWithTokenRefresh.hasErrors());
   }
 }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- Drop the Instant field stamping when a connection was observed to have auth errors. When, say, a direct connection had an unhappy schema registry, the every 5s polling would create a new timestamp in the connection error, ultimately causing sidecar to emit the updated-only-with-timestamp-change Connection as a CONNECTION_CHANGE websocket event to all the connected workspaces, adding work and noise and would need additional code to dejitter vscode-extension side. If extension side needed to care about when the error started, it will use the timestamp at which it received the single updated Connection that edged to unhappy as a "good enough" timestamp (and better than one that moves forward every 5s while in this general condition).
- Needed to more simply solve https://github.com/confluentinc/vscode/issues/908

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- I have no suggestion as to the other changes made to the openapi documents. I wonder if prior PRs didn't commit their pending openapi document changes?

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

