### PR TITLE
Reset CCloud connections after end of absolute lifetime

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionState.java
@@ -113,6 +113,13 @@ public class CCloudConnectionState extends ConnectionState {
               )
               .build()
       );
+    } else if (oauthContext.hasReachedEndOfLifetime()) {
+      return Future.succeededFuture(
+          ConnectionStatusBuilder
+              .builder()
+              .ccloud(INITIAL_STATUS.ccloud())
+              .build()
+      );
     } else {
       return oauthContext
           .checkAuthenticationStatus()

--- a/src/test/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContextTest.java
@@ -354,6 +354,35 @@ class CCloudOAuthContextTest {
   }
 
   @Test
+  void hasReachedEndOfLifetimeShouldReturnTrueIfEndOfLifetimeIsReached() {
+    var authContext = Mockito.spy(CCloudOAuthContext.class);
+    var endOfLifetime = Instant.now().minusSeconds(1);
+
+    Mockito.when(authContext.getEndOfLifetime()).thenReturn(endOfLifetime);
+
+    assertTrue(authContext.hasReachedEndOfLifetime());
+  }
+
+  @Test
+  void hasReachedEndOfLifetimeShouldReturnFalseIfEndOfLifetimeIsNotReached() {
+    var authContext = Mockito.spy(CCloudOAuthContext.class);
+    var endOfLifetime = Instant.now().plusSeconds(60);
+
+    Mockito.when(authContext.getEndOfLifetime()).thenReturn(endOfLifetime);
+
+    assertFalse(authContext.hasReachedEndOfLifetime());
+  }
+
+  @Test
+  void hasReachedEndOfLifetimeShouldReturnFalseIfEndOfLifetimeIsNull() {
+    var authContext = Mockito.spy(CCloudOAuthContext.class);
+
+    Mockito.when(authContext.getEndOfLifetime()).thenReturn(null);
+
+    assertFalse(authContext.hasReachedEndOfLifetime());
+  }
+
+  @Test
   // TODO: Figure out why this consistently fails on Windows
   @DisabledIfSystemProperty(named = "os.name", matches = ".*Windows.*")
   void shouldAttemptTokenRefreshShouldReturnTrueForConnectionsEligibleForATokenRefreshAttempt() {


### PR DESCRIPTION
## Summary of Changes

This change makes sure we reset the state of CCloud connections to the initial state, `NONE`/`NO_TOKEN`, once they've hit the end of the absolute lifetime of their refresh tokens, which equals eight hours at the moment.

Fixes #339

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

