### PR TITLE
Enable Flink private networking for Language Service

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
@@ -20,15 +20,16 @@ public record ProxyContext (
   static final String LANGUAGE_SERVICE_URL_PATTERN = ConfigProvider
       .getConfig()
       .getValue("ide-sidecar.flink-language-service-proxy.url-pattern", String.class);
-  static final String LANGUAGE_SERVICE_PRIVATE_URL_PATTERN = ConfigProvider
-      .getConfig()
-      .getValue("ide-sidecar.flink-language-service-proxy.private-url-pattern", String.class);
 
   static final String CONNECTION_ID_PARAM_NAME = "connectionId";
   static final String REGION_PARAM_NAME = "region";
   static final String PROVIDER_PARAM_NAME = "provider";
   static final String ENVIRONMENT_ID_PARAM_NAME = "environmentId";
   static final String ORGANIZATION_ID_PARAM_NAME = "organizationId";
+  static final String FLINK_PREFIX = "flink.";
+  static final String LANGUAGE_SERVICE_PREFIX = "flinkpls.";
+  static final String WSS_SCHEME = "wss";
+  static final String LSP_PATH = "/lsp";
 
   public static ProxyContext from(Session session) {
     var paramMap = session.getRequestParameterMap();
@@ -54,23 +55,53 @@ public record ProxyContext (
   }
 
   public String getConnectUrl() {
-    String urlPattern = getUrlPattern();
-    return urlPattern
-        .replace("{{ region }}", region)
-        .replace("{{ provider }}", provider);
+    String privateEndpoint = getMatchingPrivateEndpoint();
+    if (privateEndpoint != null) {
+      return transformToLanguageServiceUrl(privateEndpoint);
+    }
+
+    return buildPublicUrl();
   }
 
-  private String getUrlPattern() {
-    return hasPrivateEndpoints() ?
-        LANGUAGE_SERVICE_PRIVATE_URL_PATTERN :
-        LANGUAGE_SERVICE_URL_PATTERN;
+  private String getMatchingPrivateEndpoint() {
+    FlinkPrivateEndpointUtil util = getPrivateEndpointUtil();
+    List<String> endpoints = util.getPrivateEndpoints(environmentId);
+
+    if (endpoints == null || endpoints.isEmpty()) {
+      return null;
+    }
+
+    return endpoints.stream()
+        .filter(endpoint -> util.isValidEndpointWithMatchingRegionAndProvider(endpoint, region, provider))
+        .findFirst()
+        .orElse(null);
   }
 
-  private boolean hasPrivateEndpoints() {
-    FlinkPrivateEndpointUtil util = CDI.current()
+  private FlinkPrivateEndpointUtil getPrivateEndpointUtil() {
+    return CDI.current()
         .select(FlinkPrivateEndpointUtil.class)
         .get();
-    List<String> endpoints = util.getPrivateEndpoints(environmentId);
-    return endpoints != null && !endpoints.isEmpty();
+  }
+
+  /**
+   * Transform a Flink private endpoint URL to a Language Service URL.
+   * Example: https://flink.us-west-2.aws.private.confluent.cloud
+   *       -> wss://flinkpls.us-west-2.aws.private.confluent.cloud/lsp
+   */
+  private String transformToLanguageServiceUrl(String privateEndpoint) {
+    try {
+      java.net.URI uri = java.net.URI.create(privateEndpoint);
+      String languageServiceHost = uri.getHost().replace(FLINK_PREFIX, LANGUAGE_SERVICE_PREFIX);
+
+      return String.format("%s://%s%s", WSS_SCHEME, languageServiceHost, LSP_PATH);
+    } catch (Exception e) {
+      return buildPublicUrl();
+    }
+  }
+
+  private String buildPublicUrl() {
+    return LANGUAGE_SERVICE_URL_PATTERN
+        .replace("{{ region }}", region)
+        .replace("{{ provider }}", provider);
   }
 }

--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
@@ -67,8 +67,7 @@ public record ProxyContext (
   }
 
   private boolean hasPrivateEndpoints() {
-    FlinkPrivateEndpointUtil util = CDI.current().select(FlinkPrivateEndpointUtil.class).get();
-    List<String> endpoints = util.getPrivateEndpoints(environmentId);
+    List<String> endpoints = flinkPrivateEndpointUtil.getPrivateEndpoints(environmentId);
     return endpoints != null && !endpoints.isEmpty();
   }
 }

--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/ProxyContext.java
@@ -67,7 +67,10 @@ public record ProxyContext (
   }
 
   private boolean hasPrivateEndpoints() {
-    List<String> endpoints = flinkPrivateEndpointUtil.getPrivateEndpoints(environmentId);
+    FlinkPrivateEndpointUtil util = CDI.current()
+        .select(FlinkPrivateEndpointUtil.class)
+        .get();
+    List<String> endpoints = util.getPrivateEndpoints(environmentId);
     return endpoints != null && !endpoints.isEmpty();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,7 @@
       "request.timeout.ms": 5000
     flink-language-service-proxy:
       url-pattern: ws://127.0.0.1:${quarkus.http.test-port}/fls-mock
+      private-url-pattern: ws://127.0.0.1:${quarkus.http.test-port}/fls-mock?private=true
     schema-fetch-error-ttl: 30
     schema-fetch-retry:
       max-retries: 3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,6 +159,7 @@ ide-sidecar:
     interval-seconds: 60
   flink-language-service-proxy:
     url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.confluent.cloud/lsp
+    private-url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.private.confluent.cloud/lsp
   proxy:
     ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2/compute-pools.*)|(/metadata/security/v2alpha1/authorize)"
     ccloud-api-flink-data-plane-regex: "(/sql/v1.*)"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,6 @@
       "request.timeout.ms": 5000
     flink-language-service-proxy:
       url-pattern: ws://127.0.0.1:${quarkus.http.test-port}/fls-mock
-      private-url-pattern: ws://127.0.0.1:${quarkus.http.test-port}/fls-mock?private=true
     schema-fetch-error-ttl: 30
     schema-fetch-retry:
       max-retries: 3
@@ -160,7 +159,6 @@ ide-sidecar:
     interval-seconds: 60
   flink-language-service-proxy:
     url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.confluent.cloud/lsp
-    private-url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.private.confluent.cloud/lsp
   proxy:
     ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2/compute-pools.*)|(/metadata/security/v2alpha1/authorize)"
     ccloud-api-flink-data-plane-regex: "(/sql/v1.*)"

--- a/src/test/java/io/confluent/idesidecar/restapi/proxy/FlinkDataPlaneProxyProcessorTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/proxy/FlinkDataPlaneProxyProcessorTest.java
@@ -1,7 +1,7 @@
 package io.confluent.idesidecar.restapi.proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +10,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -36,9 +37,10 @@ class FlinkDataPlaneProxyProcessorTest {
         "https://flink.us-east-1.aws.private.confluent.cloud", "us-west-2", "aws"))
         .thenReturn(false);
 
