### PR TITLE
fix: Revert OpenAPI spec version to 3.0.3

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -1,32 +1,34 @@
 {
-  "openapi" : "3.1.0",
+  "openapi" : "3.0.3",
   "components" : {
     "schemas" : {
       "ApiKeyAndSecret" : {
         "description" : "API key and secret authentication credentials",
-        "type" : "object",
         "required" : [ "api_key", "api_secret" ],
+        "type" : "object",
         "properties" : {
           "api_key" : {
-            "type" : "string",
+            "description" : "The API key to use when connecting to the external service.",
             "maxLength" : 96,
             "minLength" : 1,
-            "description" : "The API key to use when connecting to the external service."
+            "type" : "string"
           },
           "api_secret" : {
+            "description" : "The API secret to use when connecting to the external service.",
             "maxLength" : 1024,
             "minLength" : 1,
-            "description" : "The API secret to use when connecting to the external service.",
             "type" : "string",
-            "$ref" : "#/components/schemas/ApiSecret"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ApiSecret"
+            } ]
           }
         }
       },
       "ApiSecret" : {
-        "type" : "string",
+        "description" : "A user-provided API secret that is always masked in responses",
         "maxLength" : 1024,
         "minLength" : 1,
-        "description" : "A user-provided API secret that is always masked in responses"
+        "type" : "string"
       },
       "AuthError" : {
         "type" : "object",
@@ -55,8 +57,8 @@
       },
       "Authentication" : {
         "description" : "The authentication-related status (deprecated).",
-        "type" : "object",
         "required" : [ "status" ],
+        "type" : "object",
         "properties" : {
           "status" : {
             "$ref" : "#/components/schemas/Status"
@@ -74,66 +76,76 @@
       },
       "BasicCredentials" : {
         "description" : "Basic authentication credentials",
-        "type" : "object",
         "required" : [ "username", "password" ],
+        "type" : "object",
         "properties" : {
           "username" : {
-            "type" : "string",
+            "description" : "The username to use when connecting to the external service.",
             "maxLength" : 96,
             "minLength" : 1,
-            "description" : "The username to use when connecting to the external service."
+            "type" : "string"
           },
           "password" : {
+            "description" : "The password to use when connecting to the external service.",
             "maxLength" : 1024,
             "minLength" : 1,
-            "description" : "The password to use when connecting to the external service.",
             "type" : "string",
-            "$ref" : "#/components/schemas/Password"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
           }
         }
       },
       "CCloudConfig" : {
-        "type" : "object",
         "description" : "Configuration for Confluent Cloud connections",
+        "type" : "object",
         "properties" : {
           "organization_id" : {
-            "type" : "string",
             "description" : "The identifier of the CCloud organization to use. The user's default organization is used when absent.",
+            "maxLength" : 36,
             "minLength" : 36,
-            "maxLength" : 36
+            "type" : "string"
           },
           "ide_auth_callback_uri" : {
-            "type" : "string",
             "description" : "The URI that users will be redirected to after successfully completing the authentication flow with Confluent Cloud.",
+            "maxLength" : 200,
             "minLength" : 10,
-            "maxLength" : 200
+            "type" : "string"
           }
         }
       },
       "CCloudStatus" : {
         "description" : "The status related to CCloud.",
-        "type" : "object",
         "required" : [ "state" ],
+        "type" : "object",
         "properties" : {
           "state" : {
             "description" : "The state of the connection to CCloud.",
             "type" : "string",
-            "$ref" : "#/components/schemas/ConnectedState"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
           },
           "requires_authentication_at" : {
             "description" : "If the connection's auth context holds a valid token, this attribute holds the time at which the user must re-authenticate because, for instance, the refresh token reached the end of its absolute lifetime.",
             "type" : "string",
-            "$ref" : "#/components/schemas/Instant"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Instant"
+            } ]
           },
           "user" : {
             "description" : "Information about the authenticated principal, if known.",
             "type" : "object",
-            "$ref" : "#/components/schemas/UserInfo"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
           },
           "errors" : {
             "description" : "Errors related to the connection to the Kafka cluster.",
             "type" : "object",
-            "$ref" : "#/components/schemas/AuthErrors"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
           }
         }
       },
@@ -147,18 +159,18 @@
             "type" : "string"
           },
           "total_size" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           }
         }
       },
       "ConnectedState" : {
-        "type" : "string",
-        "enum" : [ "NONE", "ATTEMPTING", "SUCCESS", "EXPIRED", "FAILED" ]
+        "enum" : [ "NONE", "ATTEMPTING", "SUCCESS", "EXPIRED", "FAILED" ],
+        "type" : "string"
       },
       "Connection" : {
-        "type" : "object",
         "required" : [ "api_version", "kind", "id", "metadata", "spec", "status" ],
+        "type" : "object",
         "properties" : {
           "api_version" : {
             "type" : "string"
@@ -199,44 +211,55 @@
         "type" : "object",
         "properties" : {
           "id" : {
-            "type" : "string",
             "description" : "The unique identifier of the connection resource.",
+            "maxLength" : 64,
             "minLength" : 1,
-            "maxLength" : 64
+            "type" : "string"
           },
           "name" : {
-            "type" : "string",
             "description" : "The user-supplied name of the connection resource.",
-            "maxLength" : 64
+            "maxLength" : 64,
+            "type" : "string"
           },
           "type" : {
             "description" : "The type of connection resource.",
             "type" : "string",
-            "$ref" : "#/components/schemas/ConnectionType"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectionType"
+            } ]
           },
           "ccloud_config" : {
             "description" : "The details for connecting to CCloud.",
             "type" : "object",
-            "$ref" : "#/components/schemas/CCloudConfig"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/CCloudConfig"
+            } ]
           },
           "local_config" : {
             "description" : "The details for connecting to Confluent Local.",
             "type" : "object",
-            "$ref" : "#/components/schemas/LocalConfig"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/LocalConfig"
+            } ]
           },
           "kafka_cluster" : {
             "description" : "The details for connecting to a CCloud, Confluent Platform, or Apache Kafka cluster.",
             "type" : "object",
-            "$ref" : "#/components/schemas/KafkaClusterConfig"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/KafkaClusterConfig"
+            } ]
           },
           "schema_registry" : {
             "description" : "The details for connecting to a Schema Registry.",
             "type" : "object",
-            "$ref" : "#/components/schemas/SchemaRegistryConfig"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/SchemaRegistryConfig"
+            } ]
           }
         }
       },
       "ConnectionStatus" : {
+        "required" : [ "authentication" ],
         "type" : "object",
         "properties" : {
           "ccloud" : {
@@ -251,16 +274,15 @@
           "authentication" : {
             "$ref" : "#/components/schemas/Authentication"
           }
-        },
-        "required" : [ "authentication" ]
+        }
       },
       "ConnectionType" : {
-        "type" : "string",
-        "enum" : [ "LOCAL", "PLATFORM", "CCLOUD", "DIRECT" ]
+        "enum" : [ "LOCAL", "PLATFORM", "CCLOUD", "DIRECT" ],
+        "type" : "string"
       },
       "ConnectionsList" : {
-        "type" : "object",
         "required" : [ "api_version", "kind", "metadata", "data" ],
+        "type" : "object",
         "properties" : {
           "api_version" : {
             "type" : "string"
@@ -281,13 +303,13 @@
       },
       "DataFormat" : {
         "description" : "The data format that represents the bytes of a Kafka message.\n\n* AVRO: Apache Avro schema format.\n* JSONSCHEMA: JSON schema format.\n* PROTOBUF: Google Protocol Buffers schema format.\n* JSON:\n    Bytes parsed as JSON.\n    The bytes did not contain a magic byte specifying a schema id, and the raw bytes\n    were successfully parsed into a JSON value.\n* UTF8_STRING:\n    Bytes parsed as a UTF-8 string (meaning the bytes were not parsed as valid JSON).\n* RAW_BYTES:\n    Raw bytes. These are the scenarios where it would be used:\n    - Arbitrary bytes that are NOT written/read using an implementation of Kafka serializer/deserializer.\n    And further, we tried to but could not interpret these bytes as a JSON value.\n    - The Kafka serializer/deserializer known to sidecar failed to parse the schematized bytes\n    (meaning the schema id was present in the magic bytes, but our classes could not interpret the rest of the bytes.)\n",
-        "type" : "string",
-        "enum" : [ "AVRO", "JSONSCHEMA", "PROTOBUF", "JSON", "UTF8_STRING", "RAW_BYTES" ]
+        "enum" : [ "AVRO", "JSONSCHEMA", "PROTOBUF", "JSON", "UTF8_STRING", "RAW_BYTES" ],
+        "type" : "string"
       },
       "Date" : {
-        "type" : "string",
         "format" : "date",
-        "examples" : [ "2022-03-10" ]
+        "type" : "string",
+        "example" : "2022-03-10"
       },
       "ExceededFields" : {
         "type" : "object",
@@ -325,13 +347,13 @@
         }
       },
       "HashAlgorithm" : {
-        "type" : "string",
-        "enum" : [ "SCRAM_SHA_256", "SCRAM_SHA_512" ]
+        "enum" : [ "SCRAM_SHA_256", "SCRAM_SHA_512" ],
+        "type" : "string"
       },
       "Instant" : {
-        "type" : "string",
         "format" : "date-time",
-        "examples" : [ "2022-03-10T16:15:50Z" ]
+        "type" : "string",
+        "example" : "2022-03-10T16:15:50Z"
       },
       "JsonMergePatch" : {
         "type" : "object"
@@ -408,21 +430,22 @@
         }
       },
       "JsonNodeType" : {
-        "type" : "string",
-        "enum" : [ "ARRAY", "BINARY", "BOOLEAN", "MISSING", "NULL", "NUMBER", "OBJECT", "POJO", "STRING" ]
+        "enum" : [ "ARRAY", "BINARY", "BOOLEAN", "MISSING", "NULL", "NUMBER", "OBJECT", "POJO", "STRING" ],
+        "type" : "string"
       },
       "KafkaClusterConfig" : {
-        "type" : "object",
         "description" : "Kafka cluster configuration.",
         "required" : [ "bootstrap_servers" ],
+        "type" : "object",
         "properties" : {
           "bootstrap_servers" : {
-            "type" : "string",
             "description" : "A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.",
+            "maxLength" : 256,
             "minLength" : 1,
-            "maxLength" : 256
+            "type" : "string"
           },
           "credentials" : {
+            "description" : "The credentials for the Kafka cluster, or null if no authentication is required",
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
@@ -433,59 +456,63 @@
               "$ref" : "#/components/schemas/ScramCredentials"
             }, {
               "$ref" : "#/components/schemas/KerberosCredentials"
-            } ],
-            "description" : "The credentials for the Kafka cluster, or null if no authentication is required"
+            } ]
           },
           "ssl" : {
             "description" : "The SSL configuration for connecting to the Kafka cluster. To disable, set `enabled` to false. To use the default SSL settings, set `enabled` to true and leave the `truststore` and `keystore` fields unset.",
-            "type" : [ "object", "null" ],
-            "anyOf" : [ {
+            "type" : "object",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/TLSConfig"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           }
         }
       },
       "KafkaClusterStatus" : {
         "description" : "The status related to the specified Kafka cluster.",
-        "type" : "object",
         "required" : [ "state" ],
+        "type" : "object",
         "properties" : {
           "state" : {
             "description" : "The state of the connection to the Kafka cluster.",
             "type" : "string",
-            "$ref" : "#/components/schemas/ConnectedState"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
           },
           "user" : {
             "description" : "Information about the authenticated principal, if known.",
             "type" : "object",
-            "$ref" : "#/components/schemas/UserInfo"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
           },
           "errors" : {
             "description" : "Errors related to the connection to the Kafka cluster.",
             "type" : "object",
-            "$ref" : "#/components/schemas/AuthErrors"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
           }
         }
       },
       "KerberosCredentials" : {
         "description" : "Kerberos authentication credentials",
-        "type" : "object",
         "required" : [ "principal", "keytab_path" ],
+        "type" : "object",
         "properties" : {
           "principal" : {
-            "type" : "string",
-            "description" : "The Kerberos principal to use."
+            "description" : "The Kerberos principal to use.",
+            "type" : "string"
           },
           "keytab_path" : {
-            "type" : "string",
-            "description" : "The Kerberos keytab file path."
+            "description" : "The Kerberos keytab file path.",
+            "type" : "string"
           },
           "service_name" : {
-            "type" : "string",
             "description" : "Service name that matches the primary name of the Kafka brokers configured in the Broker JAAS file. Defaults to 'kafka'.",
-            "default" : "kafka"
+            "default" : "kafka",
+            "type" : "string"
           }
         }
       },
@@ -493,8 +520,8 @@
         "type" : "object",
         "properties" : {
           "schema_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "data_format" : {
             "$ref" : "#/components/schemas/DataFormat"
@@ -502,94 +529,93 @@
         }
       },
       "KeyStore" : {
-        "type" : "object",
         "required" : [ "path" ],
+        "type" : "object",
         "properties" : {
           "path" : {
-            "type" : "string",
             "description" : "The path to the local key store file. Only specified if client needs to be authenticated by the server (mutual TLS).",
-            "maxLength" : 256
+            "maxLength" : 256,
+            "type" : "string"
           },
           "password" : {
             "description" : "The password for the local key store file. If a password is not set, key store file configured will still be used, but integrity checking is disabled. A key store password is not supported for PEM format.",
-            "type" : [ "string", "null" ],
-            "anyOf" : [ {
+            "type" : "string",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/Password"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           },
           "type" : {
             "description" : "The file format of the local key store file.",
-            "type" : [ "string", "null" ],
             "default" : "JKS",
-            "anyOf" : [ {
+            "type" : "string",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/StoreType"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           },
           "key_password" : {
             "description" : "The password of the private key in the local key store file.",
-            "type" : [ "string", "null" ],
-            "anyOf" : [ {
+            "type" : "string",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/Password"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           }
         }
       },
       "LocalConfig" : {
-        "type" : "object",
         "description" : "Configuration when using Confluent Local and optionally a local Schema Registry.",
+        "type" : "object",
         "properties" : {
           "schema-registry-uri" : {
-            "type" : "string",
             "description" : "The URL of the Schema Registry running locally.",
-            "maxLength" : 512
+            "maxLength" : 512,
+            "type" : "string"
           }
         }
       },
       "OAuthCredentials" : {
         "description" : "OAuth 2.0 authentication credentials",
-        "type" : "object",
         "required" : [ "tokens_url", "client_id" ],
+        "type" : "object",
         "properties" : {
           "tokens_url" : {
-            "type" : "string",
             "description" : "The URL of the OAuth 2.0 identity provider's token endpoint.",
-            "maxLength" : 256
+            "maxLength" : 256,
+            "type" : "string"
           },
           "client_id" : {
-            "type" : "string",
             "description" : "The public identifier for the application as registered with the OAuth 2.0 identity provider.",
+            "maxLength" : 128,
             "minLength" : 1,
-            "maxLength" : 128
+            "type" : "string"
           },
           "client_secret" : {
             "description" : "The client secret known only to the application and the OAuth 2.0 identity provider.",
             "type" : "string",
-            "$ref" : "#/components/schemas/Password"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
           },
           "scope" : {
-            "type" : "string",
             "description" : "The scope to use. The scope is optional and required only when your identity provider doesn't have a default scope or your groups claim is linked to a scope path to use when connecting to the external service.",
-            "maxLength" : 256
+            "maxLength" : 256,
+            "type" : "string"
           },
           "connect_timeout_millis" : {
-            "type" : "integer",
             "format" : "int32",
             "description" : "The timeout in milliseconds when connecting to your identity provider.",
-            "minimum" : 0
+            "minimum" : 0,
+            "type" : "integer"
           },
           "ccloud_logical_cluster_id" : {
-            "type" : "string",
-            "description" : "Additional property that can be added in the request header to identify the logical cluster ID to connect to. For example, this may be a Confluent Cloud Kafka or Schema Registry cluster ID."
+            "description" : "Additional property that can be added in the request header to identify the logical cluster ID to connect to. For example, this may be a Confluent Cloud Kafka or Schema Registry cluster ID.",
+            "type" : "string"
           },
           "ccloud_identity_pool_id" : {
-            "type" : "string",
-            "description" : "Additional property that can be added in the request header to identify the principal ID for authorization. For example, this may be a Confluent Cloud identity pool ID."
+            "description" : "Additional property that can be added in the request header to identify the principal ID for authorization. For example, this may be a Confluent Cloud identity pool ID.",
+            "type" : "string"
           }
         }
       },
@@ -597,12 +623,12 @@
         "type" : "object",
         "properties" : {
           "partition_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "next_offset" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "records" : {
             "type" : "array",
@@ -616,16 +642,16 @@
         "type" : "object",
         "properties" : {
           "partition_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "offset" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "timestamp" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "timestamp_type" : {
             "$ref" : "#/components/schemas/TimestampType"
@@ -671,24 +697,24 @@
         "type" : "object",
         "properties" : {
           "partition_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "offset" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           }
         }
       },
       "Password" : {
-        "type" : "string",
+        "description" : "A user-provided password that is always masked in responses",
         "maxLength" : 1024,
         "minLength" : 1,
-        "description" : "A user-provided password that is always masked in responses"
+        "type" : "string"
       },
       "Preferences" : {
-        "type" : "object",
         "required" : [ "api_version", "kind", "spec" ],
+        "type" : "object",
         "properties" : {
           "api_version" : {
             "type" : "string"
@@ -705,8 +731,8 @@
         }
       },
       "PreferencesMetadata" : {
-        "type" : "object",
         "required" : [ "self" ],
+        "type" : "object",
         "properties" : {
           "self" : {
             "type" : "string"
@@ -734,8 +760,8 @@
         "type" : "object",
         "properties" : {
           "partition_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "headers" : {
             "type" : "array",
@@ -767,12 +793,12 @@
             "type" : "string"
           },
           "schema_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "schema_version" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "schema" : {
             "type" : "string"
@@ -781,25 +807,25 @@
         }
       },
       "ProduceRequestHeader" : {
-        "type" : "object",
         "required" : [ "name" ],
+        "type" : "object",
         "properties" : {
           "name" : {
             "type" : "string"
           },
           "value" : {
-            "type" : "string",
-            "format" : "binary"
+            "format" : "binary",
+            "type" : "string"
           }
         }
       },
       "ProduceResponse" : {
-        "type" : "object",
         "required" : [ "error_code" ],
+        "type" : "object",
         "properties" : {
           "error_code" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "message" : {
             "type" : "string"
@@ -811,12 +837,12 @@
             "type" : "string"
           },
           "partition_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "offset" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "timestamp" : {
             "$ref" : "#/components/schemas/Date"
@@ -830,12 +856,12 @@
         }
       },
       "ProduceResponseData" : {
-        "type" : "object",
         "required" : [ "size", "type" ],
+        "type" : "object",
         "properties" : {
           "size" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "type" : {
             "type" : "string"
@@ -844,12 +870,12 @@
             "type" : "string"
           },
           "schema_id" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "schema_version" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           }
         }
       },
@@ -865,86 +891,95 @@
         }
       },
       "SchemaRegistryConfig" : {
-        "type" : "object",
         "description" : "Schema Registry configuration.",
+        "required" : [ "uri" ],
+        "type" : "object",
         "properties" : {
           "id" : {
-            "type" : "string",
             "description" : "The identifier of the Schema Registry cluster, if known.",
-            "maxLength" : 64
+            "maxLength" : 64,
+            "type" : "string"
           },
           "uri" : {
-            "type" : "string",
             "description" : "The URL of the Schema Registry.",
+            "maxLength" : 256,
             "minLength" : 1,
-            "maxLength" : 256
+            "type" : "string"
           },
           "credentials" : {
+            "description" : "The credentials for the Schema Registry, or null if no authentication is required",
             "oneOf" : [ {
               "$ref" : "#/components/schemas/BasicCredentials"
             }, {
               "$ref" : "#/components/schemas/ApiKeyAndSecret"
             }, {
               "$ref" : "#/components/schemas/OAuthCredentials"
-            } ],
-            "description" : "The credentials for the Schema Registry, or null if no authentication is required"
+            } ]
           },
           "ssl" : {
             "description" : "The SSL configuration for connecting to Schema Registry. If null, the connection will use SSL with the default settings. To disable, set `enabled` to false.",
-            "type" : [ "object", "null" ],
-            "anyOf" : [ {
+            "type" : "object",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/TLSConfig"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           }
-        },
-        "required" : [ "uri" ]
+        }
       },
       "SchemaRegistryStatus" : {
         "description" : "The status related to the specified Schema Registry.",
-        "type" : "object",
         "required" : [ "state" ],
+        "type" : "object",
         "properties" : {
           "state" : {
             "description" : "The state of the connection to the Schema Registry.",
             "type" : "string",
-            "$ref" : "#/components/schemas/ConnectedState"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/ConnectedState"
+            } ]
           },
           "user" : {
             "description" : "Information about the authenticated principal, if known.",
             "type" : "object",
-            "$ref" : "#/components/schemas/UserInfo"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/UserInfo"
+            } ]
           },
           "errors" : {
             "description" : "Errors related to the connection to the Schema Registry.",
             "type" : "object",
-            "$ref" : "#/components/schemas/AuthErrors"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/AuthErrors"
+            } ]
           }
         }
       },
       "ScramCredentials" : {
         "description" : "Scram authentication credentials",
-        "type" : "object",
         "required" : [ "hash_algorithm", "scram_username", "scram_password" ],
+        "type" : "object",
         "properties" : {
           "hash_algorithm" : {
             "description" : "Hash algorithm",
             "type" : "string",
-            "$ref" : "#/components/schemas/HashAlgorithm"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/HashAlgorithm"
+            } ]
           },
           "scram_username" : {
-            "type" : "string",
+            "description" : "The username to use when connecting to the external service.",
             "maxLength" : 64,
             "minLength" : 1,
-            "description" : "The username to use when connecting to the external service."
+            "type" : "string"
           },
           "scram_password" : {
+            "description" : "The password to use when connecting to the external service.",
             "maxLength" : 1024,
             "minLength" : 1,
-            "description" : "The password to use when connecting to the external service.",
             "type" : "string",
-            "$ref" : "#/components/schemas/Password"
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/Password"
+            } ]
           }
         }
       },
