### PR TITLE
chore: Ignore unknown fields when interacting with OAuth APIs

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -823,6 +823,7 @@ public class CCloudOAuthContext implements AuthContext {
   }
 
   @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private record IdTokenExchangeResponse(
       @JsonProperty(value = "access_token") String accessToken,
       @JsonProperty(value = "refresh_token") String refreshToken,
@@ -837,6 +838,7 @@ public class CCloudOAuthContext implements AuthContext {
   }
 
   @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private record ControlPlaneTokenExchangeResponse(
       String token,
       JsonNode error,
@@ -848,6 +850,7 @@ public class CCloudOAuthContext implements AuthContext {
   }
 
   @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private record DataPlaneTokenExchangeResponse(
       JsonNode error,
       String token,
@@ -856,12 +859,14 @@ public class CCloudOAuthContext implements AuthContext {
   }
 
   @RegisterForReflection
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private record CheckJwtResponse(JsonNode error, JsonNode claims) {
 
   }
 
   @RegisterForReflection
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
   private record ExchangeControlPlaneTokenRequest(
       @JsonProperty(value = "id_token", required = true) String idToken,
       @JsonProperty("org_resource_id") String orgResourceId

--- a/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/CCloudTestUtil.java
@@ -193,7 +193,7 @@ public class CCloudTestUtil {
   }
 
   private static DataPlaneToken createDataPlaneToken() {
-    return new DataPlaneToken(null, getRandomString());
+    return new DataPlaneToken(null, getRandomString(), getRandomString());
   }
 
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
@@ -338,6 +338,7 @@ public class CCloudTestUtil {
   }
 
   // Auth models
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public record AccessToken(
       String access_token,
       String refresh_token,
@@ -360,6 +361,7 @@ public class CCloudTestUtil {
   }
 
   // Copied from CCloudOAuthContext
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public record ControlPlaneTokenAndUserAndOrganization(
       String token,
       JsonNode error,
@@ -402,9 +404,11 @@ public class CCloudTestUtil {
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public record DataPlaneToken(
       JsonNode error,
-      String token
+      String token,
+      @JsonProperty("regional_token") String regionalToken
   ) {
 
   }

--- a/src/test/resources/ccloud-oauth-mock-responses/check-jwt.json
+++ b/src/test/resources/ccloud-oauth-mock-responses/check-jwt.json
@@ -23,5 +23,6 @@
       ]
     }
   },
-  "error": null
+  "error": null,
+  "unknown_field": "baz"
 }

--- a/src/test/resources/ccloud-oauth-mock-responses/control-plane-token.json
+++ b/src/test/resources/ccloud-oauth-mock-responses/control-plane-token.json
@@ -118,5 +118,6 @@
     "parent_organization_resource_id": ""
   },
   "refresh_token": "",
-  "identity_provider": ""
+  "identity_provider": "",
+  "unknown_field": "baz"
 }

--- a/src/test/resources/ccloud-oauth-mock-responses/data-plane-token.json
+++ b/src/test/resources/ccloud-oauth-mock-responses/data-plane-token.json
@@ -1,4 +1,6 @@
 {
   "error": null,
-  "token": "foo"
+  "regional_token": "bar",
+  "token": "foo",
+  "unknown_field": "baz"
 }

--- a/src/test/resources/ccloud-oauth-mock-responses/id-token.json
+++ b/src/test/resources/ccloud-oauth-mock-responses/id-token.json
@@ -4,5 +4,6 @@
   "id_token": "baz",
   "scope": "openid email offline_access",
   "expires_in": 86400,
-  "token_type": "Bearer"
+  "token_type": "Bearer",
+  "unknown_field": "baz"
 }

--- a/src/test/resources/ccloud-oauth-mock-responses/login-realm.json
+++ b/src/test/resources/ccloud-oauth-mock-responses/login-realm.json
@@ -1,1 +1,6 @@
-{"realm":"ccloud-local","is_sso":false,"error":null}
+{
+  "realm": "ccloud-local",
+  "is_sso": false,
+  "error": null,
+  "unknown_field": "baz"
+}


### PR DESCRIPTION
## Summary of Changes

This change makes sure that we ignore unknown fields when processing the responses of the OAuth-related API endpoints.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

