### PR TITLE
fix(CI): add `--force` to overwrite existing native executable artifacts in CI

### DIFF
--- a/.semaphore/build_native_executable_epilogue_macos_linux.sh
+++ b/.semaphore/build_native_executable_epilogue_macos_linux.sh
@@ -2,4 +2,4 @@ make store-test-results-to-semaphore
 make ci-bin-sem-cache-store
 make cache-docker-images
 NATIVE_EXECUTABLE=$(find target -name "*-runner")
-artifact push workflow ${NATIVE_EXECUTABLE} --destination native-executables/$(basename ${NATIVE_EXECUTABLE}-${OS}-${ARCH})
+artifact push workflow ${NATIVE_EXECUTABLE} --destination native-executables/$(basename ${NATIVE_EXECUTABLE}-${OS}-${ARCH}) --force

--- a/.semaphore/multi-arch-builds-and-upload.yml
+++ b/.semaphore/multi-arch-builds-and-upload.yml
@@ -186,7 +186,7 @@ blocks:
               Rename-Item -Path $executable -NewName (Split-Path -Leaf $executable_with_os_arch)
               Write-Host "Signing executable $executable_with_os_arch";
               azuresigntool sign -kvu "https://clicodesigningkeyvault.vault.azure.net/" -kvc CLICodeSigningCertificate -kvi $Env:APP_CLIENT_ID -kvs $Env:APP_CLIENT_SECRET --azure-key-vault-tenant-id $Env:APP_TENANT_ID -tr http://timestamp.globalsign.com/tsa/advanced -td sha256 "$executable_with_os_arch";
-              try {artifact push workflow $executable_with_os_arch --destination "native-executables/$(Split-Path -Leaf $executable_with_os_arch)"} catch {Write-Host "Artifact push failed"}
+              try {artifact push workflow $executable_with_os_arch --destination "native-executables/$(Split-Path -Leaf $executable_with_os_arch)" --force} catch {Write-Host "Artifact push failed"}
       epilogue:
         commands:
           - cache store graal_download_zip graalvm-community-jdk-21.0.2_windows-x64_bin.zip


### PR DESCRIPTION
We hit a [503 error while trying to build a native executable](https://semaphore.ci.confluent.io/jobs/f6f465f0-5ba3-4303-bdeb-4dc243bf48c2) before uploading to the GitHub release, but unfortunately we couldn't re-run `multi-arch-builds-and-upload` since the artifacts were already pushed for that [workflow](https://semaphore.ci.confluent.io/workflows/5e640e9f-b300-4a9d-b765-552c9c901395?pipeline_id=6793f328-fc24-469e-a286-8824615e9e06). (Note: MacOS AMD64 successfully built and pushed the native executable artifact in that workflow, but only because it was the one that 503'd in the previous run.)

[Non-Windows](https://semaphore.ci.confluent.io/jobs/c2ee84a8-2e93-49ed-b112-6e11d3f784b6) (strangely didn't fail the job):
<img width="1103" height="194" alt="image" src="https://github.com/user-attachments/assets/40e49804-c1a8-4bb8-b799-fcb66a0813b3" />

[Windows](https://semaphore.ci.confluent.io/jobs/b312ae7a-775f-4735-ab00-10b7a40d914f):
<img width="1100" height="557" alt="image" src="https://github.com/user-attachments/assets/76a47ccb-eaa1-471f-8a59-e3c144a27cbd" />

This change just adds the `--force` flag so any lingering artifacts are overwritten during the push.