### PR TITLE
fix: Provide reflection config for JSON Patch

### DIFF
--- a/src/main/resources/META-INF/native-image/com.github.fge.jsonpatch/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.github.fge.jsonpatch/reflect-config.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name":"com.github.fge.jsonpatch.JsonPatchMessages",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"com.github.fge.jsonpatch.mergepatch.JsonMergePatch"
+  },
+  {
+    "name":"com.github.fge.jsonpatch.mergepatch.JsonMergePatchDeserializer",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  }
+]


### PR DESCRIPTION
This change adds a reflection config for the [JSON Patch](https://github.com/java-json-tools/json-patch) library so that the Connection PATCH endpoint can be used in native mode.

Fixes #308

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