-    String result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
+    Optional<String> result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
 
-    assertEquals("https://flink.us-west-2.aws.private.confluent.cloud", result);
+    assertTrue(result.isPresent());
+    assertEquals("https://flink.us-west-2.aws.private.confluent.cloud", result.get());
   }
 
   @Test
@@ -60,9 +62,10 @@ class FlinkDataPlaneProxyProcessorTest {
         "https://flink.us-west-2.aws.private.confluent.cloud", "us-west-2", "aws"))
         .thenReturn(true);
 
-    String result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
+    Optional<String> result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
 
-    assertEquals("https://flink.us-west-2.aws.private.confluent.cloud", result);
+    assertTrue(result.isPresent());
+    assertEquals("https://flink.us-west-2.aws.private.confluent.cloud", result.get());
   }
 
   @Test
@@ -77,14 +80,14 @@ class FlinkDataPlaneProxyProcessorTest {
         anyString(), anyString(), anyString()))
         .thenReturn(false);
 
-    String result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
+    Optional<String> result = processor.selectMatchingEndpoint(endpoints, "us-west-2", "aws");
 
-    assertNull(result);
+    assertTrue(result.isEmpty());
   }
 
   @Test
   void testSelectMatchingEndpointEmptyList() {
-    String result = processor.selectMatchingEndpoint(List.of(), "us-west-2", "aws");
-    assertNull(result);
+    Optional<String> result = processor.selectMatchingEndpoint(List.of(), "us-west-2", "aws");
+    assertTrue(result.isEmpty());
   }
 }

