### PR TITLE
Scram integration tests

### DIFF
--- a/src/test/java/io/confluent/idesidecar/restapi/integration/ConfluentPlatformIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/ConfluentPlatformIT.java
@@ -75,6 +75,28 @@ public class ConfluentPlatformIT {
     }
   }
 
+  @Nested
+  class DirectWithSaslScramConnectionTests {
+    @QuarkusIntegrationTest
+    @Tag("io.confluent.common.utils.IntegrationTest")
+    @TestProfile(NoAccessFilterProfile.class)
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class TopicTests extends AbstractIT implements TopicV3Suite {
+
+      @Override
+      public CPDemoTestEnvironment environment() {
+        return TEST_ENVIRONMENT;
+      }
+
+      @BeforeEach
+      @Override
+      public void setupConnection() {
+        setupConnection(this, environment().directConnectionSaslScramAuth());
+      }
+    }
+  }
+
   @QuarkusIntegrationTest
   @Tag("io.confluent.common.utils.IntegrationTest")
   @TestProfile(NoAccessFilterProfile.class)

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CPDemoTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CPDemoTestEnvironment.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.dockerjava.api.model.Container;
 import io.confluent.idesidecar.restapi.credentials.*;
-import io.confluent.idesidecar.restapi.credentials.Credentials.HashAlgorithm;
+import io.confluent.idesidecar.restapi.credentials.ScramCredentials.HashAlgorithm;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpecKafkaClusterConfigBuilder;
 import io.confluent.idesidecar.restapi.models.ConnectionSpecSchemaRegistryConfigBuilder;

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CPDemoTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CPDemoTestEnvironment.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.dockerjava.api.model.Container;
 import io.confluent.idesidecar.restapi.credentials.*;
+import io.confluent.idesidecar.restapi.credentials.Credentials.HashAlgorithm;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpecKafkaClusterConfigBuilder;
 import io.confluent.idesidecar.restapi.models.ConnectionSpecSchemaRegistryConfigBuilder;
@@ -92,8 +93,10 @@ public class CPDemoTestEnvironment implements TestEnvironment {
         10091,
         11091,
         12091,
+        12093,
         13091,
-        14091
+        14091,
+        15091
     );
     kafka1.withEnv(Map.of(
         "KAFKA_BROKER_ID", "1",
@@ -108,8 +111,10 @@ public class CPDemoTestEnvironment implements TestEnvironment {
         10092,
         11092,
         12092,
+        12094,
         13092,
-        14092
+        14092,
+        15092
     );
     kafka2.withEnv(Map.of(
         "KAFKA_BROKER_ID", "2",
@@ -120,6 +125,9 @@ public class CPDemoTestEnvironment implements TestEnvironment {
     // Must be started in parallel
     Log.info("Starting Kafka brokers...");
     Startables.deepStart(List.of(kafka1, kafka2)).join();
+
+    // Register users for SASL/SCRAM
+    registerScramUsers();
 
     if (!cpDemoRunning) {
       Log.info("Creating role bindings...");
@@ -149,13 +157,30 @@ public class CPDemoTestEnvironment implements TestEnvironment {
     try {
       kafka1.execInContainer(
           "kafka-configs",
-          "--bootstrap-server", "kafka1:12091",
+          "--bootstrap-server", "kafka1:12093",
           "--entity-type", "topics",
           "--entity-name", "_confluent-metadata-auth",
           "--alter",
           "--add-config", "min.insync.replicas=1"
       );
     } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void registerScramUsers() {
+    Log.info("Creating users for SASL/SCRAM authentication.");
+    try {
+      kafka1.execInContainer(
+          "kafka-configs",
+          "--bootstrap-server", "kafka1:12093",
+          "--entity-type", "users",
+          "--entity-name", "admin",
+          "--alter",
+          "--add-config", "SCRAM-SHA-256=[password=admin-secret]"
+      );
+    } catch (InterruptedException | IOException e) {
+      Log.error("Could not add users for SASL/SCRAM authentication.");
       throw new RuntimeException(e);
     }
   }
@@ -365,6 +390,29 @@ public class CPDemoTestEnvironment implements TestEnvironment {
                 .build(),
             null
         ));
+  }
+
+  public Optional<ConnectionSpec> directConnectionSaslScramAuth() {
+    return Optional.of(
+        ConnectionSpec.createDirect(
+            "direct-connection-sasl-scram-auth",
+            "Direct connection (SASL/SCRAM Auth)",
+            ConnectionSpecKafkaClusterConfigBuilder
+                .builder()
+                .bootstrapServers("localhost:15091")
+                .credentials(
+                    new ScramCredentials(
+                        HashAlgorithm.SCRAM_SHA_256,
+                        "admin",
+                        new Password("admin-secret".toCharArray())
+                    )
+                )
+                // Disable TLS
+                .tlsConfig(TLSConfigBuilder.builder().enabled(false).build())
+                .build(),
+            null
+        )
+    );
   }
 
   /**

--- a/src/test/resources/cp-demo-scripts/broker_jaas.conf
+++ b/src/test/resources/cp-demo-scripts/broker_jaas.conf
@@ -16,3 +16,10 @@ tokenhost.KafkaServer {
      org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
      publicKeyPath="/tmp/conf/public.pem";
 };
+
+scramhost.KafkaServer {
+     org.apache.kafka.common.security.scram.ScramLoginModule required
+     username="admin"
+     password="admin-secret"
+     user_admin="admin-secret";
+};


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

This change adds a listener for SASL/SCRAM to the `CPServerContainer` so that we can verify the correctness of the `ScramCredentials` using the CP integration tests. For now, we run only the `TopicV3Suite` against the SASL/SCRAM listener but can add more test suites when needed.

## Any additional details or context that should be provided?

The build is expected to fail right now because the build of the [base branch](https://github.com/confluentinc/ide-sidecar/tree/cerchie/scram) fails, too.

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

