### PR TITLE
Increase reconnect.backoff.max.ms config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -163,16 +163,19 @@ ide-sidecar:
     "client.id": Confluent for VS Code sidecar ${vscode.extension.version} - Admin
     "default.api.timeout.ms": 5000
     "request.timeout.ms": 5000
+    "reconnect.backoff.max.ms": 7500
   # Configuration set by the sidecar when instantiating the Kafka Consumer
   # (We may choose to allow connection-specific overrides in the future)
   consumer-client-configs:
     "client.id": Confluent for VS Code sidecar ${vscode.extension.version} - Consumer
     "session.timeout.ms": 45000
+    "reconnect.backoff.max.ms": 7500
   # Configuration set by the sidecar when instantiating the Kafka Producer
   # (We may choose to allow connection-specific overrides in the future)
   producer-client-configs:
     acks: all
     "client.id": Confluent for VS Code sidecar ${vscode.extension.version} - Producer
+    "reconnect.backoff.max.ms": 7500
   # Configuration set by the sidecar when instantiating Kafka record serializers and deserializers.
   # See https://github.com/confluentinc/schema-registry/blob/master/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java#L39
   # for a full list of available configs.


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes
Increased the config property reconnect.backoff.max.ms for the clients using the Kafka native protocol from the default value of 1000 (1 second) to 7.5 seconds, so that we can better handle unstable network connections.

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

