### PR TITLE
Use SchemaRegistryConfig for local connections

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionSpec.java
@@ -95,6 +95,17 @@ public record ConnectionSpec(
         .build();
   }
 
+  public static ConnectionSpec createLocalWithSRConfig(
+      String id, String name, SchemaRegistryConfig schemaRegistryConfig
+  ) {
+    return ConnectionSpecBuilder.builder()
+        .id(id)
+        .name(name)
+        .type(LOCAL)
+        .schemaRegistryConfig(schemaRegistryConfig)
+        .build();
+  }
+
   public static ConnectionSpec createDirect(
       String id,
       String name,

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
@@ -153,12 +153,17 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
   }
 
   public String resolveSchemaRegistryUri(String connectionId) {
-    var localConfig = connections.getConnectionSpec(connectionId).localConfig();
-    if (localConfig == null || localConfig.schemaRegistryUri() == null) {
-      // Use the default SR URI when missing LocalConfig or missing SR URI in that config
-      return CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
+    var localSpec = connections.getConnectionSpec(connectionId);
+
+    String uri;
+    if (localSpec.schemaRegistryConfig() != null) {
+      uri = localSpec.schemaRegistryConfig().uri();
+    } else if (localSpec.localConfig() != null) {
+      uri = localSpec.localConfig().schemaRegistryUri();
+    } else {
+      // Use the default SR URI when missing LocalConfig or SchemaRegistryConfig
+      uri = CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
     }
-    var uri = localConfig.schemaRegistryUri();
     if (uri.isBlank()) {
       // Blank URL means no SR
       return null;

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
@@ -76,13 +76,6 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
           String.class
       );
 
-  static final String CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI = ConfigProvider
-      .getConfig()
-      .getValue(
-          "ide-sidecar.connections.confluent-local.default.schema-registry-uri",
-          String.class
-      );
-
   /**
    * The pattern to find {@code localhost:&lt;port>} where {@code &lt;port>} is 2 to 7 digits only.
    */
@@ -160,17 +153,13 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
       uri = localSpec.schemaRegistryConfig().uri();
     } else if (localSpec.localConfig() != null) {
       uri = localSpec.localConfig().schemaRegistryUri();
+
+      // If the URI is blank, treat it as null
+      if (uri != null && uri.isBlank()) {
+        uri = null;
+      }
     }
 
-    if (uri == null) {
-      // Use the default SR URI when missing LocalConfig or SchemaRegistryConfig
-      return CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
-    }
-
-    if (uri.isBlank()) {
-      // Blank URL means no SR
-      return null;
-    }
     return uri;
   }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcher.java
