### PR TITLE
MINOR: use sidecar version as OpenAPI spec version

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -9,7 +9,7 @@
       "url" : "https://confluent.io/contact",
       "email" : "vscode@confluent.io"
     },
-    "version" : "1.0.1"
+    "version" : "0.161.0"
   },
   "servers" : [ {
     "url" : "http://127.0.0.1:26636",

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -8,7 +8,7 @@ info:
     name: Confluent for VS Code Support
     url: https://confluent.io/contact
     email: vscode@confluent.io
-  version: 1.0.1
+  version: 0.161.0
 servers:
 - url: http://127.0.0.1:26636
   description: Auto generated value

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -258,7 +258,7 @@ quarkus:
     path: /openapi
     info-title: Confluent ide-sidecar API
     store-schema-directory: src/generated/resources/
-    info-version: 1.0.1
+    info-version: ${quarkus.application.version}
     info-description: API for the Confluent ide-sidecar, part of Confluent for VS Code
     info-terms-of-service: Your terms here
     info-contact-email: vscode@confluent.io


### PR DESCRIPTION
Removes the hard-coded OpenAPI spec `1.0.1` in favor of the quarkus app version, so anytime the sidecar version changes, it should also be reflected in the OpenAPI spec.

(This should also help on the VS Code extension side to avoid bumping the version without the associated spec version.)