--- a/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
@@ -1,0 +1,105 @@
+package io.confluent.idesidecar.websocket.proxy;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.confluent.idesidecar.restapi.connections.CCloudConnectionState;
+import io.confluent.idesidecar.restapi.util.FlinkPrivateEndpointUtil;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+@QuarkusTest
+class ProxyContextTest {
+
+  @InjectMock
+  FlinkPrivateEndpointUtil flinkPrivateEndpointUtil;
+
+  private ProxyContext createContext() {
+    return new ProxyContext(
+        "conn1",
+        "us-east-1",
+        "aws",
+        "env-123",
+        "org-456",
+        null
+    );
+  }
+
+  @Test
+  void testFromSession() {
+    // Given
+    jakarta.websocket.Session session = mock(jakarta.websocket.Session.class);
+    java.util.Map<String, java.util.List<String>> paramMap = java.util.Map.of(
+        "connectionId", List.of("test-conn"),
+        "region", List.of("eu-west-1"),
+        "provider", List.of("gcp"),
+        "environmentId", List.of("test-env"),
+        "organizationId", List.of("test-org")
+    );
+    when(session.getRequestParameterMap()).thenReturn(paramMap);
+
+    ProxyContext context = ProxyContext.from(session);
+
+    assertEquals("test-conn", context.connectionId());
+    assertEquals("eu-west-1", context.region());
+    assertEquals("gcp", context.provider());
+    assertEquals("test-env", context.environmentId());
+    assertEquals("test-org", context.organizationId());
+    assertNull(context.connection());
+  }
+
+  @Test
+  void testUsePrivateUrlPattern() {
+    // Given
+    ProxyContext context = createContext();
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of("private-endpoint"));
+
+    String url = context.getConnectUrl();
+
+    // Then - test that private pattern is used
+    assertTrue(url.contains("?private=true"));
+    assertTrue(url.contains("127.0.0.1"));
+  }
+
+  @Test
+  void testUsePublicUrlPattern() {
+    // Given
+    ProxyContext context = createContext();
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of());
+
+    String url = context.getConnectUrl();
+
+    // Then - test that public pattern is used
+    assertTrue(url.contains("fls-mock"));
+    assertFalse(url.contains("private=true"));
+  }
+
+  @Test
+  void testHasPrivateEndpoints() {
+    // Given
+    ProxyContext context = createContext();
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of("endpoint1", "endpoint2"));
+
+    String url = context.getConnectUrl();
+
+    assertTrue(url.contains("?private=true"));
+  }
+
+  @Test
+  void testNoPrivateEndpoints() {
+    // Given
+    ProxyContext context = createContext();
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of());
+
+    String url = context.getConnectUrl();
+
+    assertTrue(url.contains("fls-mock"));
+    assertFalse(url.contains("?private=true"));
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
@@ -59,7 +59,7 @@ class ProxyContextTest {
 
     String url = context.getConnectUrl();
 
-    // Then - test that private pattern is used
+    // Test that private pattern is used
     assertTrue(url.contains("?private=true"));
     assertTrue(url.contains("127.0.0.1"));
   }
@@ -73,7 +73,7 @@ class ProxyContextTest {
 
     String url = context.getConnectUrl();
 
-    // Then - test that public pattern is used
+    // Test that public pattern is used
     assertTrue(url.contains("fls-mock"));
     assertFalse(url.contains("private=true"));
   }
@@ -100,6 +100,6 @@ class ProxyContextTest {
     String url = context.getConnectUrl();
 
     assertTrue(url.contains("fls-mock"));
-    assertFalse(url.contains("?private=true"));
+    assertFalse(url.contains("private=true"));
   }
 }

--- a/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
+++ b/src/test/java/io/confluent/idesidecar/websocket/proxy/ProxyContextTest.java
@@ -19,7 +19,18 @@ class ProxyContextTest {
   private ProxyContext createContext() {
     return new ProxyContext(
         "conn1",
-        "us-east-1",
+        "us-west-2",  // Changed to match test private endpoints
+        "aws",
+        "env-123",
+        "org-456",
+        null
+    );
+  }
+
+  private ProxyContext createContextWithDifferentRegion() {
+    return new ProxyContext(
+        "conn1",
+        "eu-central-1",
         "aws",
         "env-123",
         "org-456",
@@ -51,55 +62,119 @@ class ProxyContextTest {
   }
 
   @Test
-  void testUsePrivateUrlPattern() {
-    // Given
-    ProxyContext context = createContext();
+  void testTransformPrivateEndpointToLanguageServiceUrl() {
+    // Given: Matching private endpoint exists
+    ProxyContext context = createContext(); // us-west-2, aws
+    String privateEndpoint = "https://flink.us-west-2.aws.private.confluent.cloud";
+
     when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
-        .thenReturn(List.of("private-endpoint"));
+        .thenReturn(List.of(privateEndpoint));
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        privateEndpoint, "us-west-2", "aws"))
+        .thenReturn(true);
 
     String url = context.getConnectUrl();
 
-    // Test that private pattern is used
-    assertTrue(url.contains("?private=true"));
+    // Then: Should transform to language service URL
+    assertEquals("wss://flinkpls.us-west-2.aws.private.confluent.cloud/lsp", url);
+  }
+
+  @Test
+  void testTransformCCNPrivateEndpointToLanguageServiceUrl() {
+    // Given: CCN private endpoint with domain ID
+    ProxyContext context = createContext(); // us-west-2, aws
+    String ccnEndpoint = "https://flink.domid123.us-west-2.aws.private.confluent.cloud";
+
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of(ccnEndpoint));
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        ccnEndpoint, "us-west-2", "aws"))
+        .thenReturn(true);
+
+    String url = context.getConnectUrl();
+
+    // Then: Should handle CCN format correctly
+    assertEquals("wss://flinkpls.domid123.us-west-2.aws.private.confluent.cloud/lsp", url);
+  }
+
+  @Test
+  void testFallbackToPublicUrlWhenNoPrivateEndpoints() {
+    // Given: No private endpoints configured
+    ProxyContext context = createContext();
+    when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
+        .thenReturn(List.of());
+
+    String url = context.getConnectUrl();
+
+    // Then: Should use public URL pattern from config (test pattern)
+    assertTrue(url.contains("fls-mock"));
     assertTrue(url.contains("127.0.0.1"));
+    assertFalse(url.contains(".private."));
   }
 
   @Test