@@ -155,15 +155,18 @@ public class RealLocalFetcher extends ConfluentLocalRestClient implements LocalF
   public String resolveSchemaRegistryUri(String connectionId) {
     var localSpec = connections.getConnectionSpec(connectionId);
 
-    String uri;
+    String uri = null;
     if (localSpec.schemaRegistryConfig() != null) {
       uri = localSpec.schemaRegistryConfig().uri();
     } else if (localSpec.localConfig() != null) {
       uri = localSpec.localConfig().schemaRegistryUri();
-    } else {
-      // Use the default SR URI when missing LocalConfig or SchemaRegistryConfig
-      uri = CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
     }
+
+    if (uri == null) {
+      // Use the default SR URI when missing LocalConfig or SchemaRegistryConfig
+      return CONFLUENT_LOCAL_DEFAULT_SCHEMA_REGISTRY_URI;
+    }
+
     if (uri.isBlank()) {
       // Blank URL means no SR
       return null;

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/LocalIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/LocalIT.java
@@ -94,11 +94,11 @@ public class LocalIT {
       @Override
       public void setupConnection() {
         setupConnection(this, Optional.of(
-            ConnectionSpec.createLocal(
+            ConnectionSpec.createLocalWithSRConfig(
                 "local-connection-without-sr",
                 "Local connection without Schema Registry",
                 // Disable Schema Registry
-                new ConnectionSpec.LocalConfig("")
+                null
             )
         ));
       }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.idesidecar.restapi.integration.ITSuite;
@@ -39,9 +40,9 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.id", equalTo(spec.id()))
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
-        .body("spec.local_config", notNullValue())
+        .body("spec.local_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
-        .body("spec.schema_registry", nullValue())
+        .body("spec.schema_registry", notNullValue())
         .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster", nullValue())
         .body("status.schema_registry", nullValue())
@@ -67,9 +68,9 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.id", nullValue())
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
-        .body("spec.local_config", notNullValue())
+        .body("spec.local_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
-        .body("spec.schema_registry", nullValue())
+        .body("spec.schema_registry", notNullValue())
         .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster", nullValue())
         .body("status.schema_registry", nullValue())
@@ -90,8 +91,9 @@ public interface LocalConnectionSuite extends ITSuite {
     assertEquals(connection.id(), connection.spec().id());
     assertNotNull(connection.spec());
     assertEquals(spec.name(), connection.spec().name());
-    assertNotNull(connection.spec().localConfig());
-    assertEquals(spec.localConfig().schemaRegistryUri(), connection.spec().localConfig().schemaRegistryUri());
+    assertNull(connection.spec().localConfig());
+    assertNotNull(connection.spec().schemaRegistryConfig());
+    assertEquals(spec.schemaRegistryConfig(), connection.spec().schemaRegistryConfig());
     assertNotNull(connection.status());
     assertNotNull(connection.status().authentication());
     assertEquals(Status.NO_TOKEN, connection.status().authentication().status());
@@ -110,11 +112,10 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.id", equalTo(connection.id()))
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
-        .body("spec.local_config", notNullValue())
-        .body("spec.local_config.schema-registry-uri", equalTo(spec.localConfig().schemaRegistryUri()))
+        .body("spec.local_config", nullValue())
         .body("spec.ccloud_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
-        .body("spec.schema_registry", nullValue())
+        .body("spec.schema_registry", notNullValue())
         .body(
             "status.authentication.status",
             equalTo(Status.NO_TOKEN.name())
@@ -131,7 +132,7 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("data.localConnections[0].schemaRegistry.uri", notNullValue());
 
     // Update the connection to remove the schema registry
-    var specNoSr = spec.withLocalConfig("");
+    var specNoSr = spec.withSchemaRegistryConfig(null);
 
     given()
         .when()
@@ -145,8 +146,7 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.id", equalTo(connection.id()))
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.LOCAL.name()))
-        .body("spec.local_config", notNullValue())
-        .body("spec.local_config.schema-registry-uri", equalTo(""))
+        .body("spec.local_config", nullValue())
         .body("spec.ccloud_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
         .body("spec.schema_registry", nullValue())

--- a/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/models/graph/RealLocalFetcherTest.java
@@ -216,15 +216,6 @@ class RealLocalFetcherTest {
   }
 
   @Test
-  void shouldReturnDefaultSchemaRegistryUriWhenLocalConfigIsNull() throws CreateConnectionException {
-    var connectionSpec = ConnectionSpec.createLocal("2", "Local Connection", null);
-    manager.createConnectionState(connectionSpec);
-
-    String uri = localFetcher.resolveSchemaRegistryUri("2");
-    assertEquals("http://localhost:8081", uri);
-  }
-
-  @Test
   void shouldReturnNullWhenSchemaRegistryUriIsBlank() throws CreateConnectionException {
     var localConfig = new ConnectionSpec.LocalConfig("");
     var connectionSpec = ConnectionSpec.createLocal("3", "Local Connection", localConfig);
@@ -232,14 +223,5 @@ class RealLocalFetcherTest {
 
     String uri = localFetcher.resolveSchemaRegistryUri("3");
     assertNull(uri); // No Schema Registry
-  }
-
-  @Test
-  void shouldReturnDefaultSchemaRegistryUriWhenSchemaRegistryUriIsNull() throws CreateConnectionException {
-    var localConfig = new ConnectionSpec.LocalConfig(null);
-    var connectionSpec = ConnectionSpec.createLocal("4", "Local Connection", localConfig);
-    manager.createConnectionState(connectionSpec);
-    String uri = localFetcher.resolveSchemaRegistryUri("4");
-    assertEquals("http://localhost:8081", uri);
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/LocalTestEnvironment.java
@@ -76,11 +76,15 @@ public class LocalTestEnvironment implements TestEnvironment {
 
   public Optional<ConnectionSpec> localConnectionSpec() {
     return Optional.of(
-        ConnectionSpec.createLocal(
+        ConnectionSpec.createLocalWithSRConfig(
             "local-connection",
             "Local",
-            new ConnectionSpec.LocalConfig(
-                schemaRegistry.endpoint()
+            new ConnectionSpec.SchemaRegistryConfig(
+                "local-schema-registry",
+                schemaRegistry.endpoint(),
+                null,
+                // Disable TLS
+                TLSConfigBuilder.builder().enabled(false).build()
             )
         )
     );

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -402,6 +402,7 @@ public class SidecarClient implements SidecarClientApi {
         var kafkaClusterIsNullOrConnected = spec.kafkaClusterConfig() == null
             || connection.status().kafkaCluster().isConnected();
         var schemaRegistryIsNullOrConnected = spec.schemaRegistryConfig() == null
+            || connection.status().schemaRegistry() == null
             || connection.status().schemaRegistry().isConnected();
         return kafkaClusterIsNullOrConnected && schemaRegistryIsNullOrConnected;
       });

--- a/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/SidecarClient.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.confluent.idesidecar.restapi.credentials.Password;
 import io.confluent.idesidecar.restapi.credentials.Redactable;
+import io.confluent.idesidecar.restapi.credentials.TLSConfigBuilder;
 import io.confluent.idesidecar.restapi.kafkarest.model.CreateTopicRequestData;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequest;
 import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRequestData;
@@ -321,15 +322,21 @@ public class SidecarClient implements SidecarClientApi {
 
   public Connection createLocalConnection(String schemaRegistryUri) {
     var connectionId = generateConnectionId();
-    LocalConfig localConfig = null;
+    ConnectionSpec.SchemaRegistryConfig schemaRegistryConfig = null;
     if (schemaRegistryUri != null) {
-      localConfig = new LocalConfig(schemaRegistryUri);
+      schemaRegistryConfig = new ConnectionSpec.SchemaRegistryConfig(
+          "schema-registry-%s".formatted(connectionId),
+          schemaRegistryUri,
+          null,
+          // Disable TLS
+          TLSConfigBuilder.builder().enabled(false).build()
+      );
     }
     return createConnection(
-        ConnectionSpec.createLocal(
+        ConnectionSpec.createLocalWithSRConfig(
             connectionId,
             connectionId,
-            localConfig
+            schemaRegistryConfig
         )
     );
   }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Instructs RealLocalFetcher to look up SR URI in the `schema_registry.uri` config, and if not present, fallback to `local_config.schema-registry-uri`
- Behavior change: We no longer default to the SR URI of `localhost:8081` if `local_config` (or `local_config.schema-registry-uri`) is null.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

