### PR TITLE
[ci-skip] AI tooling: add copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -166,7 +166,7 @@ Uses Quarkus CDI (Jakarta EE). Common patterns:
 - `@Named("beanName")`: Named producer beans (see `*BeanProducers` classes)
 - `@Produces`: Producer methods in `*BeanProducers` classes
 
-## Reactive Programming
+### Reactive Programming
 
 Uses SmallRye Mutiny (`Uni<T>`, `Multi<T>`):
 - `Uni<T>`: Async single result (like `CompletableFuture`)


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

This PR adds a file that has been auto-generated via GitHub Copilot.

<img width="227" height="230" alt="Screenshot 2025-11-04 at 7 48 02 AM" src="https://github.com/user-attachments/assets/49056b79-43be-4b4f-98a2-f9ff60368091" />

I am interested in two types of feedback:

1) whether we can improve the file with respect to its consumability from Copilot's perspective
2) whether this is accurate regarding the codebase itself... I noticed, for example, a small issue with the REST API Structure section, commented below 

Note that this PR does not contain an [instructions folder](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) like we [have in vscode](https://github.com/confluentinc/vscode/tree/main/.github/instructions). This is because I thought it best to start small and iterate after reading [best practices for Claude instructions](https://www.anthropic.com/engineering/claude-code-best-practices) (admittedly not Copilot but I thought this applied generally): 

> A common mistake is adding extensive content without iterating on its effectiveness.