### PR TITLE
Add regions to control plane access 

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -160,7 +160,7 @@ ide-sidecar:
   flink-language-service-proxy:
     url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.confluent.cloud/lsp
   proxy:
-    ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2/compute-pools.*)|(/metadata/security/v2alpha1/authorize)"
+    ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2.*)|(/metadata/security/v2alpha1/authorize)"
     ccloud-api-flink-data-plane-regex: "(/sql/v1.*)"
   websockets:
     # How long do we allow a connection to be established w/o it saying HELLO?


### PR DESCRIPTION
This PR opens up the control plane to include regions so we can [list them](https://docs.confluent.io/cloud/current/api.html#tag/Regions-(fcpmv2)/operation/listFcpmV2Regions), enhancing the [user flow ](https://github.com/confluentinc/vscode/tree/cerchie/regions-provider-qp)in the vscode upload command. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