-  void testUsePublicUrlPattern() {
-    // Given
-    ProxyContext context = createContext();
+  void testFallbackToPublicUrlWhenNoMatchingPrivateEndpoints() {
+    // Given: Private endpoints exist but don't match region/provider
+    ProxyContext context = createContext(); // us-west-2, aws
+    String nonMatchingEndpoint = "https://flink.eu-central-1.aws.private.confluent.cloud";
+
     when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
-        .thenReturn(List.of());
+        .thenReturn(List.of(nonMatchingEndpoint));
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        nonMatchingEndpoint, "us-west-2", "aws"))
+        .thenReturn(false);
 
     String url = context.getConnectUrl();
 
-    // Test that public pattern is used
+    // Then: Should fallback to public URL (test pattern)
     assertTrue(url.contains("fls-mock"));
-    assertFalse(url.contains("private=true"));
+    assertTrue(url.contains("127.0.0.1"));
+    assertFalse(url.contains(".private."));
   }
 
   @Test
-  void testHasPrivateEndpoints() {
-    // Given
-    ProxyContext context = createContext();
+  void testSelectsCorrectEndpointFromMultiple() {
+    // Given: Multiple private endpoints, only one matches
+    ProxyContext context = createContext(); // us-west-2, aws
+    String matchingEndpoint = "https://flink.us-west-2.aws.private.confluent.cloud";
+    String wrongRegion = "https://flink.eu-central-1.aws.private.confluent.cloud";
+    String wrongProvider = "https://flink.us-west-2.gcp.private.confluent.cloud";
+
     when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
-        .thenReturn(List.of("endpoint1", "endpoint2"));
+        .thenReturn(List.of(wrongRegion, matchingEndpoint, wrongProvider));
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        matchingEndpoint, "us-west-2", "aws"))
+        .thenReturn(true);
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        wrongRegion, "us-west-2", "aws"))
+        .thenReturn(false);
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        wrongProvider, "us-west-2", "aws"))
+        .thenReturn(false);
 
     String url = context.getConnectUrl();
 
-    assertTrue(url.contains("?private=true"));
+    // Then: Should select the matching endpoint
+    assertEquals("wss://flinkpls.us-west-2.aws.private.confluent.cloud/lsp", url);
   }
 
   @Test
-  void testNoPrivateEndpoints() {
-    // Given
+  void testHandlesInvalidPrivateEndpoint() {
+    // Given: Invalid private endpoint URL
     ProxyContext context = createContext();
+    String invalidEndpoint = "not-a-valid-url";
+
     when(flinkPrivateEndpointUtil.getPrivateEndpoints("env-123"))
-        .thenReturn(List.of());
+        .thenReturn(List.of(invalidEndpoint));
+    when(flinkPrivateEndpointUtil.isValidEndpointWithMatchingRegionAndProvider(
+        invalidEndpoint, "us-west-2", "aws"))
+        .thenReturn(true);
 
     String url = context.getConnectUrl();
 
+    // Then: Should fallback to public URL
     assertTrue(url.contains("fls-mock"));
-    assertFalse(url.contains("private=true"));
+    assertTrue(url.contains("127.0.0.1"));
+    assertFalse(url.contains(".private."));
   }
 }


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR allows language service connects to Flink private endpoint

- [x] update getConnectUrl() to include using private url
- [x] add logic to check if private endpoint set in a certain environment 
- [x] add unit tests for new functions

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [x] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

