### PR TITLE
fix: Respect hostname verification config for SR

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/SchemaRegistryClients.java
@@ -113,6 +113,10 @@ public class SchemaRegistryClients extends Clients<SchemaRegistryClient> {
   ) {
     var restService = new RestService(srClusterUri);
     restService.configure(configurationProperties);
+    if ("".equals(configurationProperties.get("ssl.endpoint.identification.algorithm"))) {
+      // Disable hostname verification
+      restService.setHostnameVerifier((hostname, session) -> true);
+    }
 
     var httpHeaders = new HashMap<String, String>();
     headers.forEach(entry -> httpHeaders.put(entry.getKey(), entry.getValue()));

--- a/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java
@@ -382,12 +382,19 @@ public class DirectConnectionState extends ConnectionState {
         false,
         TIMEOUT
     );
+
     var restService = new RestService(config.uri());
     restService.configure(srClientConfig);
+    if (config.tlsConfig() != null && Boolean.FALSE.equals(config.tlsConfig().verifyHostname())) {
+      // Disable hostname verification
+      restService.setHostnameVerifier((hostname, session) -> true);
+    }
+
     var sslFactory = new SslFactory(srClientConfig);
     if (sslFactory.sslContext() != null) {
       restService.setSslSocketFactory(sslFactory.sslContext().getSocketFactory());
     }
+
     return new SidecarSchemaRegistryClient(restService, 10);
   }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/ConfluentPlatformIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/ConfluentPlatformIT.java
@@ -138,4 +138,27 @@ public class ConfluentPlatformIT {
       setupConnection(this, TestEnvironment::directConnectionSpec);
     }
   }
+
+  @QuarkusIntegrationTest
+  @Tag("io.confluent.common.utils.IntegrationTest")
+  @TestProfile(NoAccessFilterProfile.class)
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  class WithoutHostnameVerificationRecordTests extends AbstractIT implements
+      RecordsV3Suite, RecordsV3ErrorsSuite {
+
+    @Override
+    public CPDemoTestEnvironment environment() {
+      return TEST_ENVIRONMENT;
+    }
+
+    @BeforeEach
+    @Override
+    public void setupConnection() {
+      setupConnection(
+          this,
+          environment().directConnectionSpecWithoutHostnameVerification()
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary of Changes

When interacting with schema registries, we should respect the hostname verification config, so that VS Code extension users can interact with schema registries that use self-signed certificates with non-matching hostnames.

Fixes #415

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

