### PR TITLE
Update data plane proxy regex to include `ws/v1`

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -173,7 +173,7 @@ ide-sidecar:
     url-pattern: wss://flinkpls.{{ region }}.{{ provider }}.${ide-sidecar.connections.ccloud.base-path}/lsp
   proxy:
     ccloud-api-control-plane-regex: "(/artifact.*)|(/fcpm/v2.*)|(/metadata/security/v2alpha1/authorize)"
-    ccloud-api-flink-data-plane-regex: "(/sql/v1.*)"
+    ccloud-api-flink-data-plane-regex: "(/sql/v1.*)|(/ws/v1.*)"
   websockets:
     # How long do we allow a connection to be established w/o it saying HELLO?
     initial-grace-seconds: 60

--- a/src/test/java/io/confluent/idesidecar/restapi/resources/FlinkDataPlaneProxyResourceTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/resources/FlinkDataPlaneProxyResourceTest.java
@@ -96,7 +96,8 @@ class FlinkDataPlaneProxyResourceTest {
 
   private static Stream<Arguments> pathSource() {
     return Stream.of(
-        Arguments.of("/sql/v1/organizations")
+        Arguments.of("/sql/v1/organizations"),
+        Arguments.of("/ws/v1/organizations/org-123/environments/env-456/workspaces/ws-789")
     );
   }
 


### PR DESCRIPTION
## Summary of Changes

Fixes #524 

Unblocks VS Code ticket https://github.com/confluentinc/vscode/issues/3196 

Adds regex so we can access the workspace v1 responses from VS Code, and adds this `ws/v1` dimension to the `FlinkDataPlaneProxyResource` test.

Validated against a VS Code branch where we're using the endpoint to create a deeplink. 

## Any additional details or context that should be provided?

To clicktest, build and run the sidecar in dev mode using `make quarkus-dev`. 
Get your auth token, then create and authenticate your CCloud connection using the instructions in [CONTRIBUTING.md](https://github.com/confluentinc/ide-sidecar/blob/main/CONTRIBUTING.md). 

Now in your terminal, run
```
  curl -s \
    -H "Authorization: Bearer ${DTX_ACCESS_TOKEN}" \
    -H "x-connection-id: c1" \
    -H "x-ccloud-region: us-east-2" \
    -H "x-ccloud-provider: aws" \
    "http://localhost:26636/ws/v1/organizations/f551c50b-0397-4f31-802d-d5371a49d3bf/environments/env-8g5wvq/workspaces/workspace-2025-02-04-214633" | jq -r .
```
This should get you a valid response. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [x] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [x] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

