### PR TITLE
Remove deprecated field `status.authentication`

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -55,25 +55,6 @@
           }
         }
       },
-      "Authentication" : {
-        "description" : "The authentication-related status (deprecated).",
-        "required" : [ "status" ],
-        "type" : "object",
-        "properties" : {
-          "status" : {
-            "$ref" : "#/components/schemas/Status"
-          },
-          "requires_authentication_at" : {
-            "$ref" : "#/components/schemas/Instant"
-          },
-          "user" : {
-            "$ref" : "#/components/schemas/UserInfo"
-          },
-          "errors" : {
-            "$ref" : "#/components/schemas/AuthErrors"
-          }
-        }
-      },
       "BasicCredentials" : {
         "description" : "Basic authentication credentials",
         "required" : [ "username", "password" ],
@@ -259,7 +240,6 @@
         }
       },
       "ConnectionStatus" : {
-        "required" : [ "authentication" ],
         "type" : "object",
         "properties" : {
           "ccloud" : {
@@ -270,9 +250,6 @@
           },
           "schema_registry" : {
             "$ref" : "#/components/schemas/SchemaRegistryStatus"
-          },
-          "authentication" : {
-            "$ref" : "#/components/schemas/Authentication"
           }
         }
       },
@@ -1069,10 +1046,6 @@
             }
           }
         }
