### PR TITLE
chore: Refine comment on why we must send initial OK message

### DIFF
--- a/src/main/java/io/confluent/idesidecar/websocket/resources/FlinkLanguageServiceProxy.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/resources/FlinkLanguageServiceProxy.java
@@ -69,7 +69,11 @@ public class FlinkLanguageServiceProxy {
           proxyClients.put(session.getId(), client);
           Log.infof("Opened a new session and added LSP client for session ID=%s",
               session.getId());
-          // Let the client know that the connection to the Language Service is established
+          // Let the client know that the connection to the CCloud Flink Language Service is
+          // established by sending an initial "OK" message. This message does NOT comply with the
+          // LSP protocol but makes sure that the client does not send any LSP-related messages
+          // before this proxy is fully set up, hence improving the overall experience of the Flink
+          // language server in the IDE.
           session.getAsyncRemote().sendText(INITIAL_MESSAGE);
         }
       } else {


### PR DESCRIPTION


<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

This change adds some documentation on why the Flink LSP proxy sends an initial "OK" message to the client.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

