### PR TITLE
Return meaningful error message when consuming records compressed with snappy failed

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategy.java
@@ -1,5 +1,6 @@
 package io.confluent.idesidecar.restapi.messageviewer.strategy;
 
+import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
 import io.confluent.idesidecar.restapi.messageviewer.KafkaConsumerFactory;
 import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
@@ -7,11 +8,15 @@ import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
 import io.confluent.idesidecar.restapi.messageviewer.RecordDeserializer;
 import io.confluent.idesidecar.restapi.messageviewer.SimpleConsumer;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
+import io.quarkus.logging.Log;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response.Status;
 import java.util.Optional;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.KafkaException;
 
 /**
  * Handles consuming from a Kafka topic for the message viewer API, using the
@@ -30,6 +35,11 @@ public class NativeConsumeStrategy implements ConsumeStrategy {
 
   @Inject
   SchemaRegistryClients schemaRegistryClients;
+
+  static final Pattern SNAPPY_CONSUME_FAILURE_PATTERN = Pattern.compile(
+      "Received exception when fetching the next record from snappy-\\d+\\. "
+      + "If needed, please seek past the record to continue consumption\\."
+  );
 
   @Override
   public Future<KafkaRestProxyContext
@@ -67,6 +77,22 @@ public class NativeConsumeStrategy implements ConsumeStrategy {
       context.setResponse(new SimpleConsumeMultiPartitionResponse(
           context.getClusterId(), topic, consumedData)
       );
+    } catch (KafkaException e) {
+      // Return an error if we tried consuming a record that was compressed with snappy
+      // Otherwise, re-throw the KafkaException
+      if (SNAPPY_CONSUME_FAILURE_PATTERN.matcher(e.getMessage()).matches()) {
+        Log.errorf("Failed to consume records from topic %s due to snappy compression.", topic);
+        throw new ProcessorFailedException(
+            context.failf(
+                Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                "At the moment, we don't support consuming records that were compressed with snappy. "
+                + "Please visit https://github.com/confluentinc/ide-sidecar/issues/304 to learn "
+                + "more."
+            )
+        );
+      } else {
+        throw new KafkaException(e.getMessage(), e.getCause());
+      }
     }
     return context;
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
@@ -79,7 +79,8 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
       ConnectionSpec spec,
       KafkaCluster kafkaCluster,
       SchemaRegistry srCluster,
-      SimpleConsumer consumer
+      SimpleConsumer consumer,
+      Map<String, Object> kafkaClientConfig
   ) {
     void useBy(SidecarClient client) {
       client.useConnection(spec.id());
@@ -114,6 +115,18 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
   @Override
   public SimpleConsumer simpleConsumer() {
     return current.consumer();
+  }
+
+
+  /**
+   * Get the Kafka client configuration for the current connection. The configuration can be used
+   * to instantiate a new Kafka consumer or producer client.
+   *
+   * @return the Kafka client configuration properties
+   */
+  @Override
+  public Map<String, Object> kafkaClientConfig() {
+    return current.kafkaClientConfig();
   }
 
   /**
@@ -364,7 +377,20 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
       var simpleConsumer = createSimpleConsumer(connection);
 
       Log.debugf("End: Setting up %s connection", connectionSpec.type());
-      return new ScopedConnection(spec, kafkaCluster, srCluster, simpleConsumer);
+      return new ScopedConnection(
+          spec,
+          kafkaCluster,
+          srCluster,
+          simpleConsumer,
+          ClientConfigurator.getKafkaClientConfig(
+              connection,
+              kafkaCluster.bootstrapServers(),
+              srCluster != null ? srCluster.uri() : null,
+              false,
+              null,
+              Map.of()
+          )
+      );
     });
     current.useBy(this);
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/ITSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/ITSuite.java
@@ -2,9 +2,9 @@ package io.confluent.idesidecar.restapi.integration;
 
 import io.confluent.idesidecar.restapi.messageviewer.SimpleConsumer;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
-import io.confluent.idesidecar.restapi.util.SidecarClient;
 import io.confluent.idesidecar.restapi.util.SidecarClientApi;
 import io.confluent.idesidecar.restapi.util.TestEnvironment;
+import java.util.Map;
 
 /**
  * An interface that defines the test methods for a suite of functional tests to be run against
@@ -53,6 +53,8 @@ public interface ITSuite extends SidecarClientApi {
    * @return the consumer, never null
    */
   SimpleConsumer simpleConsumer();