@@ -957,8 +992,8 @@
         }
       },
       "SidecarError" : {
-        "type" : "object",
         "description" : "Describes a particular error encountered while performing an operation.",
+        "type" : "object",
         "properties" : {
           "code" : {
             "type" : "string"
@@ -998,20 +1033,20 @@
             }
           },
           "max_poll_records" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "timestamp" : {
-            "type" : "integer",
-            "format" : "int64"
+            "format" : "int64",
+            "type" : "integer"
           },
           "fetch_max_bytes" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "message_max_bytes" : {
-            "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "type" : "integer"
           },
           "from_beginning" : {
             "type" : "boolean"
@@ -1036,79 +1071,75 @@
         }
       },
       "Status" : {
-        "type" : "string",
-        "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN", "FAILED" ]
+        "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN", "FAILED" ],
+        "type" : "string"
       },
       "StoreType" : {
-        "type" : "string",
-        "enum" : [ "JKS", "PKCS12", "PEM", "UNKNOWN" ]
+        "enum" : [ "JKS", "PKCS12", "PEM", "UNKNOWN" ],
+        "type" : "string"
       },
       "TLSConfig" : {
         "description" : "SSL configuration",
+        "required" : [ "enabled" ],
         "type" : "object",
         "properties" : {
           "verify_hostname" : {
-            "type" : "boolean",
             "description" : "Whether to verify the server certificate hostname. Defaults to true if not set.",
-            "default" : true
+            "default" : true,
+            "type" : "boolean"
           },
           "enabled" : {
-            "type" : "boolean",
             "description" : "Whether SSL is enabled. If not set, defaults to true.",
-            "default" : true
+            "default" : true,
+            "type" : "boolean"
           },
           "truststore" : {
             "description" : "The trust store configuration for authenticating the server's certificate.",
-            "type" : [ "object", "null" ],
-            "anyOf" : [ {
+            "type" : "object",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/TrustStore"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           },
           "keystore" : {
             "description" : "The key store configuration that will identify and authenticate the client to the server, required for mutual TLS (mTLS)",
-            "type" : [ "object", "null" ],
-            "anyOf" : [ {
+            "type" : "object",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/KeyStore"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           }
-        },
-        "required" : [ "enabled" ]
+        }
       },
       "TimestampType" : {
-        "type" : "string",
-        "enum" : [ "NO_TIMESTAMP_TYPE", "CREATE_TIME", "LOG_APPEND_TIME" ]
+        "enum" : [ "NO_TIMESTAMP_TYPE", "CREATE_TIME", "LOG_APPEND_TIME" ],
+        "type" : "string"
       },
       "TrustStore" : {
-        "type" : "object",
         "required" : [ "path" ],
+        "type" : "object",
         "properties" : {
           "path" : {
-            "type" : "string",
             "description" : "The path to the local trust store file. Required for authenticating the server's certificate.",
-            "maxLength" : 256
+            "maxLength" : 256,
+            "type" : "string"
           },
           "password" : {
             "description" : "The password for the local trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. A trust store password is not supported for PEM format.",
-            "type" : [ "string", "null" ],
-            "anyOf" : [ {
+            "type" : "string",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/Password"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           },
           "type" : {
             "description" : "The file format of the local trust store file",
-            "type" : [ "string", "null" ],
             "default" : "JKS",
-            "anyOf" : [ {
+            "type" : "string",
+            "allOf" : [ {
               "$ref" : "#/components/schemas/StoreType"
-            }, {
-              "type" : "null"
-            } ]
+            } ],
+            "nullable" : true
           }
         }
       },
@@ -1139,8 +1170,8 @@
         "type" : "object",
         "properties" : {
           "status" : {
-            "type" : "string",
-            "enum" : [ "UP", "DOWN" ]
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           },
           "checks" : {
             "type" : "array",
@@ -1153,15 +1184,16 @@
       "HealthCheck" : {
         "type" : "object",
         "properties" : {
+          "data" : {
+            "type" : "object",
+            "nullable" : true
+          },
           "name" : {
             "type" : "string"
           },
-          "data" : {
-            "type" : [ "object", "null" ]
-          },
           "status" : {
-            "type" : "string",
-            "enum" : [ "UP", "DOWN" ]
+            "enum" : [ "UP", "DOWN" ],
+            "type" : "string"
           }
         }
       }
@@ -1324,8 +1356,8 @@
           "name" : "dry_run",
           "in" : "query",
           "schema" : {
-            "type" : "boolean",
-            "default" : false
+            "default" : false,
+            "type" : "boolean"
           }
         }, {
           "description" : "Connection ID",
@@ -1388,8 +1420,8 @@
           "in" : "query",
           "schema" : {
             "description" : "Whether to validate the connection spec and determine the connection status without creating the connection",
-            "type" : "boolean",
-            "default" : false
+            "default" : false,
+            "type" : "boolean"
           }
         } ],
         "requestBody" : {

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -1,30 +1,31 @@
 ---
-openapi: 3.1.0
+openapi: 3.0.3
 components:
   schemas:
     ApiKeyAndSecret:
       description: API key and secret authentication credentials
-      type: object
       required:
       - api_key
       - api_secret
+      type: object
       properties:
         api_key:
-          type: string
+          description: The API key to use when connecting to the external service.
           maxLength: 96
           minLength: 1
-          description: The API key to use when connecting to the external service.
+          type: string
         api_secret:
+          description: The API secret to use when connecting to the external service.
           maxLength: 1024
           minLength: 1
-          description: The API secret to use when connecting to the external service.
           type: string
-          $ref: "#/components/schemas/ApiSecret"
+          allOf:
+          - $ref: "#/components/schemas/ApiSecret"
     ApiSecret:
-      type: string
+      description: A user-provided API secret that is always masked in responses
       maxLength: 1024
       minLength: 1
-      description: A user-provided API secret that is always masked in responses
+      type: string
     AuthError:
       type: object
       properties:
@@ -43,9 +44,9 @@ components:
           $ref: "#/components/schemas/AuthError"
     Authentication:
       description: The authentication-related status (deprecated).
-      type: object
       required:
       - status
+      type: object
       properties:
         status:
           $ref: "#/components/schemas/Status"
@@ -57,62 +58,67 @@ components:
           $ref: "#/components/schemas/AuthErrors"
     BasicCredentials:
       description: Basic authentication credentials
-      type: object
       required:
       - username
       - password
+      type: object
       properties:
         username:
-          type: string
+          description: The username to use when connecting to the external service.
           maxLength: 96
           minLength: 1
-          description: The username to use when connecting to the external service.
+          type: string
         password:
+          description: The password to use when connecting to the external service.
           maxLength: 1024
           minLength: 1
-          description: The password to use when connecting to the external service.
           type: string
-          $ref: "#/components/schemas/Password"
+          allOf:
+          - $ref: "#/components/schemas/Password"
     CCloudConfig:
-      type: object
       description: Configuration for Confluent Cloud connections
+      type: object
       properties:
         organization_id:
-          type: string
           description: The identifier of the CCloud organization to use. The user's
             default organization is used when absent.
-          minLength: 36
           maxLength: 36
-        ide_auth_callback_uri:
+          minLength: 36
           type: string
+        ide_auth_callback_uri:
           description: The URI that users will be redirected to after successfully
             completing the authentication flow with Confluent Cloud.
-          minLength: 10
           maxLength: 200
+          minLength: 10
+          type: string
     CCloudStatus:
       description: The status related to CCloud.
-      type: object
       required:
       - state
+      type: object
       properties:
         state:
           description: The state of the connection to CCloud.
           type: string
-          $ref: "#/components/schemas/ConnectedState"
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
         requires_authentication_at:
           description: "If the connection's auth context holds a valid token, this\
             \ attribute holds the time at which the user must re-authenticate because,\
             \ for instance, the refresh token reached the end of its absolute lifetime."
           type: string
-          $ref: "#/components/schemas/Instant"
+          allOf:
+          - $ref: "#/components/schemas/Instant"
         user:
           description: "Information about the authenticated principal, if known."
           type: object
-          $ref: "#/components/schemas/UserInfo"
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
         errors:
           description: Errors related to the connection to the Kafka cluster.
           type: object
-          $ref: "#/components/schemas/AuthErrors"
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     CollectionMetadata:
       type: object
       properties:
@@ -121,18 +127,17 @@ components:
         next:
           type: string
         total_size:
-          type: integer
           format: int32
+          type: integer
     ConnectedState:
-      type: string
       enum:
       - NONE
       - ATTEMPTING
       - SUCCESS
       - EXPIRED
       - FAILED
+      type: string
     Connection:
-      type: object
       required:
       - api_version
       - kind
@@ -140,6 +145,7 @@ components:
       - metadata
       - spec
       - status
+      type: object
       properties:
         api_version:
           type: string
@@ -167,36 +173,43 @@ components:
       type: object
       properties:
         id:
-          type: string
           description: The unique identifier of the connection resource.
-          minLength: 1
           maxLength: 64
-        name:
+          minLength: 1
           type: string
+        name:
           description: The user-supplied name of the connection resource.
           maxLength: 64
+          type: string
         type:
           description: The type of connection resource.
           type: string
-          $ref: "#/components/schemas/ConnectionType"
+          allOf:
+          - $ref: "#/components/schemas/ConnectionType"
         ccloud_config:
           description: The details for connecting to CCloud.
           type: object
-          $ref: "#/components/schemas/CCloudConfig"
+          allOf:
+          - $ref: "#/components/schemas/CCloudConfig"
         local_config:
           description: The details for connecting to Confluent Local.
           type: object
-          $ref: "#/components/schemas/LocalConfig"
+          allOf:
+          - $ref: "#/components/schemas/LocalConfig"
         kafka_cluster:
           description: "The details for connecting to a CCloud, Confluent Platform,\
             \ or Apache Kafka cluster."
           type: object
-          $ref: "#/components/schemas/KafkaClusterConfig"
+          allOf:
+          - $ref: "#/components/schemas/KafkaClusterConfig"
         schema_registry:
           description: The details for connecting to a Schema Registry.
           type: object
-          $ref: "#/components/schemas/SchemaRegistryConfig"
+          allOf:
+          - $ref: "#/components/schemas/SchemaRegistryConfig"
     ConnectionStatus:
+      required:
+      - authentication
       type: object
       properties:
         ccloud:
@@ -207,22 +220,20 @@ components:
           $ref: "#/components/schemas/SchemaRegistryStatus"
         authentication:
           $ref: "#/components/schemas/Authentication"
-      required:
-      - authentication
     ConnectionType:
-      type: string
       enum:
       - LOCAL
       - PLATFORM
       - CCLOUD
       - DIRECT
+      type: string
     ConnectionsList:
-      type: object
       required:
       - api_version
       - kind
       - metadata
       - data
+      type: object
       properties:
         api_version:
           type: string
@@ -253,7 +264,6 @@ components:
             And further, we tried to but could not interpret these bytes as a JSON value.
             - The Kafka serializer/deserializer known to sidecar failed to parse the schematized bytes
             (meaning the schema id was present in the magic bytes, but our classes could not interpret the rest of the bytes.)
-      type: string
       enum:
       - AVRO
       - JSONSCHEMA
@@ -261,11 +271,11 @@ components:
       - JSON
       - UTF8_STRING
       - RAW_BYTES
-    Date:
       type: string
+    Date:
       format: date
-      examples:
-      - 2022-03-10
+      type: string
+      example: 2022-03-10
     ExceededFields:
       type: object
       properties:
@@ -291,15 +301,14 @@ components:
           items:
             $ref: "#/components/schemas/SidecarError"
     HashAlgorithm:
-      type: string
       enum:
       - SCRAM_SHA_256
       - SCRAM_SHA_512
-    Instant:
       type: string
+    Instant:
       format: date-time
-      examples:
-      - 2022-03-10T16:15:50Z
+      type: string
+      example: 2022-03-10T16:15:50Z
     JsonMergePatch:
       type: object
     JsonNode:
@@ -350,7 +359,6 @@ components:
         binary:
           type: boolean
     JsonNodeType:
-      type: string
       enum:
       - ARRAY
       - BINARY
@@ -361,182 +369,179 @@ components:
       - OBJECT
       - POJO
       - STRING
+      type: string
     KafkaClusterConfig:
-      type: object
       description: Kafka cluster configuration.
       required:
       - bootstrap_servers
+      type: object
       properties:
         bootstrap_servers:
-          type: string
           description: A list of host/port pairs to use for establishing the initial
             connection to the Kafka cluster.
-          minLength: 1
           maxLength: 256
+          minLength: 1
+          type: string
         credentials:
+          description: "The credentials for the Kafka cluster, or null if no authentication\
+            \ is required"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
           - $ref: "#/components/schemas/OAuthCredentials"
           - $ref: "#/components/schemas/ScramCredentials"
           - $ref: "#/components/schemas/KerberosCredentials"
-          description: "The credentials for the Kafka cluster, or null if no authentication\
-            \ is required"
         ssl:
           description: "The SSL configuration for connecting to the Kafka cluster.\
             \ To disable, set `enabled` to false. To use the default SSL settings,\
             \ set `enabled` to true and leave the `truststore` and `keystore` fields\
             \ unset."
-          type:
-          - object
-          - "null"
-          anyOf:
+          type: object
+          allOf:
           - $ref: "#/components/schemas/TLSConfig"
-          - type: "null"
+          nullable: true
     KafkaClusterStatus:
       description: The status related to the specified Kafka cluster.
-      type: object
       required:
       - state
+      type: object
       properties:
         state:
           description: The state of the connection to the Kafka cluster.
           type: string
-          $ref: "#/components/schemas/ConnectedState"
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
         user:
           description: "Information about the authenticated principal, if known."
           type: object
-          $ref: "#/components/schemas/UserInfo"
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
         errors:
           description: Errors related to the connection to the Kafka cluster.
           type: object
-          $ref: "#/components/schemas/AuthErrors"
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     KerberosCredentials:
       description: Kerberos authentication credentials
-      type: object
       required:
       - principal
       - keytab_path
+      type: object
       properties:
         principal:
-          type: string
           description: The Kerberos principal to use.
+          type: string
         keytab_path:
-          type: string
           description: The Kerberos keytab file path.
-        service_name:
           type: string
+        service_name:
           description: Service name that matches the primary name of the Kafka brokers
             configured in the Broker JAAS file. Defaults to 'kafka'.
           default: kafka
+          type: string
     KeyOrValueMetadata:
       type: object
       properties:
         schema_id:
-          type: integer
           format: int32
+          type: integer
         data_format:
           $ref: "#/components/schemas/DataFormat"
     KeyStore:
-      type: object
       required:
       - path
+      type: object
       properties:
         path:
-          type: string
           description: The path to the local key store file. Only specified if client
             needs to be authenticated by the server (mutual TLS).
           maxLength: 256
+          type: string
         password:
           description: "The password for the local key store file. If a password is\
             \ not set, key store file configured will still be used, but integrity\
             \ checking is disabled. A key store password is not supported for PEM\
             \ format."
-          type:
-          - string
-          - "null"
-          anyOf:
+          type: string
+          allOf:
           - $ref: "#/components/schemas/Password"
-          - type: "null"
+          nullable: true
         type:
           description: The file format of the local key store file.
-          type:
-          - string
-          - "null"
           default: JKS
-          anyOf:
+          type: string
+          allOf:
           - $ref: "#/components/schemas/StoreType"
-          - type: "null"
+          nullable: true
         key_password:
           description: The password of the private key in the local key store file.
-          type:
-          - string
-          - "null"
-          anyOf:
+          type: string
+          allOf:
           - $ref: "#/components/schemas/Password"
-          - type: "null"
+          nullable: true
     LocalConfig:
-      type: object
       description: Configuration when using Confluent Local and optionally a local
         Schema Registry.
+      type: object
       properties:
         schema-registry-uri:
-          type: string
           description: The URL of the Schema Registry running locally.
           maxLength: 512
+          type: string
     OAuthCredentials:
       description: OAuth 2.0 authentication credentials
-      type: object
       required:
       - tokens_url
       - client_id
+      type: object
       properties:
         tokens_url:
-          type: string
           description: The URL of the OAuth 2.0 identity provider's token endpoint.
           maxLength: 256
-        client_id:
           type: string
+        client_id:
           description: The public identifier for the application as registered with
             the OAuth 2.0 identity provider.
-          minLength: 1
           maxLength: 128
+          minLength: 1
+          type: string
         client_secret:
           description: The client secret known only to the application and the OAuth
             2.0 identity provider.
           type: string
-          $ref: "#/components/schemas/Password"
+          allOf:
+          - $ref: "#/components/schemas/Password"
         scope:
-          type: string
           description: The scope to use. The scope is optional and required only when
             your identity provider doesn't have a default scope or your groups claim
             is linked to a scope path to use when connecting to the external service.
           maxLength: 256
+          type: string
         connect_timeout_millis:
-          type: integer
           format: int32
           description: The timeout in milliseconds when connecting to your identity
             provider.
           minimum: 0
+          type: integer
         ccloud_logical_cluster_id:
-          type: string
           description: "Additional property that can be added in the request header\
             \ to identify the logical cluster ID to connect to. For example, this\
             \ may be a Confluent Cloud Kafka or Schema Registry cluster ID."
-        ccloud_identity_pool_id:
           type: string
+        ccloud_identity_pool_id:
           description: "Additional property that can be added in the request header\
             \ to identify the principal ID for authorization. For example, this may\
             \ be a Confluent Cloud identity pool ID."
+          type: string
     PartitionConsumeData:
       type: object
       properties:
         partition_id:
-          type: integer
           format: int32
-        next_offset:
           type: integer
+        next_offset:
           format: int64
+          type: integer
         records:
           type: array
           items:
@@ -545,14 +550,14 @@ components:
       type: object
       properties:
         partition_id:
-          type: integer
           format: int32
+          type: integer
         offset:
-          type: integer
           format: int64
+          type: integer
         timestamp:
-          type: integer
           format: int64
+          type: integer
         timestamp_type:
           $ref: "#/components/schemas/TimestampType"
         headers:
@@ -582,22 +587,22 @@ components:
       type: object
       properties:
         partition_id:
-          type: integer
           format: int32
-        offset:
           type: integer
+        offset:
           format: int64
+          type: integer
     Password:
-      type: string
+      description: A user-provided password that is always masked in responses
       maxLength: 1024
       minLength: 1
-      description: A user-provided password that is always masked in responses
+      type: string
     Preferences:
-      type: object
       required:
       - api_version
       - kind
       - spec
+      type: object
       properties:
         api_version:
           type: string
@@ -608,9 +613,9 @@ components:
         spec:
           $ref: "#/components/schemas/PreferencesSpec"
     PreferencesMetadata:
-      type: object
       required:
       - self
+      type: object
       properties:
         self:
           type: string
@@ -629,8 +634,8 @@ components:
       type: object
       properties:
         partition_id:
-          type: integer
           format: int32
+          type: integer
         headers:
           type: array
           items:
@@ -651,32 +656,32 @@ components:
         subject_name_strategy:
           type: string
         schema_id:
-          type: integer
           format: int32
+          type: integer
         schema_version:
-          type: integer
           format: int32
+          type: integer
         schema:
           type: string
         data: {}
     ProduceRequestHeader:
-      type: object
       required:
       - name
+      type: object
       properties:
         name:
           type: string
         value:
-          type: string
           format: binary
+          type: string
     ProduceResponse:
-      type: object
       required:
       - error_code
+      type: object
       properties:
         error_code:
-          type: integer
           format: int32
+          type: integer
         message:
           type: string
         cluster_id:
@@ -684,11 +689,11 @@ components:
         topic_name:
           type: string
         partition_id:
-          type: integer
           format: int32
-        offset:
           type: integer
+        offset:
           format: int64
+          type: integer
         timestamp:
           $ref: "#/components/schemas/Date"
         key:
@@ -696,24 +701,24 @@ components:
         value:
           $ref: "#/components/schemas/ProduceResponseData"
     ProduceResponseData:
-      type: object
       required:
       - size
       - type
+      type: object
       properties:
         size:
-          type: integer
           format: int64
+          type: integer
         type:
           type: string
         subject:
           type: string
         schema_id:
-          type: integer
           format: int32
+          type: integer
         schema_version:
-          type: integer
           format: int32
+          type: integer
     RecordMetadata:
       type: object
       properties:
@@ -722,86 +727,89 @@ components:
         value_metadata:
           $ref: "#/components/schemas/KeyOrValueMetadata"
     SchemaRegistryConfig:
-      type: object
       description: Schema Registry configuration.
+      required:
+      - uri
+      type: object
       properties:
         id:
-          type: string
           description: "The identifier of the Schema Registry cluster, if known."
           maxLength: 64
-        uri:
           type: string
+        uri:
           description: The URL of the Schema Registry.
-          minLength: 1
           maxLength: 256
+          minLength: 1
+          type: string
         credentials:
+          description: "The credentials for the Schema Registry, or null if no authentication\
+            \ is required"
           oneOf:
           - $ref: "#/components/schemas/BasicCredentials"
           - $ref: "#/components/schemas/ApiKeyAndSecret"
           - $ref: "#/components/schemas/OAuthCredentials"
-          description: "The credentials for the Schema Registry, or null if no authentication\
-            \ is required"
         ssl:
           description: "The SSL configuration for connecting to Schema Registry. If\
             \ null, the connection will use SSL with the default settings. To disable,\
             \ set `enabled` to false."
-          type:
-          - object
-          - "null"
-          anyOf:
+          type: object
+          allOf:
           - $ref: "#/components/schemas/TLSConfig"
-          - type: "null"
-      required:
-      - uri
+          nullable: true
     SchemaRegistryStatus:
       description: The status related to the specified Schema Registry.
-      type: object
       required:
       - state
+      type: object
       properties:
         state:
           description: The state of the connection to the Schema Registry.
           type: string
-          $ref: "#/components/schemas/ConnectedState"
+          allOf:
+          - $ref: "#/components/schemas/ConnectedState"
         user:
           description: "Information about the authenticated principal, if known."
           type: object
-          $ref: "#/components/schemas/UserInfo"
+          allOf:
+          - $ref: "#/components/schemas/UserInfo"
         errors:
           description: Errors related to the connection to the Schema Registry.
           type: object
-          $ref: "#/components/schemas/AuthErrors"
+          allOf:
+          - $ref: "#/components/schemas/AuthErrors"
     ScramCredentials:
       description: Scram authentication credentials
-      type: object
       required:
       - hash_algorithm
       - scram_username
       - scram_password
+      type: object
       properties:
         hash_algorithm:
           description: Hash algorithm
           type: string
-          $ref: "#/components/schemas/HashAlgorithm"
+          allOf:
+          - $ref: "#/components/schemas/HashAlgorithm"
         scram_username:
-          type: string
+          description: The username to use when connecting to the external service.
           maxLength: 64
           minLength: 1
-          description: The username to use when connecting to the external service.
+          type: string
         scram_password:
+          description: The password to use when connecting to the external service.
           maxLength: 1024
           minLength: 1
-          description: The password to use when connecting to the external service.
           type: string
-          $ref: "#/components/schemas/Password"
+          allOf:
+          - $ref: "#/components/schemas/Password"
     SidecarAccessToken:
       type: object
       properties:
         auth_secret:
           type: string
     SidecarError:
-      type: object
       description: Describes a particular error encountered while performing an operation.
+      type: object
       properties:
         code:
           type: string
@@ -828,17 +836,17 @@ components:
           items:
             $ref: "#/components/schemas/PartitionOffset"
         max_poll_records:
-          type: integer
           format: int32
+          type: integer
         timestamp:
-          type: integer
           format: int64
+          type: integer
         fetch_max_bytes:
-          type: integer
           format: int32
+          type: integer
         message_max_bytes:
-          type: integer
           format: int32
+          type: integer
         from_beginning:
           type: boolean
     SimpleConsumeMultiPartitionResponse:
@@ -853,88 +861,80 @@ components:
           items:
             $ref: "#/components/schemas/PartitionConsumeData"
     Status:
-      type: string
       enum:
       - NO_TOKEN
       - VALID_TOKEN
       - INVALID_TOKEN
       - FAILED
-    StoreType:
       type: string
+    StoreType:
       enum:
       - JKS
       - PKCS12
       - PEM
       - UNKNOWN
+      type: string
     TLSConfig:
       description: SSL configuration
+      required:
+      - enabled
       type: object
       properties:
         verify_hostname:
-          type: boolean
           description: Whether to verify the server certificate hostname. Defaults
             to true if not set.
           default: true
-        enabled:
           type: boolean
+        enabled:
           description: "Whether SSL is enabled. If not set, defaults to true."
           default: true
+          type: boolean
         truststore:
           description: The trust store configuration for authenticating the server's
             certificate.
-          type:
-          - object
-          - "null"
-          anyOf:
+          type: object
+          allOf:
           - $ref: "#/components/schemas/TrustStore"
-          - type: "null"
+          nullable: true
         keystore:
           description: "The key store configuration that will identify and authenticate\
             \ the client to the server, required for mutual TLS (mTLS)"
-          type:
-          - object
-          - "null"
-          anyOf:
+          type: object
+          allOf:
           - $ref: "#/components/schemas/KeyStore"
-          - type: "null"
-      required:
-      - enabled
+          nullable: true
     TimestampType:
-      type: string
       enum:
       - NO_TIMESTAMP_TYPE
       - CREATE_TIME
       - LOG_APPEND_TIME
+      type: string
     TrustStore:
-      type: object
       required:
       - path
+      type: object
       properties:
         path:
-          type: string
           description: The path to the local trust store file. Required for authenticating
             the server's certificate.
           maxLength: 256
+          type: string
         password:
           description: "The password for the local trust store file. If a password\
             \ is not set, trust store file configured will still be used, but integrity\
             \ checking is disabled. A trust store password is not supported for PEM\
             \ format."
-          type:
-          - string
-          - "null"
-          anyOf:
+          type: string
+          allOf:
           - $ref: "#/components/schemas/Password"
-          - type: "null"
+          nullable: true
         type:
           description: The file format of the local trust store file
-          type:
-          - string
-          - "null"
           default: JKS
-          anyOf:
+          type: string
+          allOf:
           - $ref: "#/components/schemas/StoreType"
-          - type: "null"
+          nullable: true
     UserInfo:
       type: object
       properties:
@@ -954,10 +954,10 @@ components:
       type: object
       properties:
         status:
-          type: string
           enum:
           - UP
           - DOWN
+          type: string
         checks:
           type: array
           items:
@@ -965,17 +965,16 @@ components:
     HealthCheck:
       type: object
       properties:
+        data:
+          type: object
+          nullable: true
         name:
           type: string
-        data:
-          type:
-          - object
-          - "null"
         status:
-          type: string
           enum:
           - UP
           - DOWN
+          type: string
 paths:
   /:
     get:
@@ -1086,8 +1085,8 @@ paths:
       - name: dry_run
         in: query
         schema:
-          type: boolean
           default: false
+          type: boolean
       - description: Connection ID
         in: header
         name: x-connection-id
@@ -1131,8 +1130,8 @@ paths:
         schema:
           description: Whether to validate the connection spec and determine the connection
             status without creating the connection
-          type: boolean
           default: false
+          type: boolean
       requestBody:
         content:
           application/json:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -305,6 +305,9 @@ quarkus:
 # Hide the /internal/kafka route from the OpenAPI spec
 mp:
   openapi:
+    extensions:
+      smallrye:
+        openapi: 3.0.3
     scan:
       exclude:
         classes: >


### PR DESCRIPTION
## Summary of Changes

This change reverts the version of the sidecar's OpenAPI spec to 3.0.3 as an attempt to fix the tests on the extension side.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

