### PR TITLE
chore: gate builds on `UnusedImports` and `Checkstyle` error-severity checks

### DIFF
--- a/build-tools/checkstyle/checkstyle.xml
+++ b/build-tools/checkstyle/checkstyle.xml
@@ -11,5 +11,9 @@
         <module name="FinalClass">
             <property name="severity" value="error"/>
         </module>
+        <module name="UnusedImports">
+            <property name="severity" value="error"/>
+            <property name="processJavadoc" value="true"/>
+        </module>
     </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,25 @@
           <suppressionsLocation>${build-tools.dir}/checkstyle/suppressions.xml</suppressionsLocation>
           <includeTestSourceDirectory>false</includeTestSourceDirectory>
         </configuration>
+        <executions>
+          <!--
+            Enforce a small set of error-severity checks (see build-tools/checkstyle/checkstyle.xml)
+            at validate phase so the build fails locally and in CI on things like unused imports.
+            The top-level google_checks.xml config is kept for the reporting/manual `mvn
+            checkstyle:check` flow, which surfaces the broader Google-style warnings without
+            gating.
+          -->
+          <execution>
+            <id>enforce-critical-checks</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <configLocation>${build-tools.dir}/checkstyle/checkstyle.xml</configLocation>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/AvroRecordSerializer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/AvroRecordSerializer.java
@@ -120,7 +120,7 @@ public final class AvroRecordSerializer {
           extends Conversion<NonRecordContainer> {
     final T parent;
 
-    public NonRecordContainerConversion(T parent) {
+    NonRecordContainerConversion(T parent) {
       this.parent = parent;
     }
 

--- a/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConsumeStrategyProcessor.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConsumeStrategyProcessor.java
@@ -1,6 +1,5 @@
 package io.confluent.idesidecar.restapi.messageviewer.strategy;
 
-import io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionRequest;
 import io.confluent.idesidecar.restapi.messageviewer.data.SimpleConsumeMultiPartitionResponse;
 import io.confluent.idesidecar.restapi.processors.Processor;

--- a/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java
@@ -1,6 +1,5 @@
 package io.confluent.idesidecar.restapi.resources;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.jsonpatch.JsonPatchException;
 import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;

--- a/src/main/java/io/confluent/idesidecar/restapi/util/UriUtil.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/util/UriUtil.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
+++ b/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java
@@ -11,7 +11,6 @@ import jakarta.websocket.CloseReason.CloseCodes;
 import jakarta.websocket.ContainerProvider;
 import jakarta.websocket.OnClose;
 import jakarta.websocket.OnMessage;
-import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import java.io.IOException;
 import java.net.URI;


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Minor follow-up to https://github.com/confluentinc/ide-sidecar/pull/544 which adds `UnusedImports` to the checkstyle config, and runs style checks as part of `validate`.

Sample job: https://semaphore.ci.confluent.io/jobs/77927bb4-4276-401d-a5ec-51cdd9c2e759#L10368
```
[INFO] --- checkstyle:3.1.2:check (enforce-critical-checks) @ ide-sidecar ---
[INFO] Starting audit...
[ERROR] /home/semaphore/ide-sidecar/src/main/java/io/confluent/idesidecar/websocket/proxy/FlinkLanguageServiceProxyClient.java:14:8: Unused import - jakarta.websocket.OnOpen. [UnusedImports]
[ERROR] /home/semaphore/ide-sidecar/src/main/java/io/confluent/idesidecar/restapi/resources/ConnectionsResource.java:3:8: Unused import - com.fasterxml.jackson.databind.JsonNode. [UnusedImports]
[ERROR] /home/semaphore/ide-sidecar/src/main/java/io/confluent/idesidecar/restapi/messageviewer/strategy/ConsumeStrategyProcessor.java:3:8: Unused import - io.confluent.idesidecar.restapi.exceptions.ProcessorFailedException. [UnusedImports]
[ERROR] /home/semaphore/ide-sidecar/src/main/java/io/confluent/idesidecar/restapi/util/UriUtil.java:10:8: Unused import - java.nio.file.Path. [UnusedImports]
[ERROR] /home/semaphore/ide-sidecar/src/main/java/io/confluent/idesidecar/restapi/kafkarest/AvroRecordSerializer.java:123:5: Redundant 'public' modifier. [RedundantModifier]
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.272 s
[INFO] Finished at: 2026-07-12T00:55:05Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (enforce-critical-checks) on project ide-sidecar: Failed during checkstyle execution: There are 5 errors reported by Checkstyle 9.3 with /home/semaphore/ide-sidecar/build-tools/checkstyle/checkstyle.xml ruleset. -> [Help 1]
```

Fixes applied in https://github.com/confluentinc/ide-sidecar/pull/548/commits/c5cba31c80c940285e98f810ed2d4a37dddceb7f and https://github.com/confluentinc/ide-sidecar/pull/548/commits/2f6532d72a7c648f12f51cf66a41395f0accdcca

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

