### PR TITLE
Revert "Broadcast unchanged updates and allow vscode to turn it off (…#358)"

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,8 +156,6 @@ ide-sidecar:
     # How often to check?
     interval-seconds: 60
   websockets:
-    # Should sidecar broadcast connection statuses even if they haven't changed?
-    broadcast-unchanged-updates: true
     # How long do we allow a connection to be established w/o it saying HELLO?
     initial-grace-seconds: 60
     # ... and how often do we check?

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/ConnectionStateTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/ConnectionStateTest.java
@@ -16,7 +16,6 @@ import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
 import io.vertx.core.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 public class ConnectionStateTest {
 
@@ -94,7 +93,6 @@ public class ConnectionStateTest {
   }
 
   @Test
-  @SetSystemProperty(key = "ide-sidecar.websockets.broadcast-unchanged-updates", value = "false")
   void shouldNotNotifyListenerWithNoChangeInStatus() {
     // When the refresh is computed, and the status does not change
     when(connection.doRefreshStatus()).thenReturn(
@@ -105,21 +103,6 @@ public class ConnectionStateTest {
     // Then the listener should never be notified
     verifyNoInteractions(listener);
   }
-
-  @Test
-  @SetSystemProperty(key = "ide-sidecar.websockets.broadcast-unchanged-updates", value = "true")
-  void shouldNotifyListenerWithNoChangeInStatusWithFlagSet() {
-    // When the refresh is computed, and the status does not change
-    when(connection.doRefreshStatus()).thenReturn(
-        succeededFuture(ATTEMPTING_STATUS) // same as initial status
-    );
-    callAndWaitFor(connection.refreshStatus());
-
-    // Then the listener should be notified once of the connection and nothing else
-    verify(listener, times(1)).disconnected(connection);
-    verifyNoMoreInteractions(listener);
-  }
-
 
   @Test
   void shouldUseNoOpListenerWithNoChangeInStatus() {


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Selectively revert #358 , keeping the existing main openapi documents.

Extension-side https://github.com/confluentinc/vscode/pull/1297 removes the original desire for the hack.

I experimented with only signalling the listner when the coarse updated connection status differs from what we had before, but that led to more timeouts vscode side (longer spinny), so leaving it be. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

