### PR TITLE
232: turn off hibernator logs

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -237,6 +237,10 @@ quarkus:
         level: ERROR
       "io.confluent.kafka.serializers":
         level: ERROR
+      "io.qua.hib.val.deployment":
+        level: OFF
+      "io.qua.dep.ste.ReflectiveHierarchyStep":
+        level: OFF
   http:
     host: 127.0.0.1
     port: 26636


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

This PR sets the [ Hibernate Validator warnings](https://semaphore.ci.confluent.io/jobs/035e90b2-d1fe-46d8-9bd0-2f307748068e#L872-L879) to info level. 

Refer to issue https://github.com/confluentinc/ide-sidecar/issues/232 

## Any additional details or context that should be provided?

As an alternative, I considered removing the constraints on static methods and creating constructors instead. The splash radius on this was not insignificant. 9 classes would need refactoring, with potential impact to tests. 

For example, we would have needed to add a `verifySslCertificates` field to the `ConnectionSpecKafkaClusterConfigBuilder` class, instead of leaving it as part of the part of the KafkaClusterConfig constructor. This is because `verifySslCertificates` is mentioned in the warning:

```
Hibernate Validator does not support constraints on static methods yet. Constraints on io.confluent.idesidecar.restapi.models.ConnectionSpecKafkaClusterConfigBuilder#io.confluent.idesidecar.restapi.models.ConnectionSpec$KafkaClusterConfig KafkaClusterConfig(java.lang.@NotNull @Size(max = 256,min = 1) String bootstrapServers, io.confluent.idesidecar.restapi.credentials.@Null Credentials credentials, java.lang.@Null Boolean ssl, java.lang.@Null Boolean verifySslCertificates) are ignored.
```

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

