### PR TITLE
Use application-wide web client in HTTP proxy

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/ProxyHttpClient.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/ProxyHttpClient.java
@@ -20,11 +20,10 @@ public class ProxyHttpClient<T extends ProxyContext> {
   }
 
   public Future<T> send(T context) {
-    var options = Objects.requireNonNullElseGet(
-        context.getWebClientOptions(),
-        webClientFactory::getDefaultWebClientOptions
-    );
-    return WebClient.create(vertx, options)
+    var webClient = context.getWebClientOptions() != null
+        ? WebClient.create(vertx, context.getWebClientOptions())
+        : webClientFactory.getWebClient();
+    return webClient
         .requestAbs(context.getProxyRequestMethod(), context.getProxyRequestAbsoluteUrl())
         .putHeaders(context.getProxyRequestHeaders())
         .sendBuffer(context.getProxyRequestBody())


### PR DESCRIPTION
## Summary of Changes

Use the application-wide `WebClient` from the `WebClientFactory` in the HTTP proxy if possible, so that it picks up the custom certificates passed to the Preferences API. This change is expected to fix [a bug reported to the confluentinc/vscode repository](https://github.com/confluentinc/vscode/issues/921), where a user couldn't access their Confluent Cloud resources because their custom SSL certs did not take any effect.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

