### PR TITLE
increase username and API key length limit to 256

### DIFF
--- a/src/generated/resources/openapi.json
+++ b/src/generated/resources/openapi.json
@@ -9,7 +9,7 @@
         "properties" : {
           "api_key" : {
             "description" : "The API key to use when connecting to the external service.",
-            "maxLength" : 96,
+            "maxLength" : 256,
             "minLength" : 1,
             "type" : "string"
           },
@@ -62,7 +62,7 @@
         "properties" : {
           "username" : {
             "description" : "The username to use when connecting to the external service.",
-            "maxLength" : 96,
+            "maxLength" : 256,
             "minLength" : 1,
             "type" : "string"
           },

--- a/src/generated/resources/openapi.yaml
+++ b/src/generated/resources/openapi.yaml
@@ -11,7 +11,7 @@ components:
       properties:
         api_key:
           description: The API key to use when connecting to the external service.
-          maxLength: 96
+          maxLength: 256
           minLength: 1
           type: string
         api_secret:
@@ -51,7 +51,7 @@ components:
       properties:
         username:
           description: The username to use when connecting to the external service.
-          maxLength: 96
+          maxLength: 256
           minLength: 1
           type: string
         password:

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecret.java
@@ -35,7 +35,9 @@ public record ApiKeyAndSecret(
     ApiSecret secret
 ) implements Credentials {
 
-  private static final int KEY_MAX_LEN = 96;
+  // Some managed Kafka services use long API keys that combine multiple identifiers
+  // (e.g. tenancy + user + resource ID), which can easily exceed 96 characters.
+  private static final int KEY_MAX_LEN = 256;
 
   private static final String PLAIN_LOGIN_MODULE_CLASS =
       "org.apache.kafka.common.security.plain.PlainLoginModule";

--- a/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/credentials/BasicCredentials.java
@@ -30,8 +30,9 @@ public record BasicCredentials(
     Password password
 ) implements Credentials {
 
-  // WarpStream likes using > 64 characters for the username
-  private static final int USERNAME_MAX_LEN = 96;
+  // Some managed Kafka services use long usernames that combine multiple identifiers
+  // (e.g. tenancy + user + resource ID), which can easily exceed 96 characters.
+  private static final int USERNAME_MAX_LEN = 256;
 
   private static final String PLAIN_LOGIN_MODULE_CLASS =
       "org.apache.kafka.common.security.plain.PlainLoginModule";

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/ApiKeyAndSecretTest.java
@@ -37,4 +37,28 @@ class ApiKeyAndSecretTest extends RedactedTestBase<ApiKeyAndSecret> {
     creds.validate(errors, "path", "what");
     assertEquals(0, errors.size());
   }
+
+  @Test
+  void keyAtMaxLengthShouldPassValidation() {
+    var key = "x".repeat(256);
+    var creds = new ApiKeyAndSecret(key, new ApiSecret("api-secret".toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  void keyLongerThanMaxLengthShouldFailValidation() {
+    var key = "x".repeat(257);
+    var creds = new ApiKeyAndSecret(key, new ApiSecret("api-secret".toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(1, errors.size());
+    assertEquals(
+        "what key may not be longer than 256 characters",
+        errors.get(0).detail()
+    );
+  }
 }

--- a/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/credentials/BasicCredentialsTest.java
@@ -37,4 +37,28 @@ class BasicCredentialsTest extends RedactedTestBase<BasicCredentials> {
     creds.validate(errors, "path", "what");
     assertEquals(0, errors.size());
   }
+
+  @Test
+  void usernameAtMaxLengthShouldPassValidation() {
+    var username = "x".repeat(256);
+    var creds = new BasicCredentials(username, new Password("my-secret".toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(0, errors.size());
+  }
+
+  @Test
+  void usernameLongerThanMaxLengthShouldFailValidation() {
+    var username = "x".repeat(257);
+    var creds = new BasicCredentials(username, new Password("my-secret".toCharArray()));
+
+    var errors = new ArrayList<Error>();
+    creds.validate(errors, "path", "what");
+    assertEquals(1, errors.size());
+    assertEquals(
+        "what username may not be longer than 256 characters",
+        errors.get(0).detail()
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Bump `USERNAME_MAX_LEN` in `BasicCredentials` and `KEY_MAX_LEN` in `ApiKeyAndSecret` from 96 to 256 to support managed Kafka services with long composite identifiers (tenancy + user + resource ID).
- Regenerate `openapi.yaml` / `openapi.json` to reflect the new `maxLength: 256` on both fields.
- Add regression tests covering the new max-length boundary (256 chars passes, 257 chars fails with the expected error message) for both credential types.

Fixes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)