### PR TITLE
Allow for > 64 character usernames and API keys as generated by WarpStream.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,6 +337,12 @@ Add the `format=json` query parameter to get the JSON formatted specification:
 
     curl -s http://localhost:26636/openapi?format=json
 
+Branches with codebase changes that affect the OpenAPI specification should include the updated documents in the PR.
+These can be captured through, and should result in git diffs for `src/generated/resources/openapi.{json,yaml}`:
+
+    make mvn-generate-sidecar-openapi-spec
+
+
 ##### Swagger UI
 
 The [Swagger UI](https://swagger.io/tools/swagger-ui/) helps visualize and interact with the APIs.

--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ You may find the following `make` commands useful during development:
 
 | Make command       | Description                                   |
 |--------------------|-----------------------------------------------|
-| `make quarkus-dev`  | Runs the application in the [Quarkus dev mode](https://quarkus.io/guides/getting-started#development-mode).                                                                                                                                                         |
-| `make quarkus-test` | Runs the [continuous testing mode of Quarkus](https://quarkus.io/guides/continuous-testing#continuous-testing-without-dev-mode).                                                                                                                                    |
+| `make quarkus-dev`  | Runs the application in the [Quarkus dev mode](https://quarkus.io/guides/getting-started#development-mode)  |
+| `make quarkus-test` | Runs the [continuous testing mode of Quarkus](https://quarkus.io/guides/continuous-testing#continuous-testing-without-dev-mode) |
 | `make build`       | Build, compile, package JARs, and run tests.  |
 | `make clean`       | Clean the project and remove temporary files. |
 | `make test`        | Run the unit tests of the project.            |
 | `make test-native` | Run the tests against the native executable.  |
-| `make mvn-package-native`                | Runs the unit and integration tests and creates a native executable for the project.                                                                                                                                |
-| `make mvn-package-native-no-tests`       | Creates a native executable for the project without running the tests.                                                                                                                                              |
+| `make mvn-package-native`                | Runs the unit and integration tests and creates a native executable for the project. |
+| `make mvn-package-native-no-tests`       | Creates a native executable for the project without running the tests.  |
+| `make mvn-generate-sidecar-openapi-spec` | Regenerates the OpenAPI specification for the IDE Sidecar REST API. |
 
 ## Contributing
 

--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -784,7 +784,7 @@
         "properties" : {
           "api_key" : {
             "description" : "The API key to use when connecting to the external service.",
-            "maxLength" : 64,
+            "maxLength" : 96,
             "minLength" : 1,
             "type" : "string"
           },
@@ -856,7 +856,7 @@
         "properties" : {
           "username" : {
             "description" : "The username to use when connecting to the external service.",
-            "maxLength" : 64,
+            "maxLength" : 96,
             "minLength" : 1,
             "type" : "string"
           },
@@ -1974,31 +1974,31 @@
       "HealthResponse" : {
         "type" : "object",
         "properties" : {
-          "status" : {
-            "enum" : [ "UP", "DOWN" ],
-            "type" : "string"
-          },
           "checks" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/HealthCheck"
             }
+          },
+          "status" : {
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           }
         }
       },
       "HealthCheck" : {
         "type" : "object",
         "properties" : {
-          "data" : {
-            "type" : "object",
-            "nullable" : true
+          "status" : {
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           },
           "name" : {
             "type" : "string"
           },
-          "status" : {
-            "enum" : [ "UP", "DOWN" ],
-            "type" : "string"
+          "data" : {
+            "type" : "object",
+            "nullable" : true
           }
         }
       }

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -527,7 +527,7 @@ components:
       properties:
         api_key:
           description: The API key to use when connecting to the external service.
-          maxLength: 64
+          maxLength: 96
           minLength: 1
           type: string
         api_secret:
@@ -581,7 +581,7 @@ components:
       properties:
         username:
           description: The username to use when connecting to the external service.
-          maxLength: 64
+          maxLength: 96
           minLength: 1
           type: string
         password:
@@ -1489,25 +1489,25 @@ components:
     HealthResponse:
       type: object
       properties:
-        status:
-          enum:
-          - UP
-          - DOWN
-          type: string
         checks:
           type: array
           items:
             $ref: "#/components/schemas/HealthCheck"
-    HealthCheck:
-      type: object
-      properties:
-        data:
-          type: object
-          nullable: true
-        name:
-          type: string
         status:
           enum:
           - UP
           - DOWN
           type: string
+    HealthCheck:
+      type: object
+      properties:
+        status:
+          enum:
+          - UP
+          - DOWN
+          type: string
+        name:
+          type: string
+        data:
+          type: object
+          nullable: true

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
@@ -35,7 +35,7 @@ public record ApiKeyAndSecret(
     ApiSecret secret
 ) implements Credentials {
 
-  private static final int KEY_MAX_LEN = 64;
+  private static final int KEY_MAX_LEN = 96;
 
   private static final String PLAIN_LOGIN_MODULE_CLASS =
       "org.apache.kafka.common.security.plain.PlainLoginModule";

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
@@ -30,7 +30,7 @@ public record BasicCredentials(
     Password password
 ) implements Credentials {
 
-  // Warmstream at least likes using > 64 characters for the username
+  // WarpStream likes using > 64 characters for the username
   private static final int USERNAME_MAX_LEN = 96;
 
   private static final String PLAIN_LOGIN_MODULE_CLASS =

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
@@ -30,7 +30,8 @@ public record BasicCredentials(
     Password password
 ) implements Credentials {
 
-  private static final int USERNAME_MAX_LEN = 64;
+  // Warmstream at least likes using > 64 characters for the username
+  private static final int USERNAME_MAX_LEN = 96;
 
   private static final String PLAIN_LOGIN_MODULE_CLASS =
       "org.apache.kafka.common.security.plain.PlainLoginModule";

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
@@ -28,8 +28,8 @@ class ApiKeyAndSecretTest extends RedactedTestBase<ApiKeyAndSecret> {
   @Test
   void warpstreamLengthCredentialsShouldPassValidation() {
     // 69 char key, 68 char secret from prior examples failing.
-    var key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-    var secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    var key = "x".repeat(69);
+    var secret = "x".repeat(68);
 
     var creds = new ApiKeyAndSecret(key, new ApiSecret(secret.toCharArray()));
 

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
@@ -2,6 +2,8 @@ package io.confluent.idesidecar.restapi.credentials;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 class ApiKeyAndSecretTest extends RedactedTestBase<ApiKeyAndSecret> {
@@ -21,5 +23,18 @@ class ApiKeyAndSecretTest extends RedactedTestBase<ApiKeyAndSecret> {
         "credentials/api_key_and_secret_redacted.json",
         ApiKeyAndSecret.class
     );
+  }
+
+  @Test
+  void warpstreamLengthCredentialsShouldPassValidation() {
+    // 69 char key, 68 char secret from prior examples failing.
+    var key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    var secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+    var creds = new ApiKeyAndSecret(key, new ApiSecret(secret.toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(0, errors.size());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
@@ -1,7 +1,9 @@
 package io.confluent.idesidecar.restapi.credentials;
+import io.confluent.idesidecar.restapi.exceptions.Failure.Error;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 class BasicCredentialsTest extends RedactedTestBase<BasicCredentials> {
@@ -21,5 +23,18 @@ class BasicCredentialsTest extends RedactedTestBase<BasicCredentials> {
         "credentials/basic_credentials_redacted.json",
         BasicCredentials.class
     );
+  }
+
+  @Test
+  void warpstreamLengthCredentialsShouldPassValidation() {
+    // 69 char username, 68 char password from prior examples failing.
+    var username = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    var password = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+    var creds = new BasicCredentials(username, new Password(password.toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(0, errors.size());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
@@ -28,8 +28,8 @@ class BasicCredentialsTest extends RedactedTestBase<BasicCredentials> {
   @Test
   void warpstreamLengthCredentialsShouldPassValidation() {
     // 69 char username, 68 char password from prior examples failing.
-    var username = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
-    var password = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    var username = "x".repeat(69);
+    var password = "x".repeat(68);
 
     var creds = new BasicCredentials(username, new Password(password.toCharArray()));
 


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- WarpStream SASL username generation creates long usernames and / or SASL API keys, ~69 chars in the example provided. Prevent the connection creation attempt from being rejected with:

`{"status":"400","code":"invalid_input","title":"Invalid input","id":"320c1640-3def-4436-b89b-70f71f96d1ed","errors":[{"detail":"Kafka cluster username may not be longer than 64 characters","source":"kafka_cluster.credentials.username"}`

- Raise username / key limits in `ApiKeyAndSecret` and `BasicCredentials` to 96 chars, write tests.
- Document how to regenerate the OpenAPI spec documents in `README.md` and `CONTRIBUTING.md`.

E2E tested with both long username/password and API credentials, and the connections were able to be created:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/dbee90b2-3779-4323-a6c2-5dfeae32ec40" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
- Closes #376 
- Closes #360 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

