### PR TITLE
feat: identify failed record serialization parts

### DIFF
--- a/kafka-rest.openapi.yaml
+++ b/kafka-rest.openapi.yaml
@@ -2256,6 +2256,19 @@ components:
           type: string
           nullable: true
 
+    ProduceRecordError:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            message_part:
+              type: string
+              description: The part of the record that failed local serialization.
+              enum:
+                - key
+                - value
+                - both
+
     PartitionData:
       allOf:
         - $ref: '#/components/schemas/Resource'
@@ -4345,17 +4358,23 @@ components:
 
     BadRequestErrorResponse_ProduceRecords:
       description: 'Indicates a bad request error. It could be caused by an unexpected request
-        body format or other forms of request validation failure.'
+        body format, record serialization error, or other forms of request validation failure.'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/ProduceRecordError'
           examples:
             header_not_base64_encoded:
               description: "Thrown when headers in the produce-record are not base64 encoded."
               value:
                 error_code: 400
                 message: "Cannot deserialize value of type `byte[]` from String \"\": Unexpected end of base64-encoded String: base64 variant 'MIME-NO-LINEFEEDS' expects padding (one or more '=' characters) at the end. This Base64Variant might have been incorrectly configured"
+            key_serialization_failed:
+              description: "Thrown when the record key cannot be serialized."
+              value:
+                error_code: 400
+                message: "Failed to serialize key when producing message to topic my-topic"
+                message_part: key
 
     UnprocessableEntity_ProduceRecord:
       description: 'Indicates a bad request error. It could be caused by an unexpected request

--- a/src/main/java/io/confluent/idesidecar/restapi/application/ReflectionConfiguration.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/application/ReflectionConfiguration.java
@@ -4,6 +4,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.sun.security.auth.module.JndiLoginModule;
 import com.sun.security.auth.module.KeyStoreLoginModule;
