### PR TITLE
Add comments on why we proxy requests against CCloud SR clusters

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
@@ -64,7 +64,14 @@ public class SchemaRegistryClients extends Clients<SchemaRegistryClient> {
           var headers = connection.getSchemaRegistryAuthenticationHeaders(clusterId);
 
           // For CCloud connections, we must point the SchemaRegistryClient to the sidecar-exposed
-          // proxy endpoints so that we get access to user-provided HTTP configs, like SSL certs
+          // SR proxy endpoints instead of directly interacting with the CCloud SR endpoints for two
+          // main reasons:
+          //
+          // (1) the sidecar-exposed SR proxy gives us access to user-provided HTTP configs, like
+          //     custom SSL certs
+          // (2) the sidecar-exposed SR proxy supports authentication with long-lived access tokens,
+          //     so we won't run into issues caused by the cached SchemaRegistryClient holding
+          //     expired CCloud data plane tokens
           if (connection.getType().equals(ConnectionType.CCLOUD)) {
             schemaRegistryUri = sidecarHost;
             headers.addAll(

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/ClusterProxyRequestProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/ClusterProxyRequestProcessor.java
@@ -52,9 +52,10 @@ public class ClusterProxyRequestProcessor extends
       case KAFKA -> proxyHttpClient.send(context);
       case SCHEMA_REGISTRY ->
           switch (context.getConnectionState().getType()) {
-            // For CCloud connections, use Proxy HTTP client
+            // For CCloud connections, use the ProxyHttpClient so that we get access to
+            // user-provided HTTP settings, like custom SSL certs
             case CCLOUD -> proxyHttpClient.send(context);
-            // For all other connections, use SR client
+            // For all other connections, use the REST service of the cached SR client
             case DIRECT, LOCAL, PLATFORM -> processSchemaRegistry(context);
           };
     };


### PR DESCRIPTION
Add some comments on why we use the sidecar-exposed proxy endpoints when talking to Confluent Cloud Schema Registry clusters instead of directly interacting with the Confluent Cloud API.

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

