### PR TITLE
chore: Add log statements to language service proxy

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
@@ -42,6 +42,7 @@ public class FlinkLanguageServiceProxyClient implements AutoCloseable {
       var container = ContainerProvider.getWebSocketContainer();
       container.connectToServer(this, URI.create(context.getConnectUrl()));
     } catch (Exception e) {
+      Log.warnf("Failed to connect to CCloud Flink Language Service: %s", e.getMessage());
       throw new ProxyConnectionFailedException(e);
     }
   }


### PR DESCRIPTION
## Summary of Changes

Add more log statements to the Flink language service proxy, so that we can better debug the behavior of the language server in VS Code.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

