### PR TITLE
Do not reconnect to CCloud Language Service when session is closed

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,7 +148,6 @@ ide-sidecar:
     # How often to check?
     interval-seconds: 60
   flink-language-service-proxy:
-    reconnect-attempts: 1
     url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.confluent.cloud/lsp
   proxy:
     ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2/compute-pools.*)|(/metadata/security/v2alpha1/authorize)"


### PR DESCRIPTION
## Summary of Changes

This change delegates the handling of reconnection attempts from the sidecar-provided CCloud language service proxy to the extension-side WebSockets client.

Fixes #411

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

