### PR TITLE
Allow GraphQL API to return partial data/failure responses

### DIFF
--- a/src/generated/resources/schema.graphql
+++ b/src/generated/resources/schema.graphql
@@ -8,10 +8,10 @@ type CCloudConnection {
 
 type CCloudEnvironment {
   connectionId: String!
-  flinkComputePools: [CCloudFlinkComputePool]!
+  flinkComputePools: [CCloudFlinkComputePool]
   governancePackage: CCloudGovernancePackage!
   id: String!
-  kafkaClusters: [CCloudKafkaCluster]!
+  kafkaClusters: [CCloudKafkaCluster]
   name: String!
   organization: CCloudReference!
   schemaRegistry: CCloudSchemaRegistry
@@ -115,9 +115,9 @@ type Query {
   "Get all direct connections"
   directConnections: [DirectConnection]!
   "Find CCloud Kafka clusters using a connection and various criteria"
-  findCCloudKafkaClusters(connectionId: String!, environmentId: String = "", name: String = "", provider: String = "", region: String = ""): [CCloudKafkaCluster]!
+  findCCloudKafkaClusters(connectionId: String!, environmentId: String = "", name: String = "", provider: String = "", region: String = ""): [CCloudKafkaCluster]
   "Get Flink compute pools for a specific connection and environment"
-  getFlinkComputePools(connectionId: String!, envId: String!): [CCloudFlinkComputePool]!
+  getFlinkComputePools(connectionId: String!, envId: String!): [CCloudFlinkComputePool]
   "Get all local connections"
   localConnections: [LocalConnection]!
 }

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResource.java
@@ -92,7 +92,7 @@ public class ConfluentCloudQueryResource {
    * @param env the environment
    * @return the Kafka clusters; never null but may be empty
    */
-  @NonNull
+  @Nullable
   public Uni<List<CCloudKafkaCluster>> getKafkaClusters(
       @Source CCloudEnvironment env
   ) {
@@ -149,7 +149,7 @@ public class ConfluentCloudQueryResource {
    */
   @Query("findCCloudKafkaClusters")
   @Description("Find CCloud Kafka clusters using a connection and various criteria")
-  @NonNull
+  @Nullable
   public Uni<List<CCloudKafkaCluster>> findKafkaClusters(
       @NonNull String connectionId,
       @DefaultValue("") String environmentId,
@@ -175,7 +175,7 @@ public class ConfluentCloudQueryResource {
     );
   }
 
-  @NonNull
+  @Nullable
   public Uni<List<CCloudFlinkComputePool>> getFlinkComputePools(@Source CCloudEnvironment env) {
     Log.infof("Get Flink compute pools for connection %s and environment %s", env.connectionId(), env.id());
     return multiToUni(ccloud.getFlinkComputePools(env.connectionId(), env.id()));
@@ -183,7 +183,7 @@ public class ConfluentCloudQueryResource {
 
   @Query("getFlinkComputePools")
   @Description("Get Flink compute pools for a specific connection and environment")
-  @NonNull
+  @Nullable
   public Uni<List<CCloudFlinkComputePool>> getFlinkComputePools(@NonNull String connectionId, @NonNull String envId) {
     Log.infof("Get Flink compute pools for connection %s and environment %s", connectionId, envId);
     return multiToUni(ccloud.getFlinkComputePools(connectionId, envId));

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
@@ -313,7 +313,7 @@ public class ConfluentCloudQueryResourceTest extends ConfluentQueryResourceTestB
         bearerToken,
         "ccloud-resources-mock-responses/get-schema-registry-empty.json");
 
-    // Then the results should have orgs, environments, schema registries but no kafka clusters.
+    // Then the results should have orgs, environments, and schema registries but no kafka clusters.
     // This actual results are strange, in that the parent environment is null when a child
     // fetched object has an error, rather than the environment's field for the child being null.
     // It's not clear how better to handle errors. If we return an empty Multi then no error

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/ConfluentCloudQueryResourceTest.java
@@ -313,7 +313,7 @@ public class ConfluentCloudQueryResourceTest extends ConfluentQueryResourceTestB
         bearerToken,
         "ccloud-resources-mock-responses/get-schema-registry-empty.json");
 
-    // Then the results should have orgs and environments but no kafka clusters.
+    // Then the results should have orgs, environments, schema registries but no kafka clusters.
     // This actual results are strange, in that the parent environment is null when a child
     // fetched object has an error, rather than the environment's field for the child being null.
     // It's not clear how better to handle errors. If we return an empty Multi then no error
@@ -323,6 +323,63 @@ public class ConfluentCloudQueryResourceTest extends ConfluentQueryResourceTestB
     assertQueryResponseMatches(
         "graph/real/get-ccloud-connection-by-id-query.graphql",
         "graph/real/get-ccloud-connection-by-id-failed-kafka-expected.json",
+        this::replaceWireMockPort
+    );
+  }
+
+  @Test
+  void shouldFailWhenErrorGettingFlinkComputePools() {
+    // When listing organizations is successful
+    var bearerToken = ccloudTestUtil.getControlPlaneToken("ccloud-dev");
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        orgListUri,
+        bearerToken,
+        "ccloud-resources-mock-responses/list-organizations.json");
+
+    // And listing environments is successful
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        envListUri,
+        bearerToken,
+        "ccloud-resources-mock-responses/list-environments.json");
+
+    // And getting Kafka clusters works
+    String mainTestEnvId = "env-x7727g";
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        lkcListUri.formatted(mainTestEnvId),
+        bearerToken,
+        "ccloud-resources-mock-responses/list-kafka-clusters.json");
+    String emptyEnvId = "env-kkk3jg";
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        lkcListUri.formatted(emptyEnvId),
+        bearerToken,
+        "ccloud-resources-mock-responses/list-kafka-clusters-empty.json");
+
+    // And getting schema registry works
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        srListUri.formatted(mainTestEnvId),
+        bearerToken,
+        "ccloud-resources-mock-responses/get-schema-registry.json");
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        srListUri.formatted(emptyEnvId),
+        bearerToken,
+        "ccloud-resources-mock-responses/get-schema-registry-empty.json");
+
+    // And getting Flink compute pools DOES NOT work for the first environment
+    expectNotFoundForCCloudGet(
+        computePoolListUri.formatted(mainTestEnvId),
+        bearerToken
+    );
+    // but for the second environment
+    ccloudTestUtil.expectSuccessfulCCloudGet(
+        computePoolListUri.formatted(emptyEnvId),
+        bearerToken,
+        "ccloud-resources-mock-responses/list-flink-compute-pools-empty.json");
+
+    // The GraphQL API should return a partial data/failure response returning all resources
+    // except for the Flink compute pools of the first environment
+    assertQueryResponseMatches(
+        "graph/real/get-ccloud-connection-by-id-with-compute-pools-query.graphql",
+        "graph/real/get-ccloud-connection-by-id-failed-compute-pool-expected.json",
         this::replaceWireMockPort
     );
   }

