### PR TITLE
change upper limit to 1024

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ScramCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ScramCredentials.java
@@ -42,7 +42,7 @@ public record ScramCredentials(
 
   private static final int SCRAM_USERNAME_MAX_LEN = 64;
 
-  private static final int SCRAM_PASSWORD_MAX_LEN= 64;
+  private static final int SCRAM_PASSWORD_MAX_LEN= 1024;
 
   public enum HashAlgorithm {
     SCRAM_SHA_256("SCRAM-SHA-256"),


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

1 line change to update the upper limit of SCRAM auth passwords as they can be very long. 

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


WarpStream requests were failing due to this limit. 

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

