### PR TITLE
Harden Flink Language Service Proxy

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/resources/FlinkLanguageServiceProxy.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/resources/FlinkLanguageServiceProxy.java
@@ -26,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @ApplicationScoped
 public class FlinkLanguageServiceProxy {
 
+  public static final String INITIAL_MESSAGE = "OK";
+
   @Inject
   ConnectionStateManager connectionStateManager;
 
@@ -63,8 +65,12 @@ public class FlinkLanguageServiceProxy {
               context.withConnection(cCloudConnectionState),
               session
           );
+          client.connectToCCloud();
           proxyClients.put(session.getId(), client);
-          Log.infof("Opened a new session and added LSP client for session ID=%s", session.getId());
+          Log.infof("Opened a new session and added LSP client for session ID=%s",
+              session.getId());
+          // Let the client know that the connection to the Language Service is established
+          session.getAsyncRemote().sendText(INITIAL_MESSAGE);
         }
       } else {
         Log.warnf(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -298,6 +298,8 @@ quarkus:
     # Disable file caching in Vert.X since the native executable includes the path of the tmp dir
     # of the machine where the native image was built.
     caching: false
+  websocket:
+    dispatch-to-worker: true
   kerberos:
     devservices:
       enabled: false


### PR DESCRIPTION
## Summary of Changes

This change hardens the Flink Language Service Proxy by moving the handling of the WebSocket endpoints off the event loop thread to worker thread. Additionally, it sends an initial, one-time message (the string `OK`) to the extension once the connection to the CCloud Flink Language Service has been established.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