--- a/src/test/resources/graph/real/get-ccloud-connection-by-id-failed-compute-pool-expected.json
+++ b/src/test/resources/graph/real/get-ccloud-connection-by-id-failed-compute-pool-expected.json
@@ -1,0 +1,83 @@
+{
+  "errors": [
+    {
+      "message": "GET http://localhost:${quarkus.wiremock.devservices.port}/api/fcpm/v2/compute-pools?environment=env-x7727g failed with 1 error(s): (HTTP 404) Not found",
+      "locations": [
+        {
+          "line": 27,
+          "column": 13
+        }
+      ],
+      "path": [
+        "ccloudConnectionById",
+        "environments",
+        0,
+        "flinkComputePools"
+      ],
+      "extensions": {
+        "classification": "DataFetchingException"
+      }
+    }
+  ],
+  "data": {
+    "ccloudConnectionById": {
+      "id": "ccloud-dev",
+      "name": "CCloud Dev",
+      "type": "CCLOUD",
+      "organizations": [
+        {
+          "id": "23b1185e-d874-4f61-81d6-c9c61aa8969c",
+          "name": "Development Org",
+          "current": true
+        },
+        {
+          "id": "d6fc52f8-ae8a-405c-9692-e997965b730dc",
+          "name": "Test Org",
+          "current": false
+        },
+        {
+          "id": "1a507773-d2cb-4055-917e-ffb205f3c433",
+          "name": "Staging Org",
+          "current": false
+        }
+      ],
+      "environments": [
+        {
+          "id": "env-x7727g",
+          "name": "main-test-env",
+          "kafkaClusters": [
+            {
+              "id": "lkc-123abcd",
+              "name": "kafka-cluster-with-no-topics",
+              "provider": "GCP",
+              "region": "us-west2",
+              "bootstrapServers": "SASL_SSL://pkc-12345z.us-west2.gcp.confluent.cloud:9092",
+              "uri": "https://pkc-12345z.us-west2.gcp.confluent.cloud:443"
+            },
+            {
+              "id": "lkc-456xyz",
+              "name": "main-test-kafka-cluster",
+              "provider": "GCP",
+              "region": "us-east1",
+              "bootstrapServers": "SASL_SSL://pkc-6789a.us-east1.gcp.confluent.cloud:9092",
+              "uri": "https://pkc-6789a.us-east1.gcp.confluent.cloud:443"
+            }
+          ],
+          "schemaRegistry": {
+            "provider": "GCP",
+            "region": "us-west2",
+            "uri": "https://psrc-ghijk0.us-west2.gcp.confluent.cloud"
+          },
+          "flinkComputePools": null
+        },
+        {
+          "id": "env-kkk3jg",
+          "name": "env-with-no-kafka-cluster",
+          "kafkaClusters": [],
+          "schemaRegistry": null,
+          "flinkComputePools": []
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/graph/real/get-ccloud-connection-by-id-failed-kafka-expected.json
+++ b/src/test/resources/graph/real/get-ccloud-connection-by-id-failed-kafka-expected.json
@@ -50,7 +50,16 @@
       ],
       "environments":
       [
-        null,
+        {
+          "id": "env-x7727g",
+          "name": "main-test-env",
+          "kafkaClusters": null,
+          "schemaRegistry": {
+            "provider": "GCP",
+            "region": "us-west2",
+            "uri": "https://psrc-ghijk0.us-west2.gcp.confluent.cloud"
+          }
+        },
         {
           "id": "env-kkk3jg",
           "name": "env-with-no-kafka-cluster",

--- a/src/test/resources/graph/real/get-ccloud-connection-by-id-with-compute-pools-query.graphql
+++ b/src/test/resources/graph/real/get-ccloud-connection-by-id-with-compute-pools-query.graphql
@@ -1,0 +1,36 @@
+query devConnection {
+    ccloudConnectionById(id: "ccloud-dev") {
+        id
+        name
+        type
+        organizations {
+            id
+            name
+            current
+        }
+        environments {
+            id
+            name
+            kafkaClusters {
+                id
+                name
+                provider
+                region
+                bootstrapServers
+                uri
+            }
+            schemaRegistry {
+                provider
+                region
+                uri
+            }
+            flinkComputePools {
+                id
+                display_name
+                provider
+                region
+                max_cfu
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of Changes

This change allows the GraphQL API to return partial data in case of a partial failure, so that the VS Code extension can, for instance, list Kafka clusters when the API endpoint for listing Flink compute pools is broken.

Fixes #460

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