-      },
-      "Status" : {
-        "enum" : [ "NO_TOKEN", "VALID_TOKEN", "INVALID_TOKEN", "FAILED" ],
-        "type" : "string"
       },
       "StoreType" : {
         "enum" : [ "JKS", "PKCS12", "PEM", "UNKNOWN" ],

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -42,20 +42,6 @@ components:
           $ref: "#/components/schemas/AuthError"
         token_refresh:
           $ref: "#/components/schemas/AuthError"
-    Authentication:
-      description: The authentication-related status (deprecated).
-      required:
-      - status
-      type: object
-      properties:
-        status:
-          $ref: "#/components/schemas/Status"
-        requires_authentication_at:
-          $ref: "#/components/schemas/Instant"
-        user:
-          $ref: "#/components/schemas/UserInfo"
-        errors:
-          $ref: "#/components/schemas/AuthErrors"
     BasicCredentials:
       description: Basic authentication credentials
       required:
@@ -208,8 +194,6 @@ components:
           allOf:
           - $ref: "#/components/schemas/SchemaRegistryConfig"
     ConnectionStatus:
-      required:
-      - authentication
       type: object
       properties:
         ccloud:
@@ -218,8 +202,6 @@ components:
           $ref: "#/components/schemas/KafkaClusterStatus"
         schema_registry:
           $ref: "#/components/schemas/SchemaRegistryStatus"
-        authentication:
-          $ref: "#/components/schemas/Authentication"
     ConnectionType:
       enum:
       - LOCAL
@@ -859,13 +841,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PartitionConsumeData"
-    Status:
-      enum:
-      - NO_TOKEN
-      - VALID_TOKEN
-      - INVALID_TOKEN
-      - FAILED
-      type: string
     StoreType:
       enum:
       - JKS

--- a/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/ConnectionStatus.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.idesidecar.restapi.auth.AuthErrors;
-import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
 import io.soabase.recordbuilder.core.RecordBuilder;
 import jakarta.validation.constraints.Null;
 import java.time.Instant;
@@ -28,20 +27,6 @@ public record ConnectionStatus(
     @JsonProperty("schema_registry")
     SchemaRegistryStatus schemaRegistry
 ) implements ConnectionStatusBuilder.With {
-
-  // TODO: Remove this once the extension has been updated to use the new status
-  @JsonProperty(required = true)
-  public Authentication authentication() {
-    if (ccloud != null) {
-      return new Authentication(
-          Status.from(ccloud.state()),
-          ccloud.requiresAuthenticationAt(),
-          ccloud.user(),
-          ccloud.errors()
-      );
-    }
-    return new Authentication(Status.NO_TOKEN, null, null, null);
-  }
 
   /**
    * Return whether the supplied connection has been successfully established with some or all
@@ -169,55 +154,6 @@ public record ConnectionStatus(
       AuthErrors errors
   ) implements StateOwner, ConnectionStatusSchemaRegistryStatusBuilder.With {
 
-  }
-
-  @Schema(description = "The authentication-related status (deprecated).")
-  // TODO: Remove this once the extension has been updated to use the new status
-  @JsonInclude(Include.NON_NULL)
-  public record Authentication(
-      @JsonProperty(required = true) Status status,
-      /**
-       * If the connection's auth context holds a valid token, this attribute holds the time at
-       * which the user must re-authenticate because, for instance, the refresh token reached the
-       * end of its absolute lifetime.
-       */
-      @JsonProperty(value = "requires_authentication_at") Instant requiresAuthenticationAt,
-
-      /**
-       * Information about the user of the authenticated principal if provided by the connection.
-       */
-      UserInfo user,
-      /**
-       * Auth-related errors of this connection.
-       */
-      AuthErrors errors
-  ) {
-
-    /**
-     * A connection can be in one of four states: Initially, a connection does not hold any tokens
-     * and is in the state NO_TOKEN. If the connection holds tokens, these tokens can be valid or
-     * invalid. Depending on the health of the tokens, the connection is in the state VALID_TOKEN or
-     * INVALID_TOKEN. The connection will regularly refresh tokens before they expire to keep them
-     * valid. If the connection experienced a non-transient error, it will enter the state FAILED
-     * from which it can't recover automatically. Consumers of the API are advised to trigger a new
-     * authentication flow to recover from the FAILED state.
-     */
-    public enum Status {
-      NO_TOKEN,
-      VALID_TOKEN,
-      INVALID_TOKEN,
-      FAILED;
-
-      public static Status from(ConnectedState state) {
-        return switch (state) {
-          case NONE -> NO_TOKEN;
-          case SUCCESS -> VALID_TOKEN;
-          case EXPIRED -> INVALID_TOKEN;
-          case FAILED -> FAILED;
-          default -> throw new IllegalArgumentException("Invalid state: " + state);
-        };
-      }
-    }
   }
 
   /**

--- a/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/connections/CCloudConnectionTest.java
@@ -13,7 +13,7 @@ import io.confluent.idesidecar.restapi.connections.ConnectionState.StateChangedL
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus;
-import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
 import io.quarkus.test.junit.QuarkusTest;
 import io.vertx.core.Future;
 import io.vertx.junit5.VertxTestContext;
@@ -64,7 +64,7 @@ public class CCloudConnectionTest {
   }
 
   @Test
-  void refreshStatusShouldReturnNoTokenIfRefreshTokenIsMissing() throws Throwable {
+  void refreshStatusShouldReturnNoneIfRefreshTokenIsMissing() throws Throwable {
     var testContext = new VertxTestContext();
     var connectionState = spyCCloudConnectionState(
         true,
@@ -79,8 +79,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.NO_TOKEN,
-                      status.authentication().status()
+                      ConnectedState.NONE,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));
@@ -93,7 +93,7 @@ public class CCloudConnectionTest {
   }
 
   @Test
-  void refreshStatusShouldReturnNoTokenIfControlPlaneTokenIsMissing() throws Throwable {
+  void refreshStatusShouldReturnNoneIfControlPlaneTokenIsMissing() throws Throwable {
     var testContext = new VertxTestContext();
     var connectionState = spyCCloudConnectionState(
         true,
@@ -108,8 +108,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.NO_TOKEN,
-                      status.authentication().status()
+                      ConnectedState.NONE,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));
@@ -122,7 +122,7 @@ public class CCloudConnectionTest {
   }
 
   @Test
-  void refreshStatusShouldReturnNoTokenIfDataPlaneTokenIsMissing() throws Throwable {
+  void refreshStatusShouldReturnNoneIfDataPlaneTokenIsMissing() throws Throwable {
     var testContext = new VertxTestContext();
     var connectionState = spyCCloudConnectionState(
         true,
@@ -137,8 +137,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.NO_TOKEN,
-                      status.authentication().status()
+                      ConnectedState.NONE,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));
@@ -181,7 +181,7 @@ public class CCloudConnectionTest {
   }
 
   @Test
-  void refreshStatusShouldReturnValidTokenIfAuthenticationSucceeds() throws Throwable {
+  void refreshStatusShouldReturnSuccessIfAuthenticationSucceeds() throws Throwable {
     var testContext = new VertxTestContext();
     var connectionState = spyCCloudConnectionState(
         true,
@@ -196,8 +196,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.VALID_TOKEN,
-                      status.authentication().status()
+                      ConnectedState.SUCCESS,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));
@@ -210,7 +210,7 @@ public class CCloudConnectionTest {
   }
 
   @Test
-  void refreshStatusShouldReturnInvalidTokenIfAuthenticationFails() throws Throwable {
+  void refreshStatusShouldReturnExpiredIfAuthenticationFails() throws Throwable {
     var testContext = new VertxTestContext();
     var connectionState = spyCCloudConnectionState(
         false,
@@ -225,8 +225,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.INVALID_TOKEN,
-                      status.authentication().status()
+                      ConnectedState.EXPIRED,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));
@@ -254,8 +254,8 @@ public class CCloudConnectionTest {
             testContext.succeeding(status ->
                 testContext.verify(() -> {
                   assertEquals(
-                      Status.FAILED,
-                      status.authentication().status()
+                      ConnectedState.FAILED,
+                      status.ccloud().state()
                   );
                   testContext.completeNow();
                 })));

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/connection/DirectConnectionSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/connection/DirectConnectionSuite.java
@@ -20,7 +20,6 @@ import io.confluent.idesidecar.restapi.credentials.Password;
 import io.confluent.idesidecar.restapi.integration.ITSuite;
 import io.confluent.idesidecar.restapi.models.Connection;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
-import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
 import io.confluent.idesidecar.restapi.util.SidecarClient;
 import io.restassured.http.ContentType;
@@ -49,7 +48,6 @@ public interface DirectConnectionSuite extends ITSuite {
         .body("spec.id", equalTo(spec.id()))
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
-        .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster.state", equalTo(ConnectedState.SUCCESS.name()));
 
     assertNotNull(rsps.extract().body().as(Connection.class));
@@ -71,7 +69,6 @@ public interface DirectConnectionSuite extends ITSuite {
           .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
           .body("spec.kafka_cluster", notNullValue())
           .body("spec.schema_registry", nullValue())
-          .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
           .body("status.kafka_cluster.state", equalTo(ConnectedState.SUCCESS.name()))
           .body("status.schema_registry", nullValue())
           .extract().body().as(Connection.class);
@@ -90,7 +87,6 @@ public interface DirectConnectionSuite extends ITSuite {
           .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
           .body("spec.kafka_cluster", nullValue())
           .body("spec.schema_registry", notNullValue())
-          .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
           .body("status.kafka_cluster", nullValue())
           .body("status.schema_registry.state", equalTo(ConnectedState.SUCCESS.name()))
           .extract().body().as(Connection.class);
@@ -116,7 +112,6 @@ public interface DirectConnectionSuite extends ITSuite {
         .body("spec.id", nullValue())
         .body("spec.name", equalTo(spec.name()))
         .body("spec.type", equalTo(ConnectionType.DIRECT.name()))
-        .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster.state", equalTo(ConnectedState.SUCCESS.name()))
         .extract().body().as(Connection.class);
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/connection/LocalConnectionSuite.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.confluent.idesidecar.restapi.integration.ITSuite;
 import io.confluent.idesidecar.restapi.models.Connection;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec.ConnectionType;
-import io.confluent.idesidecar.restapi.models.ConnectionStatus.Authentication.Status;
 import io.restassured.http.ContentType;
 import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,6 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.local_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
         .body("spec.schema_registry", notNullValue())
-        .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster", nullValue())
         .body("status.schema_registry", nullValue())
         .extract().body().as(Connection.class);
@@ -73,7 +71,6 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.local_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
         .body("spec.schema_registry", notNullValue())
-        .body("status.authentication.status", equalTo(Status.NO_TOKEN.name()))
         .body("status.kafka_cluster", nullValue())
         .body("status.schema_registry", nullValue())
         .extract().body().as(Connection.class);
@@ -98,8 +95,6 @@ public interface LocalConnectionSuite extends ITSuite {
     assertNotNull(connection.spec().schemaRegistryConfig());
     assertEquals(spec.schemaRegistryConfig(), connection.spec().schemaRegistryConfig());
     assertNotNull(connection.status());
-    assertNotNull(connection.status().authentication());
-    assertEquals(Status.NO_TOKEN, connection.status().authentication().status());
 
     // Update the spec to include the generated ID
     spec = spec.withId(connection.id());
@@ -119,10 +114,6 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.ccloud_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
         .body("spec.schema_registry", notNullValue())
-        .body(
-            "status.authentication.status",
-            equalTo(Status.NO_TOKEN.name())
-        )
         .extract().body().as(Connection.class);
 
     // Query for resources
@@ -153,10 +144,6 @@ public interface LocalConnectionSuite extends ITSuite {
         .body("spec.ccloud_config", nullValue())
         .body("spec.kafka_cluster", nullValue())
         .body("spec.schema_registry", nullValue())
-        .body(
-            "status.authentication.status",
-            equalTo(Status.NO_TOKEN.name())
-        )
         .extract().body().as(Connection.class);
 
     // Query for resources

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/RestProxyResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/RestProxyResourceTest.java
@@ -11,6 +11,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
 import io.confluent.idesidecar.restapi.connections.ConnectionStateManager;
+import io.confluent.idesidecar.restapi.models.ConnectionStatus.ConnectedState;
 import io.confluent.idesidecar.restapi.testutil.NoAccessFilterProfile;
 import io.confluent.idesidecar.restapi.util.CCloudTestUtil;
 import io.quarkiverse.wiremock.devservice.ConnectWireMock;
@@ -109,7 +110,7 @@ class RestProxyResourceTest {
     var orgName = "Development Org";
     ccloudTestUtil.createAuthedCCloudConnection(connectionId, connectionName, orgName, null);
 
-    assertAuthStatus(connectionId, "VALID_TOKEN");
+    assertAuthStatus(connectionId, ConnectedState.SUCCESS.name());
 
     // Get the data plane token directly from the connection manager
     var controlPlaneToken =
@@ -172,7 +173,7 @@ class RestProxyResourceTest {
         null
     );
 
-    assertAuthStatus(connectionId, "VALID_TOKEN");
+    assertAuthStatus(connectionId, ConnectedState.SUCCESS.name());
 
     // Given we have a fake CCloud RBAC server endpoint
     // that always returns a 401

--- a/src/test/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpointTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/resources/WebsocketEndpointTest.java
@@ -290,7 +290,7 @@ public class WebsocketEndpointTest extends AbstractWebsocketTestBase {
 
     // assert that body.connection.status.authentication.requires_authentication_at round-tripped as a java.time.Instant
     assertInstanceOf(Instant.class,
-        receivedBody.connection().status().authentication().requiresAuthenticationAt());
+        receivedBody.connection().status().ccloud().requiresAuthenticationAt());
   }
 
   /**

--- a/src/test/resources/connections/create-connection-response.json
+++ b/src/test/resources/connections/create-connection-response.json
@@ -12,8 +12,5 @@
     "type": "LOCAL"
   },
   "status": {
-    "authentication": {
-      "status": "NO_TOKEN"
-    }
   }
 }

--- a/src/test/resources/connections/list-connections-response.json
+++ b/src/test/resources/connections/list-connections-response.json
@@ -21,12 +21,7 @@
         "name": "Connection 1",
         "type": "LOCAL"
       },
-      "status":
-      {
-        "authentication": {
-          "status": "NO_TOKEN"
-        }
-      }
+      "status": {}
     },
     {
       "api_version": "gateway/v1",
@@ -45,9 +40,6 @@
       },
       "status":
       {
-        "authentication": {
-          "status": "NO_TOKEN"
-        },
         "ccloud": {
           "state": "NONE"
         }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

This change removes the deprecated `status.authentication` field from the `Connection` resource.

Fixes #458 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

