### PR TITLE
Add integration tests to verify we can consume compressed records

### DIFF
--- a/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/AbstractIT.java
@@ -79,7 +79,8 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
       ConnectionSpec spec,
       KafkaCluster kafkaCluster,
       SchemaRegistry srCluster,
-      SimpleConsumer consumer
+      SimpleConsumer consumer,
+      Map<String, Object> kafkaClientConfig
   ) {
     void useBy(SidecarClient client) {
       client.useConnection(spec.id());
@@ -114,6 +115,18 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
   @Override
   public SimpleConsumer simpleConsumer() {
     return current.consumer();
+  }
+
+
+  /**
+   * Get the Kafka client configuration for the current connection. The configuration can be used
+   * to instantiate a new Kafka consumer or producer client.
+   *
+   * @return the Kafka client configuration properties
+   */
+  @Override
+  public Map<String, Object> kafkaClientConfig() {
+    return current.kafkaClientConfig();
   }
 
   /**
@@ -364,7 +377,20 @@ public abstract class AbstractIT extends SidecarClient implements ITSuite {
       var simpleConsumer = createSimpleConsumer(connection);
 
       Log.debugf("End: Setting up %s connection", connectionSpec.type());
-      return new ScopedConnection(spec, kafkaCluster, srCluster, simpleConsumer);
+      return new ScopedConnection(
+          spec,
+          kafkaCluster,
+          srCluster,
+          simpleConsumer,
+          ClientConfigurator.getKafkaClientConfig(
+              connection,
+              kafkaCluster.bootstrapServers(),
+              srCluster != null ? srCluster.uri() : null,
+              false,
+              null,
+              Map.of()
+          )
+      );
     });
     current.useBy(this);
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/ITSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/ITSuite.java
@@ -2,9 +2,9 @@ package io.confluent.idesidecar.restapi.integration;
 
 import io.confluent.idesidecar.restapi.messageviewer.SimpleConsumer;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
-import io.confluent.idesidecar.restapi.util.SidecarClient;
 import io.confluent.idesidecar.restapi.util.SidecarClientApi;
 import io.confluent.idesidecar.restapi.util.TestEnvironment;
+import java.util.Map;
 
 /**
  * An interface that defines the test methods for a suite of functional tests to be run against
@@ -53,6 +53,8 @@ public interface ITSuite extends SidecarClientApi {
    * @return the consumer, never null
    */
   SimpleConsumer simpleConsumer();
+
+  Map<String, Object> kafkaClientConfig();
 
   /**
    * Hook that allows the integration test to set up the

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -217,6 +218,8 @@ public interface SimpleConsumerSuite extends ITSuite {
 
     var config = kafkaClientConfig();
     config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
+    config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     try(var producer = new KafkaProducer<String, String>(config)) {
       // And write records to Kafka
       var records = new String[][]{

--- a/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/messageviewer/SimpleConsumerSuite.java
@@ -3,6 +3,9 @@ package io.confluent.idesidecar.restapi.messageviewer;
 import static io.confluent.idesidecar.restapi.util.ResourceIOUtil.loadResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.KafkaProducerClients;
+import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
 import io.confluent.idesidecar.restapi.integration.ITSuite;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequestBuilder;
@@ -15,7 +18,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public interface SimpleConsumerSuite extends ITSuite {
 
@@ -193,6 +204,45 @@ public interface SimpleConsumerSuite extends ITSuite {
 
       assertEquals(records[i][0], key, "Key should match");
       assertEquals(records[i][1], value, "Value should match");
+    }
+  }
+
+  @ParameterizedTest
+  // TODO: Add "snappy" once we support it (see https://github.com/confluentinc/ide-sidecar/issues/304)
+  @ValueSource(strings = {"gzip", "lz4", "zstd"})
+  default void testProduceAndConsumeWithCompression(String compressionType) {
+    // When we create a topic
+    String topic = randomTopicName();
+    createTopic(topic);
+
+    var config = kafkaClientConfig();
+    config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
+    try(var producer = new KafkaProducer<String, String>(config)) {
+      // And write records to Kafka
+      var records = new String[][]{
+          {"key1", "value1"},
+          {"key2", "value2"},
+          {"key3", "value3"}
+      };
+      for (var record : records) {
+        producer.send(new ProducerRecord<>(topic, record[0], record[1]));
+      }
+
+      // Then we can consume the same records
+      var response = simpleConsumer().consume(topic, consumeRequestSinglePartitionFromOffsetZero());
+
+      assertEquals(1, response.size(), "Should have data for 1 partition");
+      PartitionConsumeData partitionData = response.getFirst();
+      assertEquals(3, partitionData.records().size(), "Should have 3 records");
+
+      for (int i = 0; i < 3; i++) {
+        PartitionConsumeRecord record = partitionData.records().get(i);
+        String key = record.key().asText();
+        String value = record.value().asText();
+
+        assertEquals(records[i][0], key, "Key should match");
+        assertEquals(records[i][1], value, "Value should match");
+      }
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

This change adds integration tests so that we can verify that we can consume records that were compressed with one of the supported compression algorithms.

One test also checks that we no longer throw the generic `KafkaException` when consuming records that were compressed with Snappy (fixed by https://github.com/confluentinc/ide-sidecar/pull/342).

Fixes #303

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

