### PR TITLE
Set `quarkus.native.march=compatibility`

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -250,6 +250,7 @@ quarkus:
     fail-on-unknown-properties: true
   native:
     additional-build-args: --initialize-at-run-time=io.confluent.idesidecar.restapi.auth.CCloudOAuthConfig\,io.confluent.idesidecar.restapi.auth.CCloudOAuthContext\,io.confluent.ide.sidecar.restapi.util.WebClientFactory\,org.apache.kafka.common.security.authenticator.SaslClientAuthenticator\,org.apache.avro.file.DataFileWriter\,io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils\,com.github.luben.zstd
+    march: compatibility
     resources:
       includes: templates/callback.html,templates/callback_failure.html,templates/default.html,templates/reset_password.html,feature-flag-defaults.json
   smallrye-health:


### PR DESCRIPTION
## Summary of Changes

This change sets the config `quarkus.native.march=compatibility`, so that the generated native executables use older instruction sets, making the executables more compatible and allowing older machines/CPUs to run them.

Fixes #421

## Any additional details or context that should be provided?

https://quarkus.io/guides/native-reference#work-around-missing-cpu-features

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

