### PR TITLE
MINOR: fix `allowed-tools` syntax for claude skills

### DIFF
--- a/.claude/skills/graalvm-docs/SKILL.md
+++ b/.claude/skills/graalvm-docs/SKILL.md
@@ -6,7 +6,13 @@ description:
   "native image build error", "reflection-config.json", "native library loading", "GraalVM
   substitution", "--initialize-at-run-time", "native executable test", "native build args",
   "ClassNotFoundException in native", or "make test-native".
-allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
 argument-hint: "[topic or error message]"
 ---
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -5,7 +5,12 @@ description:
   before sharing with the team, or when user mentions "review PR", "help with PR", "review changes",
   "self-review", "review local changes", or "check my PR". Provides generic PR Review skill with
   project-specific patterns and tech stack-related requirements.
-allowed-tools: Read, Bash, Grep, Glob, Task
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - Task
 ---
 
 # PR Review Skill

--- a/.claude/skills/quarkus-docs/SKILL.md
+++ b/.claude/skills/quarkus-docs/SKILL.md
@@ -6,7 +6,13 @@ description:
   Triggers on questions like "how does @Inject work", "Uni vs Multi", "Quarkus test profile",
   "application.yml config", "@ApplicationScoped vs @Singleton", "@Produces bean", "@Observes event",
   "CDI observer pattern", "Mutiny transform", "Vert.x HTTP client", or "Quarkus guide for X".
-allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
 argument-hint: "[topic]"
 ---
 


### PR DESCRIPTION
https://code.claude.com/docs/en/skills#frontmatter-reference
> `allowed-tools` - Tools Claude can use without asking permission when this skill is active. **Accepts a space-separated string or a YAML list.**
