### PR TITLE
chore: Introduce `ObjectMapperFactory` with hardened default config

### DIFF
--- a/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/auth/CCloudOAuthContext.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.idesidecar.restapi.exceptions.CCloudAuthenticationFailedException;
 import io.confluent.idesidecar.restapi.models.ConnectionStatus;
 import io.confluent.idesidecar.restapi.util.CCloud;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.idesidecar.restapi.util.UriUtil;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
 import io.quarkus.arc.Arc;
@@ -51,7 +52,7 @@ import org.apache.commons.codec.binary.Base64;
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class CCloudOAuthContext implements AuthContext {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
   private static final String HASH_ALGORITHM = "SHA-256";
   private static final int CODE_VERIFIER_LENGTH = 32;
   private static final int OAUTH_STATE_PARAMETER_LENGTH = 32;

--- a/src/main/java/io/confluent/idesidecar/restapi/exceptions/Failure.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/exceptions/Failure.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import jakarta.ws.rs.core.Response.Status;
 import java.io.Serializable;
 import java.util.List;
@@ -48,7 +49,7 @@ public record Failure(
     List<Error> errors
 ) implements Serializable {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   public Failure(Exception exception, Status status, String code, String title, String id,
       String source) {

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
@@ -7,6 +7,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
 import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
 import io.confluent.idesidecar.restapi.util.ByteArrayJsonUtil;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
@@ -34,7 +35,7 @@ public class RecordSerializer {
   @Inject
   ClientConfigurator clientConfigurator;
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
 
 
   public ByteString serialize(

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/RecordDeserializer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/RecordDeserializer.java
@@ -24,6 +24,7 @@ import io.confluent.idesidecar.restapi.models.KeyOrValueMetadata;
 import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
 import io.confluent.idesidecar.restapi.util.ByteArrayJsonUtil;
 import io.confluent.idesidecar.restapi.util.ConfigUtil;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
@@ -67,7 +68,7 @@ public class RecordDeserializer {
 
   private static final Map<String, String> SERDE_CONFIGS = ConfigUtil
       .asMap("ide-sidecar.serde-configs");
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
   private static final ObjectMapper AVRO_OBJECT_MAPPER = new AvroMapper(new AvroFactory());
   public static final byte MAGIC_BYTE = 0x0;
   private static final Duration CACHE_FAILED_SCHEMA_ID_FETCH_DURATION = Duration.ofSeconds(30);

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/data/SimpleConsumeMultiPartitionRequest.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/data/SimpleConsumeMultiPartitionRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.soabase.recordbuilder.core.RecordBuilder;
 import java.util.List;
@@ -25,7 +26,7 @@ public record SimpleConsumeMultiPartitionRequest(
     @JsonProperty("from_beginning") Boolean fromBeginning
 ) implements SimpleConsumeMultiPartitionRequestBuilder.With {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   @RegisterForReflection
   public record PartitionOffset(

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConfluentCloudConsumeStrategy.java
@@ -16,6 +16,7 @@ import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPart
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse.RecordMetadata;
 import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
 import io.confluent.idesidecar.restapi.proxy.ProxyHttpClient;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.quarkus.logging.Log;
@@ -39,7 +40,7 @@ import java.util.Optional;
 @ApplicationScoped
 public class ConfluentCloudConsumeStrategy implements ConsumeStrategy {
 
-  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
   static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
   static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 

--- a/src/main/java/io/confluent/idesidecar/restapi/models/graph/ConfluentRestClient.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/models/graph/ConfluentRestClient.java
@@ -11,6 +11,7 @@ import io.confluent.idesidecar.restapi.exceptions.ConnectionNotFoundException;
 import io.confluent.idesidecar.restapi.exceptions.ErrorResponse;
 import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.exceptions.ResourceFetchingException;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.idesidecar.restapi.util.UriUtil;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
 import io.quarkus.logging.Log;
@@ -31,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @RegisterForReflection
 public abstract class ConfluentRestClient {
 
-  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  protected static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   @Inject
   ConnectionStateManager connections;

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/KafkaRestProxyContext.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/KafkaRestProxyContext.java
@@ -7,6 +7,7 @@ import io.confluent.idesidecar.restapi.models.ClusterType;
 import io.confluent.idesidecar.restapi.models.graph.KafkaCluster;
 import io.confluent.idesidecar.restapi.models.graph.SchemaRegistry;
 import io.confluent.idesidecar.restapi.proxy.clusters.ClusterProxyContext;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -25,7 +26,7 @@ public class KafkaRestProxyContext<T, U> extends ClusterProxyContext {
 
   private U response;
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   static {
     OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ConfluentCloudKafkaRestProduceProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/proxy/clusters/processors/ConfluentCloudKafkaRestProduceProcessor.java
@@ -8,6 +8,7 @@ import io.confluent.idesidecar.restapi.kafkarest.model.ProduceResponse;
 import io.confluent.idesidecar.restapi.processors.Processor;
 import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
 import io.confluent.idesidecar.restapi.proxy.ProxyHttpClient;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.idesidecar.restapi.util.WebClientFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -23,7 +24,7 @@ public class ConfluentCloudKafkaRestProduceProcessor extends Processor<
     KafkaRestProxyContext<ProduceRequest, ProduceResponse>,
     Future<KafkaRestProxyContext<ProduceRequest, ProduceResponse>>> {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
 
   @Inject
   WebClientFactory webClientFactory;

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -11,6 +11,7 @@ import io.confluent.idesidecar.restapi.exceptions.Failure;
 import io.confluent.idesidecar.restapi.models.Connection;
 import io.confluent.idesidecar.restapi.models.ConnectionSpec;
 import io.confluent.idesidecar.restapi.models.ConnectionsList;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.quarkus.logging.Log;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
@@ -200,7 +201,7 @@ public class ConnectionsResource {
       @PathParam("id") String id,
       JsonMergePatch patch
   ) {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
     try {
       var connection = connectionStateManager.getConnectionState(id);
       // Convert connection spec to JsonNode

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/KafkaConsumeResource.java
@@ -9,6 +9,7 @@ import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPart
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
 import io.confluent.idesidecar.restapi.processors.Processor;
 import io.confluent.idesidecar.restapi.proxy.KafkaRestProxyContext;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.quarkus.logging.Log;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
@@ -75,7 +76,7 @@ public class KafkaConsumeResource {
         .map(messageViewerContext -> {
           // Extract the number of bytes of the response body
           var response = messageViewerContext.getResponse();
-          ObjectMapper objectMapper = new ObjectMapper();
+          ObjectMapper objectMapper = ObjectMapperFactory.getObjectMapper();
           String jsonResponse;
           try {
             jsonResponse = objectMapper.writeValueAsString(response);

--- a/src/main/java/io/confluent/idesidecar/restapi/util/ByteArrayJsonUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/ByteArrayJsonUtil.java
@@ -15,7 +15,7 @@ import java.util.Base64;
 public final class ByteArrayJsonUtil {
 
   public static final String RAW_FIELD = "__raw__";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
   private static final CharsetDecoder UTF8_DECODER = StandardCharsets.UTF_8.newDecoder();
 
   public static byte[] asBytes(JsonNode node) {

--- a/src/main/java/io/confluent/idesidecar/restapi/util/ObjectMapperFactory.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/ObjectMapperFactory.java
@@ -1,0 +1,21 @@
+package io.confluent.idesidecar.restapi.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Factory class for {@link ObjectMapper}s. Makes sure that we use the correct configuration
+ * when deserializing/serializing JSON objects.
+ */
+public class ObjectMapperFactory {
+
+  /**
+   * Creates a new {@link ObjectMapper} instance that ignores unknown properties.
+   * @return a configured {@link ObjectMapper} instance
+   */
+  public static ObjectMapper getObjectMapper() {
+    var objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return objectMapper;
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
@@ -1,6 +1,7 @@
 package io.confluent.idesidecar.websocket.proxy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
 import io.confluent.idesidecar.websocket.exceptions.ProxyConnectionFailedException;
 import io.confluent.idesidecar.websocket.messages.FlinkLanguageServiceAuthMessage;
 import io.quarkus.logging.Log;
@@ -22,7 +23,7 @@ import java.util.concurrent.Future;
 @ClientEndpoint
 public class FlinkLanguageServiceProxyClient implements AutoCloseable {
 
-  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getObjectMapper();
   static final String CCLOUD_DATA_PLANE_TOKEN_PLACEHOLDER = "{{ ccloud.data_plane_token }}";
 
   Session remoteSession;

--- a/src/test/java/io/confluent/idesidecar/restapi/util/ObjectMapperFactoryTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/util/ObjectMapperFactoryTest.java
@@ -1,0 +1,17 @@
+package io.confluent.idesidecar.restapi.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ObjectMapperFactoryTest {
+
+  @Test
+  void getObjectMapperShouldReturnConfiguredObjectMapper() {
+    var objectMapper = ObjectMapperFactory.getObjectMapper();
+
+    Assertions.assertFalse(
+        objectMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    );
+  }
+}


### PR DESCRIPTION
## Summary of Changes

This change introduces the `ObjectMapperFactory`, which makes sure that Jackson `ObjectMapper`s are correctly configured and ignore unknown properties by default.

It also replaces all instantiations of the `ObjectMapper` with the usage of the `ObjectMapperFactory`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

