### PR TITLE
fix: Fix CCloud authentication

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -571,6 +571,7 @@ public class CCloudOAuthContext implements AuthContext {
                 response.bodyAsString(),
                 DataPlaneTokenExchangeResponse.class);
           } catch (JsonProcessingException exception) {
+
             throw new CCloudAuthenticationFailedException(
                 String.format(
                     "Could not parse the response from Confluent Cloud when exchanging the control "
@@ -848,8 +849,11 @@ public class CCloudOAuthContext implements AuthContext {
   }
 
   @RegisterForReflection
-  private record DataPlaneTokenExchangeResponse(JsonNode error, String token) {
-
+  private record DataPlaneTokenExchangeResponse(
+      JsonNode error,
+      String token,
+      @JsonProperty(value = "regional_token") String regionalToken
+  ) {
   }
 
   @RegisterForReflection

--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -571,7 +571,6 @@ public class CCloudOAuthContext implements AuthContext {
                 response.bodyAsString(),
                 DataPlaneTokenExchangeResponse.class);
           } catch (JsonProcessingException exception) {
-
             throw new CCloudAuthenticationFailedException(
                 String.format(
                     "Could not parse the response from Confluent Cloud when exchanging the control "


### PR DESCRIPTION
This change adds a new field to the response of the `/api/access_tokens` endpoint, which fixes the authentication with Confluent Cloud.

<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

This change adds a new field to the response of the `/api/access_tokens` endpoint, which fixes the authentication with Confluent Cloud.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

