### PR TITLE
Fix password max lengths and set it to 1024

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -754,7 +754,7 @@
           },
           "api_secret" : {
             "description" : "The API secret to use when connecting to the external service.",
-            "maxLength" : 64,
+            "maxLength" : 1024,
             "minLength" : 1,
             "type" : "string",
             "allOf" : [ {
@@ -765,7 +765,7 @@
       },
       "ApiSecret" : {
         "description" : "A user-provided API secret that is always masked in responses",
-        "maxLength" : 64,
+        "maxLength" : 1024,
         "minLength" : 1,
         "type" : "string"
       },
@@ -826,7 +826,7 @@
           },
           "password" : {
             "description" : "The password to use when connecting to the external service.",
-            "maxLength" : 64,
+            "maxLength" : 1024,
             "minLength" : 1,
             "type" : "string",
             "allOf" : [ {
@@ -1430,7 +1430,7 @@
       },
       "Password" : {
         "description" : "A user-provided password that is always masked in responses",
-        "maxLength" : 64,
+        "maxLength" : 1024,
         "minLength" : 1,
         "type" : "string"
       },
@@ -1716,7 +1716,10 @@
             "description" : "The password to use when connecting to the external service.",
             "maxLength" : 1024,
             "minLength" : 1,
-            "type" : "object"
+            "type" : "string",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
           }
         }
       },

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -508,14 +508,14 @@ components:
           type: string
         api_secret:
           description: The API secret to use when connecting to the external service.
-          maxLength: 64
+          maxLength: 1024
           minLength: 1
           type: string
           allOf:
           - $ref: "#/components/schemas/ApiSecret"
     ApiSecret:
       description: A user-provided API secret that is always masked in responses
-      maxLength: 64
+      maxLength: 1024
       minLength: 1
       type: string
     AuthError:
@@ -562,7 +562,7 @@ components:
           type: string
         password:
           description: The password to use when connecting to the external service.
-          maxLength: 64
+          maxLength: 1024
           minLength: 1
           type: string
           allOf:
@@ -1047,7 +1047,7 @@ components:
           type: integer
     Password:
       description: A user-provided password that is always masked in responses
-      maxLength: 64
+      maxLength: 1024
       minLength: 1
       type: string
     Preferences:
@@ -1264,7 +1264,9 @@ components:
           description: The password to use when connecting to the external service.
           maxLength: 1024
           minLength: 1
-          type: object
+          type: string
+          allOf:
+          - $ref: "#/components/schemas/Password"
     SidecarAccessToken:
       type: object
       properties:

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiSecret.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiSecret.java
@@ -22,7 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @RegisterForReflection
 public class ApiSecret extends Redactable {
 
-  public static final int MAX_LENGTH = 64;
+  public static final int MAX_LENGTH = 1024;
 
   public ApiSecret(char[] raw) {
     super(raw);
@@ -45,7 +45,7 @@ public class ApiSecret extends Redactable {
       String path,
       String what
   ) {
-    if (longerThan(Password.MAX_LENGTH)) {
+    if (longerThan(ApiSecret.MAX_LENGTH)) {
       errors.add(
           Error.create()
                .withDetail("%s API secret may not be longer than %d characters", what, MAX_LENGTH)

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/Password.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/Password.java
@@ -16,13 +16,13 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(
     description = "A user-provided password that is always masked in responses",
     type = SchemaType.STRING,
-    maxLength = ApiSecret.MAX_LENGTH,
+    maxLength = Password.MAX_LENGTH,
     minLength = 1
 )
 @RegisterForReflection
 public class Password extends Redactable {
 
-  public static final int MAX_LENGTH = 64;
+  public static final int MAX_LENGTH = 1024;
 
   public Password(char[] raw) {
     super(raw);

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ScramCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ScramCredentials.java
@@ -42,7 +42,7 @@ public record ScramCredentials(
 
   private static final int SCRAM_USERNAME_MAX_LEN = 64;
 
-  private static final int SCRAM_PASSWORD_MAX_LEN= 1024;
+  private static final int SCRAM_PASSWORD_MAX_LEN = 1024;
 
   public enum HashAlgorithm {
     SCRAM_SHA_256("SCRAM-SHA-256"),


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix references to `MAX_LENGTH` in the `Password` and `ApiSecret` classes (they were jumbled previously).
- Set `MAX_LENGTH` in `ApiSecret` and `Password` to 1024

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

