### PR TITLE
Use Ubuntu 20 for building sidecar on Linux

### DIFF
--- a/.semaphore/multi-arch-builds-and-upload.yml
+++ b/.semaphore/multi-arch-builds-and-upload.yml
@@ -57,7 +57,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-amd64-2
+          type: s1-prod-ubuntu20-04-amd64-2
       prologue:
         commands_file: build_native_executable_prologue_macos_linux.sh
       env_vars:
@@ -78,7 +78,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu24-04-arm64-2
+          type: s1-prod-ubuntu20-04-arm64-2
       prologue:
         commands_file: build_native_executable_prologue_macos_linux.sh
       env_vars:


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Sidecars built on Ubuntu 24 don't work on Ubuntu 20 because 
```
/home/jim/.vscode-server/extensions/confluentinc.vscode-confluent-0.26.1-linux-x64/ide-sidecar-0.170.0-runner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /home/jim/.vscode-server/extensions/confluentinc.vscode-confluent-0.26.1-linux-x64/ide-sidecar-0.170.0-runner)
```

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

