### PR TITLE
feat: Provide meaningful error message when provided pem path is empty

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
@@ -9,6 +9,7 @@ import io.confluent.idesidecar.restapi.resources.PreferencesResource;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 @JsonPropertyOrder({
@@ -67,18 +68,37 @@ public record Preferences(
       }
     }
 
+    /**
+     * Validates the TLS PEM paths provided in the preferences. Checks if the provided paths exist
+     * in the file system and are not empty.
+     *
+     * @return a list of errors if any of the TLS PEM paths are invalid
+     */
     List<Error> validateTlsPemPaths() {
       return this.tlsPemPaths.stream()
-          .filter(pemPath -> Files.notExists(Path.of(pemPath)))
-          .map(pemPath ->
-              new Error(
-                  "cert_not_found",
-                  "Cert file cannot be found",
-                  "The cert file %s cannot be found.".formatted(pemPath),
-                  "/spec/tls_pem_paths"
-
-              )
-          )
+          .flatMap(pemPath -> {
+            if (pemPath.isBlank()) {
+              return Stream.of(
+                  new Error(
+                      "cert_path_empty",
+                      "Cert file path is empty",
+                      "The cert file path cannot be empty.",
+                      "/spec/tls_pem_paths"
+                  )
+              );
+            } else if (Files.notExists(Path.of(pemPath))) {
+              return Stream.of(
+                  new Error(
+                      "cert_not_found",
+                      "Cert file cannot be found",
+                      "The cert file '%s' cannot be found.".formatted(pemPath),
+                      "/spec/tls_pem_paths"
+                  )
+              );
+            } else {
+              return Stream.empty();
+            }
+          })
           .toList();
     }
   }

--- a/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/Preferences.java
@@ -77,12 +77,12 @@ public record Preferences(
     List<Error> validateTlsPemPaths() {
       return this.tlsPemPaths.stream()
           .flatMap(pemPath -> {
-            if (pemPath.isBlank()) {
+            if (pemPath == null || pemPath.isBlank()) {
               return Stream.of(
                   new Error(
                       "cert_path_empty",
-                      "Cert file path is empty",
-                      "The cert file path cannot be empty.",
+                      "Cert file path is null or empty",
+                      "The cert file path cannot be null or empty.",
                       "/spec/tls_pem_paths"
                   )
               );

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
@@ -206,9 +206,42 @@ public class PreferencesResourceTest {
     assertNotNull(errors);
     var error = errors.get(0);
     assertEquals(
-        "The cert file cert-does-not-exist.pem cannot be found.",
+        "The cert file 'cert-does-not-exist.pem' cannot be found.",
         error.get("detail").textValue()
     );
+  }
+
+  @Test
+  @Order(6)
+  void updatePreferencesShouldReturnErrorIfProvidedTlsPemPathIsEmpty() {
+    var responseBody = given()
+        .when()
+        .body(
+            """
+                {
+                  "api_version": "gateway/v1",
+                  "kind": "Preferences",
+                  "spec": {
+                    "tls_pem_paths": [""]
+                  }
+                }
+                """
+        )
+        .header("Content-Type", "application/json")
+        .put()
+        .then()
+        .statusCode(400)
+        .extract()
+        .body()
+        .asString();
+    var responseJson = asJson(responseBody);
+
+    assertNotNull(responseJson);
+    var errors = responseJson.get("errors");
+    assertNotNull(errors);
+    var error = errors.get(0);
+    assertEquals("cert_path_empty", error.get("code").textValue());
+    assertEquals("The cert file path cannot be empty.", error.get("detail").textValue());
   }
 
   /**

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/PreferencesResourceTest.java
@@ -241,7 +241,7 @@ public class PreferencesResourceTest {
     assertNotNull(errors);
     var error = errors.get(0);
     assertEquals("cert_path_empty", error.get("code").textValue());
-    assertEquals("The cert file path cannot be empty.", error.get("detail").textValue());
+    assertEquals("The cert file path cannot be null or empty.", error.get("detail").textValue());
   }
 
   /**


### PR DESCRIPTION
## Summary of Changes

This change makes sure the Preferences API returns a meaningful error message when an empty pem path is provided.

Fixes #363

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

