### PR TITLE
fix: Let Kafka consumer/producer use correct config

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/clients/ClientConfigurator.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/clients/ClientConfigurator.java
@@ -411,7 +411,7 @@ public class ClientConfigurator {
       Log.debugf("Not using Schema Registry for Kafka cluster %s", cluster.id());
     }
 
-    return getKafkaProducerConfig(
+    return getKafkaConsumerConfig(
         connection,
         cluster.bootstrapServers(),
         sr != null ? sr.uri() : null,
@@ -458,7 +458,7 @@ public class ClientConfigurator {
       Log.debugf("Not using Schema Registry for Kafka cluster %s", cluster.id());
     }
 
-    return getKafkaConsumerConfig(
+    return getKafkaProducerConfig(
         connection,
         cluster.bootstrapServers(),
         sr != null ? sr.uri() : null,


### PR DESCRIPTION
## Summary of Changes

This change makes sure the Kafka consumer client uses the consumer config and the Kafka producer client uses the producer config. I accidentally stumbled upon this bug when working on something else.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