+
+  Map<String, Object> kafkaClientConfig();
 
   /**
    * Hook that allows the integration test to set up the

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
@@ -1,8 +1,15 @@
 package io.confluent.idesidecar.restapi.messageviewer;
 
 import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.loadResource;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.KafkaProducerClients;
+import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
+import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
 import io.confluent.idesidecar.restapi.integration.ITSuite;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequestBuilder;
@@ -15,7 +22,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public interface SimpleConsumerSuite extends ITSuite {
 
@@ -193,6 +210,81 @@ public interface SimpleConsumerSuite extends ITSuite {
 
       assertEquals(records[i][0], key, "Key should match");
       assertEquals(records[i][1], value, "Value should match");
+    }
+  }
+
+  @Test
+  // TODO: Remove test once we support Snappy compression (see https://github.com/confluentinc/ide-sidecar/issues/304)
+  default void testProduceAndConsumeWithSnappyCompression() {
+    // When we create a topic
+    String topic = randomTopicName();
+    createTopic(topic);
+
+    var config = kafkaClientConfig();
+    // And configure Snappy compression
+    config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+    config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    try(var producer = new KafkaProducer<String, String>(config)) {
+      // And write records to Kafka
+      var records = new String[][]{
+          {"key1", "value1"},
+          {"key2", "value2"},
+          {"key3", "value3"}
+      };
+      for (var record : records) {
+        producer.send(new ProducerRecord<>(topic, record[0], record[1]));
+      }
+
+      // Then the consumption of records should NOT throw a KafkaException. It could successfully
+      // return records or throw a ProcessorFailedException, which holds a meaningful error message.
+      try {
+        simpleConsumer().consume(topic, consumeRequestSinglePartitionFromOffsetZero());
+      } catch (KafkaException e) {
+        fail("Should not have thrown a KafkaException.");
+      }
+    }
+  }
+
+  @ParameterizedTest
+  // TODO: Add "snappy" once we support it (see https://github.com/confluentinc/ide-sidecar/issues/304)
+  @ValueSource(strings = {"gzip", "lz4", "zstd"})
+  default void testProduceAndConsumeWithCompression(String compressionType) {
+    // When we create a topic
+    String topic = randomTopicName();
+    createTopic(topic);
+
+    var config = kafkaClientConfig();
+    // And configure compression
+    config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
+    config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    try(var producer = new KafkaProducer<String, String>(config)) {
+      // And write records to Kafka
+      var records = new String[][]{
+          {"key1", "value1"},
+          {"key2", "value2"},
+          {"key3", "value3"}
+      };
+      for (var record : records) {
+        producer.send(new ProducerRecord<>(topic, record[0], record[1]));
+      }
+
+      // Then we can consume the same records
+      var response = simpleConsumer().consume(topic, consumeRequestSinglePartitionFromOffsetZero());
+
+      assertEquals(1, response.size(), "Should have data for 1 partition");
+      PartitionConsumeData partitionData = response.getFirst();
+      assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+      for (int i = 0; i < 3; i++) {
+        PartitionConsumeRecord record = partitionData.records().get(i);
+        String key = record.key().asText();
+        String value = record.value().asText();
+
+        assertEquals(records[i][0], key, "Key should match");
+        assertEquals(records[i][1], value, "Value should match");
+      }
     }
   }
 

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategyTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/strategy/NativeConsumeStrategyTest.java
@@ -1,0 +1,49 @@
+package io.confluent.idesidecar.restapi.messageviewer.strategy;
+
+import static org.junit.Assert.assertThrows;
+
+import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
+import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
+import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.apache.kafka.common.KafkaException;
+
+@QuarkusTest
+public class NativeConsumeStrategyTest {
+  @Inject
+  NativeConsumeStrategy nativeConsumeStrategy;
+
+  @Test
+  void handleKafkaExceptionReturnsMeaningfulMessageForErrorsRelatedToSnappy() {
+    var context = new KafkaRestProxyContext<SimpleConsumeMultiPartitionRequest, SimpleConsumeMultiPartitionResponse>(
+        "connectionId", "clusterId", "topicName", null);
+    assertThrows(
+        ProcessorFailedException.class,
+        () -> nativeConsumeStrategy.handleKafkaException(
+            new KafkaException(
+                "Received exception when fetching the next record from snappy-1. If needed, please"
+                    + " seek past the record to continue consumption."
+            ),
+            context
+        )
+    );
+  }
+
+  @Test
+  void handleKafkaExceptionRethrowsExceptionForErrorsNotRelatedToSnappy() {
+    var context = new KafkaRestProxyContext<SimpleConsumeMultiPartitionRequest, SimpleConsumeMultiPartitionResponse>(
+        "connectionId", "clusterId", "topicName", null);
+    assertThrows(
+        KafkaException.class,
+        () -> nativeConsumeStrategy.handleKafkaException(
+            new KafkaException(
+                "Hey, I'm not Snappy!."
+            ),
+            context
+        )
+    );
+  }
+}


### PR DESCRIPTION
## Summary of Changes

At the moment, the sidecar is not able to consume records that were compressed with snappy when running in native mode. When attempting to do so, the REST API will return a response similar to the following one:

```
{
  "details": "Error id 88fab26a-4535-4a66-bf06-b037dac1fb5f-1",
  "stack": ""
}
```

Per the application logs, the sidecar throws a `KafkaException` with the message `Received exception when fetching the next record from snappy-0. If needed, please seek past the record to continue consumption.` or similar.

Unfortunately, this is not very helpful to extension users. Since fixing the underlying bug, captured in https://github.com/confluentinc/ide-sidecar/issues/304, will take longer than expected and has been moved out of the GA scope, this change makes sure we return a more meaningful error message to users in the meantime, hopefully helping them to figure out why the extension's Message Viewer can't show records. The new response looks similar to the following one:

```
{
  "status": "500",
  "code": "proxy_error",
  "title": "At the moment, we don't support consuming records that were compressed with snappy. Please visit https://github.com/confluentinc/ide-sidecar/issues/304 to learn more.",
  "id": "d27faa2c-5e1c-4ef1-8562-7c3192ac8bc7",
  "errors": [
    {
      "code": "proxy_error",
      "title": "At the moment, we don't support consuming records that were compressed with snappy. Please visit https://github.com/confluentinc/ide-sidecar/issues/304 to learn more.",
      "detail": "At the moment, we don't support consuming records that were compressed with snappy. Please visit https://github.com/confluentinc/ide-sidecar/issues/304 to learn more."
    }
  ]
}
```

Fixes #341

## Any additional details or context that should be provided?

I'll work on https://github.com/confluentinc/ide-sidecar/issues/303 as a follow up and see if we can add a integration test which verifies the meaningful error message is returned when consuming records compressed with snappy. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

