### PR TITLE
fix warpstream integration tests

### DIFF
--- a/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
@@ -16,11 +16,12 @@ import org.junit.jupiter.api.Tag;
 public class WarpStreamRegressionIT {
 
   private static final WarpStreamTestEnvironment TEST_ENVIRONMENT = new WarpStreamTestEnvironment(
-      // This is a WarpStream version that is known to return `null` as part of the
-      // `DescribeCluster.controller()` response. The sidecar's Internal Kafka REST
-      // previously failed to handle this case correctly. This test class ensures that
-      // the ClusterV3Suite passes since the sidecar now correctly handles this case.
-      "latest"
+      // Pin the stable channel rather than `latest`: `latest` is a moving tag that tracks the
+      // newest (possibly pre-release) agent, so a republish can break CI on every branch at once.
+      // This suite verifies that the sidecar's Internal Kafka REST (the ClusterV3Suite) works
+      // against WarpStream; it originally regression-guarded a version that returned `null` for
+      // `DescribeCluster.controller()`, an edge case newer stable builds may no longer exercise.
+      "latest-stable"
   );
 
   static {

--- a/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/integration/WarpStreamRegressionIT.java
@@ -16,12 +16,13 @@ import org.junit.jupiter.api.Tag;
 public class WarpStreamRegressionIT {
 
   private static final WarpStreamTestEnvironment TEST_ENVIRONMENT = new WarpStreamTestEnvironment(
-      // Pin the stable channel rather than `latest`: `latest` is a moving tag that tracks the
-      // newest (possibly pre-release) agent, so a republish can break CI on every branch at once.
-      // This suite verifies that the sidecar's Internal Kafka REST (the ClusterV3Suite) works
-      // against WarpStream; it originally regression-guarded a version that returned `null` for
-      // `DescribeCluster.controller()`, an edge case newer stable builds may no longer exercise.
-      "latest-stable"
+      // Pin an explicit agent version rather than a moving tag (`latest`/`latest-stable`): a tag
+      // republish can pull a broken agent and break CI on every branch at once. v822's `playground`
+      // crashes on startup (its Tableflow agent fails to load an embedded DuckDB dependency); v821
+      // is the newest version that boots cleanly. This suite checks the sidecar's Internal Kafka
+      // REST (ClusterV3Suite) against WarpStream; the null/empty `DescribeCluster.controller()` case
+      // it originally guarded is now covered directly in ClusterManagerImplTest.
+      "v821"
   );
 
   static {

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImplTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/ClusterManagerImplTest.java
@@ -1,0 +1,84 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.idesidecar.restapi.clients.AdminClients;
+import io.quarkus.test.junit.QuarkusTest;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ClusterManagerImpl}'s handling of a null or empty
+ * {@code DescribeCluster.controller()}. WarpStream reports no controller for its playground
+ * clusters, so this guards that case directly, independent of the WarpStream agent version that
+ * {@code WarpStreamRegressionIT} happens to run against.
+ */
+@QuarkusTest
+class ClusterManagerImplTest {
+
+  private static final String CONNECTION_ID = "connection-id";
+  private static final String CLUSTER_ID = "cluster-1";
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  private DescribeClusterResult describeClusterResult;
+  private ClusterManagerImpl clusterManager;
+
+  @BeforeEach
+  void setUp() {
+    var adminClients = mock(AdminClients.class);
+    var adminClient = mock(AdminClient.class);
+    describeClusterResult = mock(DescribeClusterResult.class);
+
+    when(adminClients.getClient(CONNECTION_ID, CLUSTER_ID)).thenReturn(adminClient);
+    when(adminClient.describeCluster()).thenReturn(describeClusterResult);
+    when(describeClusterResult.clusterId()).thenReturn(KafkaFuture.completedFuture(CLUSTER_ID));
+    when(describeClusterResult.nodes())
+        .thenReturn(KafkaFuture.<Collection<Node>>completedFuture(List.of()));
+
+    clusterManager = new ClusterManagerImpl();
+    clusterManager.adminClients = adminClients;
+    clusterManager.connectionId = () -> CONNECTION_ID;
+  }
+
+  @Test
+  void getKafkaClusterShouldOmitControllerWhenControllerIsNull() {
+    when(describeClusterResult.controller()).thenReturn(KafkaFuture.<Node>completedFuture(null));
+
+    var cluster = clusterManager.getKafkaCluster(CLUSTER_ID).await().atMost(TIMEOUT);
+
+    assertNull(cluster.getController());
+  }
+
+  @Test
+  void getKafkaClusterShouldOmitControllerWhenControllerIsEmpty() {
+    when(describeClusterResult.controller())
+        .thenReturn(KafkaFuture.completedFuture(Node.noNode()));
+
+    var cluster = clusterManager.getKafkaCluster(CLUSTER_ID).await().atMost(TIMEOUT);
+
+    assertNull(cluster.getController());
+  }
+
+  @Test
+  void getKafkaClusterShouldIncludeControllerWhenControllerIsPresent() {
+    var controller = new Node(7, "broker-7", 9092);
+    when(describeClusterResult.controller())
+        .thenReturn(KafkaFuture.completedFuture(controller));
+
+    var cluster = clusterManager.getKafkaCluster(CLUSTER_ID).await().atMost(TIMEOUT);
+
+    assertNotNull(cluster.getController());
+    assertTrue(cluster.getController().getRelated().endsWith("/brokers/7"));
+  }
+}


### PR DESCRIPTION
<!-- Consider adding [ci skip] to the PR title if the PR does not change the source code or tests. -->

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Swaps the WarpStream agent Docker image tag from `latest` ([v822](https://docs.warpstream.com/warpstream/overview/change-log#release-v822)) to [`v821`](https://docs.warpstream.com/warpstream/overview/change-log#release-v821) to fix currently-breaking integration tests on `main` ([example](https://semaphore.ci.confluent.io/jobs/757f88c3-6f51-4db9-be83-7752562cea4e/summary?report_id=17990af8-cb17-371c-9a8e-215e0e201902)).  

> [!NOTE]
> [v823](https://docs.warpstream.com/warpstream/overview/change-log#release-v823) was released today to include a fix for the error below, but pinning to a version is still a good defensive measure.

This container issue was also seen from `docker run public.ecr.aws/warpstream-labs/warpstream_agent:latest demo` (when `latest` was still v822):
```
Starting local agents...
Setting up the demo environment, this can take up to 10s...
panic: error starting tableflow agent: failed to initialize duckdb client dependencies: failed to initialize embedded duckdb cli: duckdb process failed: exit status 127 (stderr: /tmp/warpstream-duckdb/duckdb: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
	)

goroutine 28 [running]:
github.com/warpstreamlabs/warpstream/pkg/logging.Fatalf(...)
	/opt/actions-runner/_work/warpstream/warpstream/pkg/logging/logging.go:50
github.com/warpstreamlabs/warpstream/pkg/logging.FatalfCLI(...)
	/opt/actions-runner/_work/warpstream/warpstream/pkg/logging/logging.go:58
main.runPlayground.func7()
	/opt/actions-runner/_work/warpstream/warpstream/services/agent/app/playground.go:505 +0x19c
created by github.com/warpstreamlabs/warpstream/pkg/xgo.GoWithoutRecover in goroutine 1
	/opt/actions-runner/_work/warpstream/warpstream/pkg/xgo/xgo.go:6 +0x1c
```

Dropping to `v821` allows the container to start as intended, and tests are now passing.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

- Tests:
    - [ ] Added new
    - [ ] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
    ```shell
    make quarkus-dev
    ```
- [ ] Have you validated this change against a locally running native executable?
    ```shell
    make mvn-package-native && ./target/ide-sidecar-*-runner
    ```

