### PR TITLE
fix: Specify that `directConnectionById` may return `null`

### DIFF
--- a/src/generated/resources/schema.graphql
+++ b/src/generated/resources/schema.graphql
@@ -111,7 +111,7 @@ type Query {
   "Get all CCloud connections"
   ccloudConnections: [CCloudConnection]!
   "Get direct connection by ID"
-  directConnectionById(connectionID: String): DirectConnection!
+  directConnectionById(id: String!): DirectConnection
   "Get all direct connections"
   directConnections: [DirectConnection]!
   "Find CCloud Kafka clusters using a connection and various criteria"

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/DirectFetcher.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/DirectFetcher.java
@@ -13,12 +13,12 @@ public interface DirectFetcher {
   List<DirectConnection> getConnections();
 
   /**
-   * Get direct connection by ID.
+   * Get the Direct connection with the specified identifier.
    *
-   * @param connectionId the ID of the connection
-   * @return the direct connection by ID; may be null
+   * @param id the ID of the connection
+   * @return the Direct connection
    */
-  DirectConnection getDirectConnectionByID(String connectionID) throws Exception;
+  Uni<DirectConnection> getDirectConnectionByID(String id);
 
   /**
    * Get the Kafka cluster or broker.

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/DirectQueryResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/DirectQueryResource.java
@@ -44,9 +44,8 @@ public class DirectQueryResource {
    */
   @Query("directConnectionById")
   @Description("Get direct connection by ID")
-  @NonNull
-  public DirectConnection getDirectConnectionByID(String connectionID) throws Exception {
-    return direct.getDirectConnectionByID(connectionID);
+  public Uni<DirectConnection> getDirectConnectionByID(@NonNull String id) {
+    return direct.getDirectConnectionByID(id);
   }
 
   /**


### PR DESCRIPTION
## Summary of Changes

This change updates the GraphQL schema to specify that the query `directConnectionById` may return a `null` value. Also, it performs a few minor refactorings.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

