### PR TITLE
Support consuming records that were compressed with zstd

### DIFF
--- a/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/index.json
+++ b/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/index.json
@@ -1,0 +1,5 @@
+[
+  "jni-config.json",
+  "reflect-config.json",
+  "resource-config.json"
+]

--- a/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/jni-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/jni-config.json
@@ -1,0 +1,100 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdCompressCtx"
+    },
+    "name": "com.github.luben.zstd.ZstdCompressCtx",
+    "fields": [
+      {
+        "name": "nativePtr"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDecompressCtx"
+    },
+    "name": "com.github.luben.zstd.ZstdDecompressCtx",
+    "fields": [
+      {
+        "name": "nativePtr"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDictCompress"
+    },
+    "name": "com.github.luben.zstd.ZstdDictCompress",
+    "fields": [
+      {
+        "name": "nativePtr"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDictDecompress"
+    },
+    "name": "com.github.luben.zstd.ZstdDictDecompress",
+    "fields": [
+      {
+        "name": "nativePtr"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+    },
+    "name": "com.github.luben.zstd.ZstdDirectBufferCompressingStream$1"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer"
+    },
+    "name": "com.github.luben.zstd.ZstdDirectBufferCompressingStreamNoFinalizer",
+    "fields": [
+      {
+        "name": "consumed"
+      },
+      {
+        "name": "produced"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+    },
+    "name": "com.github.luben.zstd.ZstdDirectBufferDecompressingStream$1"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer"
+    },
+    "name": "com.github.luben.zstd.ZstdDirectBufferDecompressingStreamNoFinalizer",
+    "fields": [
+      {
+        "name": "consumed"
+      },
+      {
+        "name": "produced"
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.ZstdInputStreamNoFinalizer"
+    },
+    "name": "com.github.luben.zstd.ZstdInputStreamNoFinalizer",
+    "fields": [
+      {
+        "name": "dstPos"
+      },
+      {
+        "name": "srcPos"
+      }
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.util.Native"
+    },
+    "name": "java.security.SecureRandomParameters"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.util.Native"
+    },
+    "name": "org.osgi.framework.BundleEvent"
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.util.Native"
+    },
+    "name": "sun.security.provider.NativePRNG",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "com.github.luben.zstd.util.Native"
+    },
+    "name": "sun.security.provider.SHA",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.luben/zstd-jni/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "condition": {
+          "typeReachable": "com.github.luben.zstd.util.Native"
+        },
+        "pattern": "[a-z]+/[a-z0-9]+/libzstd-jni-[0-9.-]+(so|dll|dylib)"
+      }
+    ]
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -236,7 +236,7 @@ quarkus:
   jackson:
     fail-on-unknown-properties: true
   native:
-    additional-build-args: --initialize-at-run-time=io.confluent.idesidecar.restapi.auth.CCloudOAuthConfig\,io.confluent.idesidecar.restapi.auth.CCloudOAuthContext\,io.confluent.ide.sidecar.restapi.util.WebClientFactory\,org.apache.kafka.common.security.authenticator.SaslClientAuthenticator\,org.apache.avro.file.DataFileWriter\,io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils
+    additional-build-args: --initialize-at-run-time=io.confluent.idesidecar.restapi.auth.CCloudOAuthConfig\,io.confluent.idesidecar.restapi.auth.CCloudOAuthContext\,io.confluent.ide.sidecar.restapi.util.WebClientFactory\,org.apache.kafka.common.security.authenticator.SaslClientAuthenticator\,org.apache.avro.file.DataFileWriter\,io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils\,com.github.luben.zstd
     resources:
       includes: templates/callback.html,templates/callback_failure.html,static/templates.zip,feature-flag-defaults.json
   smallrye-health:


### PR DESCRIPTION
## Summary of Changes

This change fixes the build of native executables so that users can consume records that were compressed with the `zstd` algorithm.

Fixes #302

## Any additional details or context that should be provided?

This change increases the size of the native executable by approx. 10 MB because we have to integrate more dependencies and a native library. @shouples We should talk about it tomorrow.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