+import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRecordError;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
@@ -61,7 +62,7 @@ import org.apache.kafka.common.security.scram.internals.ScramServerCallbackHandl
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 /**
- * Registers external classes for reflection.
+ * Registers classes for reflection that Quarkus cannot infer automatically.
  *
  * @see <a
  * href="https://quarkus.io/guides/writing-native-applications-tips#registering-for-reflection">Registering
@@ -69,6 +70,9 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
  */
 @RegisterForReflection(
     targets = {
+        // Generated Kafka REST model returned through a raw Response entity
+        ProduceRecordError.class,
+        ProduceRecordError.MessagePartEnum.class,
         ByteArrayDeserializer.class,
         CooperativeStickyAssignor.class,
         RangeAssignor.class,

--- a/src/main/java/io/confluent/idesidecar/restapi/exceptions/ExceptionMappers.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/exceptions/ExceptionMappers.java
@@ -1,6 +1,8 @@
 package io.confluent.idesidecar.restapi.exceptions;
 
+import io.confluent.idesidecar.restapi.kafkarest.RecordSerializationException;
 import io.confluent.idesidecar.restapi.kafkarest.UnknownAlterConfigOperation;
+import io.confluent.idesidecar.restapi.kafkarest.model.ProduceRecordError;
 import io.confluent.idesidecar.restapi.util.UuidFactory;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import jakarta.inject.Inject;
@@ -272,6 +274,22 @@ public class ExceptionMappers {
 
   @ServerExceptionMapper
   public Response mapBadRequestException(BadRequestException exception) {
+    if (exception instanceof RecordSerializationException serializationException) {
+      var error = ProduceRecordError
+          .builder()
+          .errorCode(Status.BAD_REQUEST.getStatusCode())
+          .message(exception.getMessage())
+          .messagePart(ProduceRecordError.MessagePartEnum.fromValue(
+              serializationException.getMessagePart().getValue()
+          ))
+          .build();
+      return Response
+          .status(Status.BAD_REQUEST)
+          .entity(error)
+          .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+          .build();
+    }
+
     var error = io.confluent.idesidecar.restapi.kafkarest.model.Error
         .builder()
         .errorCode(Status.BAD_REQUEST.getStatusCode())

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/GenericProduceRecord.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/GenericProduceRecord.java
@@ -198,23 +198,50 @@ public abstract class GenericProduceRecord {
         .onFailure()
         .recoverWithUni(t -> {
           if (t instanceof CompositeException e) {
-            return Uni.createFrom().failure(new BadRequestException(
-                "Failed to serialize both key and value: %s".formatted(
-                    e
-                        .getCauses()
-                        .stream()
-                        .map(ExceptionUtil::unwrapWithCombinedMessage)
-                        .map(Throwable::getMessage)
-                        .collect(Collectors.joining(", "))
-                ), e)
+            var message = "Failed to serialize both key and value: %s".formatted(
+                e
+                    .getCauses()
+                    .stream()
+                    .map(ExceptionUtil::unwrapWithCombinedMessage)
+                    .map(Throwable::getMessage)
+                    .collect(Collectors.joining(", "))
+            );
+            return Uni.createFrom().failure(
+                new RecordSerializationException(
+                    message,
+                    e,
+                    RecordSerializationException.MessagePart.BOTH
+                )
             );
           } else {
             var rootCause = unwrapWithCombinedMessage(t);
+            var serializationException = findRecordSerializationException(t);
+            if (serializationException.isPresent()) {
+              return Uni.createFrom().failure(
+                  new RecordSerializationException(
+                      rootCause.getMessage(),
+                      rootCause,
+                      serializationException.get().getMessagePart()
+                  )
+              );
+            }
             return Uni.createFrom().failure(
                 new BadRequestException(rootCause.getMessage(), rootCause)
             );
           }
         });
+  }
+
+  private Optional<RecordSerializationException> findRecordSerializationException(
+      Throwable throwable
+  ) {
+    if (throwable instanceof RecordSerializationException exception) {
+      return Optional.of(exception);
+    }
+    if (throwable.getCause() != null) {
+      return findRecordSerializationException(throwable.getCause());
+    }
+    return Optional.empty();
   }
 
   protected abstract Uni<ProduceContext> sendSerializedRecord(ProduceContext c);

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializationException.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializationException.java
@@ -1,0 +1,60 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import jakarta.ws.rs.BadRequestException;
+
+/**
+ * Indicates which part of a record failed local serialization.
+ */
+public class RecordSerializationException extends BadRequestException {
+
+  private final MessagePart messagePart;
+
+  /**
+   * Creates an exception for a failed record part.
+   *
+   * @param message the error message
+   * @param cause the serialization failure
+   * @param messagePart the record part that failed
+   */
+  public RecordSerializationException(
+      String message,
+      Throwable cause,
+      MessagePart messagePart
+  ) {
+    super(message, cause);
+    this.messagePart = messagePart;
+  }
+
+  /**
+   * Returns the record part that failed serialization.
+   *
+   * @return the failed record part
+   */
+  public MessagePart getMessagePart() {
+    return messagePart;
+  }
+
+  /**
+   * A record part that can fail serialization.
+   */
+  public enum MessagePart {
+    KEY("key"),
+    VALUE("value"),
+    BOTH("both");
+
+    private final String value;
+
+    MessagePart(String value) {
+      this.value = value;
+    }
+
+    /**
+     * Returns the value exposed in error responses.
+     *
+     * @return the error-response value
+     */
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
+++ b/src/main/java/io/confluent/idesidecar/restapi/kafkarest/RecordSerializer.java
@@ -71,15 +71,18 @@ public class RecordSerializer {
             serializeProtobuf(client, parsedSchema, serdeConfigs, topicName, jsonNode, isKey);
       };
     } catch (RuntimeException e) {
-      // Wrap the exception with key/value information in the exception message.
+      // Wrap the exception with machine-readable key/value information.
       var what = isKey ? "key" : "value";
       Log.errorf(e,
           "Failed to serialize %s when producing message to topic %s", what, topicName
       );
-      throw new RuntimeException(
+      throw new RecordSerializationException(
           "Failed to serialize %s when producing message to topic %s: %s"
               .formatted(what, topicName, e.getMessage()),
-          e
+          e,
+          isKey
+              ? RecordSerializationException.MessagePart.KEY
+              : RecordSerializationException.MessagePart.VALUE
       );
     }
   }

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/GenericProduceRecordTest.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/GenericProduceRecordTest.java
@@ -1,0 +1,113 @@
+package io.confluent.idesidecar.restapi.kafkarest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.confluent.idesidecar.restapi.clients.ClientConfigurator;
+import io.confluent.idesidecar.restapi.clients.SchemaRegistryClients;
+import io.confluent.idesidecar.restapi.exceptions.ExceptionMappers;
+import io.confluent.idesidecar.restapi.util.ObjectMapperFactory;
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.BadRequestException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GenericProduceRecordTest {
+
+  private GenericProduceRecord produceRecord;
+
+  @BeforeEach
+  void setUp() {
+    var clientConfigurator = mock(ClientConfigurator.class);
+    when(clientConfigurator.getSerdeConfigs(any(), anyBoolean()))
+        .thenThrow(new IllegalArgumentException("invalid record"));
+
+    var recordSerializer = new RecordSerializer();
+    recordSerializer.clientConfigurator = clientConfigurator;
+
+    produceRecord = new TestProduceRecord();
+    produceRecord.schemaRegistryClients = mock(SchemaRegistryClients.class);
+    produceRecord.schemaManager = new SchemaManager();
+    produceRecord.recordSerializer = recordSerializer;
+  }
+
+  @Test
+  void shouldIdentifyKeySerializationFailures() {
+    var error = produceAndMapError(data("invalid"), data(null));
+
+    assertEquals("key", error.path("message_part").asText());
+    assertEquals(400, error.path("error_code").asInt());
+    assertEquals(
+        "Failed to serialize key when producing message to topic topic: invalid record"
+            + " caused by: invalid record",
+        error.path("message").asText()
+    );
+  }
+
+  @Test
+  void shouldIdentifyValueSerializationFailures() {
+    var error = produceAndMapError(data(null), data("invalid"));
+
+    assertEquals("value", error.path("message_part").asText());
+    assertEquals(400, error.path("error_code").asInt());
+    assertEquals(
+        "Failed to serialize value when producing message to topic topic: invalid record"
+            + " caused by: invalid record",
+        error.path("message").asText()
+    );
+  }
+
+  @Test
+  void shouldIdentifyKeyAndValueSerializationFailures() {
+    var error = produceAndMapError(data("invalid-key"), data("invalid-value"));
+
+    assertEquals("both", error.path("message_part").asText());
+    assertEquals(400, error.path("error_code").asInt());
+  }
+
+  @Test
+  void shouldNotIdentifyUnrelatedBadRequestsAsSerializationFailures() {
+    var response = new ExceptionMappers().mapBadRequestException(
+        new BadRequestException("unrelated")
+    );
+    var error = ObjectMapperFactory.getObjectMapper().valueToTree(response.getEntity());
+
+    assertFalse(error.has("message_part"));
+    assertEquals("unrelated", error.path("message").asText());
+  }
+
+  private JsonNode produceAndMapError(
+      ProduceRequestData key,
+      ProduceRequestData value
+  ) {
+    var request = new ProduceRequest(null, List.of(), key, value, null);
+    var exception = assertThrows(
+        BadRequestException.class,
+        () -> produceRecord
+            .produce("connection", "cluster", "topic", true, request)
+            .await()
+            .indefinitely()
+    );
+    var response = new ExceptionMappers().mapBadRequestException(exception);
+    return ObjectMapperFactory.getObjectMapper().valueToTree(response.getEntity());
+  }
+
+  private static ProduceRequestData data(Object data) {
+    return new ProduceRequestData(null, null, null, null, null, null, data);
+  }
+
+  private static final class TestProduceRecord extends GenericProduceRecord {
+
+    @Override
+    protected Uni<ProduceContext> sendSerializedRecord(ProduceContext context) {
+      throw new AssertionError("dry-run must not send records");
+    }
+  }
+}

--- a/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ErrorsSuite.java
+++ b/src/test/java/io/confluent/idesidecar/restapi/kafkarest/RecordsV3ErrorsSuite.java
@@ -192,6 +192,7 @@ public interface RecordsV3ErrorsSuite extends RecordsV3BaseSuite {
             produceRecordThen(
                 null, topic, badData, keySchema.getVersion(), null, null, Set.of())
                 .statusCode(400)
+                .body("message_part", equalTo("key"))
                 .body("message", containsString("Failed to parse data"))
         );
 
@@ -207,6 +208,7 @@ public interface RecordsV3ErrorsSuite extends RecordsV3BaseSuite {
             produceRecordThen(
                 null, topic, null, null, badData, valueSchema.getVersion(), Set.of())
                 .statusCode(400)
+                .body("message_part", equalTo("value"))
                 .body("message", containsString("Failed to parse data"))
         );
   }


### PR DESCRIPTION
## Summary of Changes

- add an optional `message_part` field to produce serialization errors, with `key`, `value`, and `both` values
- preserve the existing error message and ordinary bad-request response shape
- document the generated response model and register it for native reflection

## Any additional details or context that should be provided?

The key and value serializers now retain which side failed through the parallel dry-run pipeline. If both serializers fail, the response reports `both`; unrelated 400 responses continue to omit `message_part`.

Local validation completed:

- `./mvnw --settings .mvn/settings.xml -Dtest=io.confluent.idesidecar.restapi.kafkarest.GenericProduceRecordTest -DskipITs verify`
- `make mvn-generate-sidecar-openapi-spec`
- `make mvn-package-native-sources-only`
- generated native reflection configuration inspection

The full non-IT unit run passed 710 of 713 tests. The remaining three `PreferencesResourceTest` cases also fail in isolation because their test resource URLs are percent-encoded under this non-ASCII checkout path and are then treated as filesystem paths. Container-backed integration tests were not run locally because Docker is unavailable; CI can exercise the added `RecordsV3ErrorsSuite` assertions.

Closes #416

## Pull request checklist

- Tests:
    - [x] Added new
    - [x] Updated existing
    - [ ] Deleted existing
- [ ] Have you validated this change locally against a running instance of the Quarkus dev server?
- [ ] Have you validated this change against a locally running native executable?